### PR TITLE
Add Heimgewebe organism context to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,3 +371,15 @@ flowchart TD
   Consumes digests and insights as part of its decision-making, and writes decisions and outcomes back into `chronik`, closing the loop.
 
 In short: `leitstand` is the place where the organism looks at itself once per day and formulates a coherent story about its current state.
+
+## Organismus-Kontext
+
+Dieses Repository ist Teil des **Heimgewebe-Organismus**.
+
+Die übergeordnete Architektur, Achsen, Rollen und Contracts sind zentral beschrieben im  
+👉 [`metarepo/docs/heimgewebe-organismus.md`](https://github.com/heimgewebe/metarepo/blob/main/docs/heimgewebe-organismus.md)  
+sowie im Zielbild  
+👉 [`metarepo/docs/heimgewebe-zielbild.md`](https://github.com/heimgewebe/metarepo/blob/main/docs/heimgewebe-zielbild.md).
+
+Alle Rollen-Definitionen, Datenflüsse und Contract-Zuordnungen dieses Repos
+sind dort verankert.


### PR DESCRIPTION
## Summary
- append the Heimgewebe organism context block with links to central documentation in the README

## Testing
- not run (documentation change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693558e810c4832ca5d232d1a496161b)