### PR TITLE
docs: add ops.runbook.leitstand-gateway

### DIFF
--- a/docs/runbooks/ops.runbook.leitstand-gateway.md
+++ b/docs/runbooks/ops.runbook.leitstand-gateway.md
@@ -3,6 +3,7 @@
 Stand: 2026-02-03 (abgeleitet aus heimserver.context.md)
 Dokumentklasse: OPERATIV · KANONISCH
 Scope: Heimserver-only
+Owner: ops / Heimserver; Änderungen an Proxy/Firewall/DNS müssen dieses Runbook im selben PR updaten.
 
 ## 0) Zweck
 Dieses Runbook beschreibt den kanonischen Betrieb eines dauerhaft erreichbaren Heimgewebe-Viewers:
@@ -122,9 +123,9 @@ DOCKER-USER wirkt nur, wenn Docker Traffic durch FORWARD/DOCKER-Ketten führt (S
 
 Artefakte liegen unter:
 - /opt/heimgewebe/gateway/
-- compose.gateway.yml
-- Caddyfile
-- leitstand.config.json (falls Leitstand Artefaktpfade liest)
+  - compose.gateway.yml
+  - Caddyfile
+  - leitstand.config.json (falls Leitstand Artefaktpfade liest)
 
 systemd wrapper:
 - /etc/systemd/system/heimgewebe-gateway.service


### PR DESCRIPTION
Add `ops.runbook.leitstand-gateway.md` to `docs/runbooks/`. This document serves as the canonical reference for operating the Leitstand gateway, specifying:

- **Purpose**: Canonical operation of the Heimgewebe-Viewer.
- **Invariants**: LAN/WireGuard only, Caddy as the sole entry point, strict READ-ONLY default for Leitstand.
- **Architecture**: Client -> WireGuard -> Heimserver -> Caddy -> Leitstand/ACS.
- **Trust Zones**: Explicit definitions of Trusted (LAN, WG) and Not Trusted (Docker bridge, WAN).
- **Deployment**: Step-by-step instructions including preflight, deploy, postflight, and rollback.
- **Policy**: Canonical rules for firewall (iptables/DOCKER-USER) and drift management.


---
*PR created automatically by Jules for task [3592943137688352915](https://jules.google.com/task/3592943137688352915) started by @alexdermohr*