### PR TITLE
docs(ops): avoid hardcoding sync endpoint path

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Leitstand acts strictly as a viewer; authentication and authorization enforcemen
     - *Avoid using `*` if possible.*
 
 3.  **Viewer vs. Actor**:
-    By default (`LEITSTAND_OPS_ALLOW_JOB_FALLBACK=false`), Leitstand only attempts non-mutating fetches (the sync endpoint, if exposed by acs). Enabling fallback allows it to trigger jobs (`POST /api/audit/git`), which is a state-changing action (even if just starting an audit). The UI will display a disclaimer reflecting the current mode. **Crucially, if enabled, Leitstand may *request* an audit job, but authorization and execution remain strictly on the acs side.**
+    By default (`LEITSTAND_OPS_ALLOW_JOB_FALLBACK=false`), Leitstand only attempts non-mutating fetches (the sync endpoint, if exposed by acs). Enabling fallback allows it to trigger jobs (the job-trigger endpoint, e.g. `POST /api/audit/git`), which is a state-changing action (even if just starting an audit). The UI will display a disclaimer reflecting the current mode. **Crucially, if enabled, Leitstand may *request* an audit job, but authorization and execution remain strictly on the acs side.**
 
 ## Data Flow & Contracts
 


### PR DESCRIPTION
Update README to clarify Ops Viewer endpoints are defined by acs, not hardcoded in Leitstand docs.

---
*PR created automatically by Jules for task [7638504530530172197](https://jules.google.com/task/7638504530530172197) started by @alexdermohr*