### PR TITLE
perf: replace sync FS calls with async queue for meta updates

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -12,14 +12,12 @@ import { validatePlexerReport } from './validation/validators.js';
 
 const execPromise = promisify(exec);
 
-// In-memory queue for _meta.json updates to prevent race conditions during read-modify-write cycles
-// This is process-local and assumes a single writer within this server process.
+// In-memory queue for _meta.json updates to prevent race conditions during read-modify-write cycles.
+// Process-local only; not suitable for multi-process deployments (e.g. clusters or multiple containers).
 let metaUpdateQueue = Promise.resolve();
 
 /**
- * In-memory queue for _meta.json updates to prevent race conditions during read-modify-write cycles.
- * This is process-local and assumes a single writer within this server process.
- * Not suitable for multi-process deployments (e.g. PM2 cluster or multiple containers).
+ * Enqueues a read-modify-write operation for _meta.json.
  */
 async function enqueueMetaUpdate(updateFn: (meta: Record<string, unknown>) => Record<string, unknown>): Promise<void> {
   metaUpdateQueue = metaUpdateQueue.then(async () => {
@@ -308,6 +306,14 @@ if (isDirectRun) {
   app.listen(port, () => {
     console.log(`Leitstand server running at http://localhost:${port}`);
   });
+}
+
+/**
+ * Test helper to wait for all currently enqueued metadata updates to complete.
+ * Not intended for production use.
+ */
+export async function __wait_for_meta_queue(): Promise<void> {
+  await metaUpdateQueue;
 }
 
 export { app };

--- a/tests/meta_concurrency.test.ts
+++ b/tests/meta_concurrency.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import request from 'supertest';
-import { app } from '../src/server.js';
+import { app, __wait_for_meta_queue } from '../src/server.js';
 import { resetEnvConfig } from '../src/config.js';
 import { resetValidators } from '../src/validation/validators.js';
 import fs from 'node:fs/promises';
@@ -58,10 +58,8 @@ describe('POST /events concurrency', () => {
             expect(res.body).toEqual({ status: 'saved' });
         });
 
-        // Small wait for the async queue to finish (since it is un-awaited in the handler)
-        // In a real environment, we'd want a way to wait for the queue explicitly,
-        // but for a test, a small delay should suffice given the iterations.
-        await new Promise(resolve => setTimeout(resolve, 500));
+        // Deterministically wait for all queued updates to finish
+        await __wait_for_meta_queue();
 
         // Verify _meta.json integrity and existence
         const metaContent = await fs.readFile(metaPath, 'utf8');


### PR DESCRIPTION
Replaced blocking synchronous file system operations in the plexer report event handler with non-blocking asynchronous calls.

To prevent race conditions during the read-modify-write cycle of the shared _meta.json file, an in-memory sequential queue was implemented. This ensures that updates are processed one at a time within the server process. Additionally, atomic file writes are now used (via temporary file + rename) to guarantee file integrity.