### PR TITLE
chore(security): neutralize token placeholder in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@ PORT=3000
 
 # Agent Control Surface (ACS) Integration
 # LEITSTAND_ACS_URL=https://acs.internal
-# LEITSTAND_ACS_VIEWER_TOKEN=optional-viewer-token
+# LEITSTAND_ACS_VIEWER_TOKEN=OPTIONAL_SET_VIA_ENV_ONLY
 # LEITSTAND_OPS_ALLOW_JOB_FALLBACK=false
 
 # Ops Viewer Configuration


### PR DESCRIPTION
Neutralized `LEITSTAND_ACS_VIEWER_TOKEN` placeholder in `.env.example` to `OPTIONAL_SET_VIA_ENV_ONLY` to avoid "value-like" tokens in public repo. This prevents potential confusion and false positives in security scans.

---
*PR created automatically by Jules for task [12511706049834296143](https://jules.google.com/task/12511706049834296143) started by @alexdermohr*