### PR TITLE
feat(docs): Implement agent-friendly repo blueprint phase 1 & 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,15 @@ jobs:
     - name: Drift Gates
       if: success()
       run: bash scripts/ci/check-drift-gates.sh
+
+    - name: Repo Structure Guard
+      if: success()
+      run: bash scripts/ci/repo-structure-guard.sh
+
+    - name: Docs Relations Guard
+      if: success()
+      run: bash scripts/ci/docs-relations-guard.sh
+
+    - name: Generated Files Guard
+      if: success()
+      run: bash scripts/ci/generated-files-guard.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,63 @@
+# AGENTS
+
+## Purpose
+This document provides the agentic read path and working boundaries for the `leitstand` repository. It is the primary guide for agents operating within this repository, helping them understand the structure, truth sources, and safe operational boundaries.
+
+## Read This First
+1. `repo.meta.yaml` - Defines repository identity, type, and expected artifacts.
+2. `docs/index.md` - The canonical entry point for all documentation.
+3. `agent-policy.yaml` - Defines safe read, guarded write, and forbidden paths.
+
+## Canonical Sources
+- `repo.meta.yaml`: Repo identity and structure truth.
+- `AGENTS.md`: Agentic read path and working boundaries.
+- `docs/index.md`: Architecture, decisions, reference, guides, runbooks.
+- `docs/runtime.contract.md`: Normative invariant for deployment constraints.
+- `metarepo`: Canonical schemas for data consumed by Leitstand (e.g., `fleet.health.schema.json`, `insights.daily.schema.json`, `event.line.schema.json`).
+
+## Discovery Rules
+The repository uses a discovery mechanism starting from the roots defined in `repo.meta.yaml` (`docs/`, `src/`, `scripts/`, `tests/`, `.github/workflows/`).
+- New markdown documents must include YAML frontmatter and be referenced.
+- Obsolete documents must be marked `deprecated` or `archived` with explicit `supersedes`/`deprecated_by` relations where applicable.
+
+## Generated Files
+Files in `docs/_generated/` are automatically generated overviews and diagnostics. **Do not modify these files manually.** They are produced by generator scripts based on the state of the repository.
+- `docs/_generated/doc-index.md`
+- `docs/_generated/system-map.md`
+- `docs/_generated/orphans.md`
+- `docs/_generated/impl-index.md`
+- `docs/_generated/backlinks.md`
+- `docs/_generated/supersession-map.md`
+- `docs/_generated/agent-readiness.md`
+
+## Safe Read Paths
+- `README.md`
+- `AGENTS.md`
+- `docs/`
+
+## Guarded / Risky Paths
+- `docs/`
+- `scripts/`
+- `src/`
+- `.github/workflows/`
+
+Changes to these paths require verification, tests, and adherence to policies defined in `agent-policy.yaml`.
+
+## Required Checks
+Before submitting patches, the following checks must pass:
+- `repo-structure-guard`
+- `docs-relations-guard`
+- `generated-files-guard`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm typecheck`
+
+## Common Traps
+- **Missing Frontmatter:** Ensure all `.md` files in `docs/` (excluding `_generated/` and `index.md` if not applicable) have valid frontmatter.
+- **Manual Edits to Generated Files:** Do not edit `docs/_generated/` manually.
+- **Ignoring Event.line schemas:** Do not assume missing data can be mocked incorrectly; use valid schemas.
+- **Modifying Artifacts:** Edit source files, not generated static sites or dist folders.
+
+## Open Gaps
+- Implicit dependencies between deployment scripts and runbooks are tracked heuristically.
+- Full automated test coverage of the frontend UI rendering logic is sparse.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Dashboard and control-room for the **heimgewebe** organism.
 
+**Repo Status:** Active
+**Repo Type:** Service
+
 ## Overview
 
 `leitstand` is the central monitoring and reporting system for the heimgewebe multi-repo ecosystem. In this initial iteration, it provides a **daily system digest generator** that combines data from multiple sources into a unified markdown report.
@@ -45,6 +48,11 @@ For details, refer to:
 - [Runtime Contract](docs/runtime.contract.md) (Normative)
 - [Access Matrix](docs/access.matrix.md)
 - [Drift Signals](docs/drift.signals.md)
+
+## Important Agent & Documentation Links
+
+- [AGENTS.md](AGENTS.md) - Agentic read path and working boundaries
+- [docs/index.md](docs/index.md) - Canonical entry point for all documentation
 
 ## Features
 

--- a/agent-policy.yaml
+++ b/agent-policy.yaml
@@ -1,0 +1,32 @@
+safe_read_paths:
+  - README.md
+  - AGENTS.md
+  - docs/
+
+guarded_write_paths:
+  - docs/
+  - scripts/
+  - src/
+  - .github/workflows/
+
+forbidden_write_paths:
+  - docs/_generated/
+  - tests/fixtures/
+
+requires_target_proof_for:
+  - src/
+  - deploy/
+  - scripts/
+  - .github/workflows/
+
+required_checks_before_patch:
+  - repo-structure-guard
+  - docs-relations-guard
+  - generated-files-guard
+  - lint
+  - test
+  - typecheck
+
+human_review_required_for:
+  - deploy/
+  - .github/workflows/security-hygiene.yml

--- a/audit/impl-registry.yaml
+++ b/audit/impl-registry.yaml
@@ -1,0 +1,32 @@
+implementations:
+  - id: impl.service.server
+    path: src/server.ts
+    impl_type: service
+    status: active
+    documented_by:
+      - docs/index.md
+    verified_by:
+      - tests/
+    supersedes: []
+    deprecated_by: []
+
+  - id: impl.cli.digest
+    path: src/cli.ts
+    impl_type: cli
+    status: active
+    documented_by:
+      - docs/index.md
+    verified_by:
+      - tests/
+    supersedes: []
+    deprecated_by: []
+
+  - id: impl.script.deployment
+    path: scripts/leitstand-up
+    impl_type: script
+    status: active
+    documented_by:
+      - docs/runbooks/ops.runbook.leitstand-gateway.md
+    verified_by: []
+    supersedes: []
+    deprecated_by: []

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,3 +1,12 @@
+---
+id: docs.deployment
+title: Deployment
+doc_type: guide
+status: active
+canonicality: canonical
+summary: >
+  General deployment guide for Leitstand.
+---
 # Deployment
 
 ## Artifact Ingestion

--- a/docs/_generated/agent-readiness.md
+++ b/docs/_generated/agent-readiness.md
@@ -1,0 +1,1 @@
+<!-- This is a generated file. Do not edit manually. -->

--- a/docs/_generated/backlinks.md
+++ b/docs/_generated/backlinks.md
@@ -1,0 +1,1 @@
+<!-- This is a generated file. Do not edit manually. -->

--- a/docs/_generated/doc-index.md
+++ b/docs/_generated/doc-index.md
@@ -1,0 +1,1 @@
+<!-- This is a generated file. Do not edit manually. -->

--- a/docs/_generated/impl-index.md
+++ b/docs/_generated/impl-index.md
@@ -1,0 +1,1 @@
+<!-- This is a generated file. Do not edit manually. -->

--- a/docs/_generated/orphans.md
+++ b/docs/_generated/orphans.md
@@ -1,0 +1,1 @@
+<!-- This is a generated file. Do not edit manually. -->

--- a/docs/_generated/supersession-map.md
+++ b/docs/_generated/supersession-map.md
@@ -1,0 +1,1 @@
+<!-- This is a generated file. Do not edit manually. -->

--- a/docs/_generated/system-map.md
+++ b/docs/_generated/system-map.md
@@ -1,0 +1,1 @@
+<!-- This is a generated file. Do not edit manually. -->

--- a/docs/access.matrix.md
+++ b/docs/access.matrix.md
@@ -1,3 +1,12 @@
+---
+id: docs.access.matrix
+title: Zugriffsmatrix
+doc_type: reference
+status: active
+canonicality: canonical
+summary: >
+  Definiert die erlaubten Zugriffswege auf den Leitstand.
+---
 # Zugriffsmatrix
 
 Diese Tabelle definiert die erlaubten Zugriffswege auf den Leitstand.

--- a/docs/blueprints/leitstand_manifest.md
+++ b/docs/blueprints/leitstand_manifest.md
@@ -1,3 +1,12 @@
+---
+id: docs.blueprints.leitstand.manifest
+title: Leitstand – Heimgewebe-Visualisierung(en)
+doc_type: architecture
+status: active
+canonicality: canonical
+summary: >
+  Blaupause: Leitstand – Heimgewebe-Visualisierung(en).
+---
 # Blaupause: Leitstand – Heimgewebe-Visualisierung(en)
 
 (Arbeitsrahmen, der nicht alles auf einmal will, sondern Orientierung + Reihenfolge erzwingt)

--- a/docs/blueprints/leitstand_visualization.md
+++ b/docs/blueprints/leitstand_visualization.md
@@ -1,3 +1,12 @@
+---
+id: docs.blueprints.leitstand.visualization
+title: Visualisierung des Heimgewebes im Leitstand
+doc_type: architecture
+status: active
+canonicality: canonical
+summary: >
+  Blaupause: Visualisierung des Heimgewebes im Leitstand.
+---
 # Blaupause: Visualisierung des Heimgewebes im Leitstand
 
 ## Phase 1: Anatomie (Strukturelle Übersicht)

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -1,3 +1,12 @@
+---
+id: docs.data.flow
+title: Data Flow & Required Inputs
+doc_type: architecture
+status: active
+canonicality: canonical
+summary: >
+  Beschreibt die Datenströme, die der Leitstand konsumiert.
+---
 # Leitstand – Data Flow & Required Inputs
 
 Dieses Dokument beschreibt die Datenströme, die der Leitstand konsumiert.

--- a/docs/decisions/wgx-leitstand.md
+++ b/docs/decisions/wgx-leitstand.md
@@ -1,3 +1,12 @@
+---
+id: docs.decisions.wgx.leitstand
+title: leitstand has a tracked WGX profile
+doc_type: decision
+status: active
+canonicality: canonical
+summary: >
+  Decision: leitstand has a tracked WGX profile.
+---
 # Decision: leitstand has a tracked WGX profile
 
 ## Context

--- a/docs/deploy-cloudflare.md
+++ b/docs/deploy-cloudflare.md
@@ -1,3 +1,12 @@
+---
+id: docs.deploy.cloudflare
+title: Deploying Leitstand to Cloudflare Pages
+doc_type: guide
+status: active
+canonicality: canonical
+summary: >
+  Guide for deploying Leitstand to Cloudflare Pages.
+---
 # Deploying Leitstand to Cloudflare Pages
 
 Leitstand relies on a deterministic build process where data artifacts are fetched *before* the static site generation.

--- a/docs/deploy/heimserver.naming.md
+++ b/docs/deploy/heimserver.naming.md
@@ -1,3 +1,12 @@
+---
+id: docs.deploy.heimserver.naming
+title: Heimserver Naming Policy
+doc_type: reference
+status: active
+canonicality: derived
+summary: >
+  Heimserver Naming Policy (Referenzkopie).
+---
 # Heimserver Naming Policy (Referenzkopie)
 
 Stand: 2026-02-03

--- a/docs/drift.signals.md
+++ b/docs/drift.signals.md
@@ -1,3 +1,12 @@
+---
+id: docs.drift.signals
+title: Drift-Signale
+doc_type: reference
+status: active
+canonicality: canonical
+summary: >
+  Typische Indikatoren für Fehler in der Betriebskonfiguration (Drift).
+---
 # Drift-Signale
 
 Typische Indikatoren für Fehler in der Betriebskonfiguration (Drift).

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,16 @@
 
 Leitstand is the visual control center of the Heimgewebe organism. It is organized into strict normative invariants (contracts) and operative runbooks. This router connects the "What is true?" (Contracts) with the "How does it stay true?" (Checks).
 
+## Generated Overviews
+
+- [Documentation Index](_generated/doc-index.md)
+- [System Map](_generated/system-map.md)
+- [Orphaned Documents](_generated/orphans.md)
+- [Implementation Index](_generated/impl-index.md)
+- [Backlinks Map](_generated/backlinks.md)
+- [Supersession Map](_generated/supersession-map.md)
+- [Agent Readiness](_generated/agent-readiness.md)
+
 ## 1. Normative Invariants
 
 Small, stable, hard rules and diagnostic signals.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,12 @@
+---
+id: docs.index
+title: Leitstand Documentation Router
+doc_type: index
+status: active
+canonicality: canonical
+summary: >
+  Canonical entry point for all documentation.
+---
 # Leitstand Documentation Router
 
 Leitstand is the visual control center of the Heimgewebe organism. It is organized into strict normative invariants (contracts) and operative runbooks. This router connects the "What is true?" (Contracts) with the "How does it stay true?" (Checks).

--- a/docs/runbooks/leitstand.md
+++ b/docs/runbooks/leitstand.md
@@ -1,3 +1,12 @@
+---
+id: docs.runbooks.leitstand
+title: Leitstand Runbook
+doc_type: runbook
+status: active
+canonicality: canonical
+summary: >
+  Leitstand Runbook.
+---
 # Leitstand Runbook
 
 ## Inputs and Data Flow

--- a/docs/runbooks/ops.runbook.leitstand-gateway.md
+++ b/docs/runbooks/ops.runbook.leitstand-gateway.md
@@ -1,3 +1,12 @@
+---
+id: docs.runbooks.ops.runbook.leitstand.gateway
+title: ops.runbook.leitstand-gateway
+doc_type: runbook
+status: active
+canonicality: canonical
+summary: >
+  Runbook for leitstand-gateway operations.
+---
 # ops.runbook.leitstand-gateway
 
 Stand: 2026-02-03 (abgeleitet aus heimserver.context.md)

--- a/docs/runbooks/ops.runbook.leitstand-gateway.updates.md
+++ b/docs/runbooks/ops.runbook.leitstand-gateway.updates.md
@@ -1,3 +1,12 @@
+---
+id: docs.runbooks.ops.runbook.leitstand.gateway.updates
+title: ops.runbook.leitstand-gateway.updates
+doc_type: runbook
+status: active
+canonicality: canonical
+summary: >
+  Runbook for leitstand-gateway updates.
+---
 # ops.runbook.leitstand-gateway.updates
 
 Stand: 2026-02-03

--- a/docs/runtime.contract.md
+++ b/docs/runtime.contract.md
@@ -1,3 +1,12 @@
+---
+id: docs.runtime.contract
+title: Runtime Contract
+doc_type: reference
+status: active
+canonicality: canonical
+summary: >
+  Beschreibt die unveränderlichen Bedingungen für den Betrieb des Leitstands.
+---
 # Runtime Contract
 
 Dieses Dokument beschreibt die unveränderlichen Bedingungen für den Betrieb des Leitstands.

--- a/repo.meta.yaml
+++ b/repo.meta.yaml
@@ -27,6 +27,7 @@ discovery_roots:
   - src/
   - scripts/
   - tests/
+  - deploy/
   - .github/workflows/
 
 generated_artifacts:
@@ -47,6 +48,7 @@ guarded_write_paths:
   - docs/
   - scripts/
   - src/
+  - deploy/
   - .github/workflows/
 
 forbidden_write_paths:

--- a/repo.meta.yaml
+++ b/repo.meta.yaml
@@ -1,0 +1,78 @@
+repo_name: leitstand
+repo_type: service
+role: dashboard_and_digest_generator
+status: active
+summary: >
+  Dashboard and control-room for the heimgewebe organism - daily system digest generator.
+
+owners:
+  - heimgewebe
+
+primary_languages:
+  - typescript
+  - markdown
+
+entrypoints:
+  - README.md
+  - AGENTS.md
+  - docs/index.md
+
+canonical_sources:
+  - repo.meta.yaml
+  - AGENTS.md
+  - docs/index.md
+
+discovery_roots:
+  - docs/
+  - src/
+  - scripts/
+  - tests/
+  - .github/workflows/
+
+generated_artifacts:
+  - docs/_generated/doc-index.md
+  - docs/_generated/system-map.md
+  - docs/_generated/orphans.md
+  - docs/_generated/impl-index.md
+  - docs/_generated/backlinks.md
+  - docs/_generated/supersession-map.md
+  - docs/_generated/agent-readiness.md
+
+safe_read_paths:
+  - README.md
+  - AGENTS.md
+  - docs/
+
+guarded_write_paths:
+  - docs/
+  - scripts/
+  - src/
+
+forbidden_write_paths:
+  - docs/_generated/
+
+required_checks:
+  - repo-structure-guard
+  - docs-relations-guard
+  - generated-files-guard
+
+indexing:
+  enabled: true
+  require_frontmatter_for_docs: true
+  require_registry_for_critical_impl: true
+  fail_on_untyped_docs: false
+  fail_on_missing_doc_index: true
+  fail_on_orphans: false
+  fail_on_unmapped_critical_impl: false
+
+related_repos:
+  - metarepo
+  - wgx
+  - semantAH
+  - chronik
+
+keywords:
+  - docs
+  - agent-ready
+  - dashboard
+  - insights

--- a/repo.meta.yaml
+++ b/repo.meta.yaml
@@ -47,6 +47,7 @@ guarded_write_paths:
   - docs/
   - scripts/
   - src/
+  - .github/workflows/
 
 forbidden_write_paths:
   - docs/_generated/

--- a/scripts/ci/docs-relations-guard.sh
+++ b/scripts/ci/docs-relations-guard.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log_info() { echo "→ $1"; }
+log_success() { echo "✓ $1"; }
+log_error() { echo "❌ $1" >&2; }
+fail() { log_error "$1"; exit 1; }
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+
+log_info "Running Docs Relations Guard..."
+
+# Basic check: just make sure that files in docs/ (excluding _generated) have frontmatter `---`
+# Only check `.md` files.
+
+DOC_FILES=$(find docs/ -type f -name "*.md" -not -path "docs/_generated/*" -not -name "index.md")
+
+for file in $DOC_FILES; do
+    if ! head -n 1 "$file" | grep -q "^---$"; then
+        fail "Markdown document '$file' is missing YAML frontmatter (must start with '---')."
+    fi
+done
+
+log_success "Docs Relations Guard passed."

--- a/scripts/ci/docs-relations-guard.sh
+++ b/scripts/ci/docs-relations-guard.sh
@@ -11,15 +11,32 @@ cd "$REPO_ROOT"
 
 log_info "Running Docs Relations Guard..."
 
-# Basic check: just make sure that files in docs/ (excluding _generated) have frontmatter `---`
-# Only check `.md` files.
-
+# Basic check: make sure that files in docs/ (excluding _generated) have frontmatter `---`
+# and contain the required fields.
 DOC_FILES=$(find docs/ -type f -name "*.md" -not -path "docs/_generated/*" -not -name "index.md")
+
+REQUIRED_FIELDS=(
+    "id"
+    "title"
+    "doc_type"
+    "status"
+    "canonicality"
+    "summary"
+)
 
 for file in $DOC_FILES; do
     if ! head -n 1 "$file" | grep -q "^---$"; then
         fail "Markdown document '$file' is missing YAML frontmatter (must start with '---')."
     fi
+
+    # Read frontmatter (between the first two '---' lines)
+    FRONTMATTER=$(awk '/^---$/{c++;if(c==2)exit} c==1{print}' "$file")
+
+    for field in "${REQUIRED_FIELDS[@]}"; do
+        if ! echo "$FRONTMATTER" | grep -Eq "^${field}:"; then
+            fail "Markdown document '$file' is missing required frontmatter field: '$field'."
+        fi
+    done
 done
 
 log_success "Docs Relations Guard passed."

--- a/scripts/ci/docs-relations-guard.sh
+++ b/scripts/ci/docs-relations-guard.sh
@@ -13,8 +13,6 @@ log_info "Running Docs Relations Guard..."
 
 # Basic check: make sure that files in docs/ (excluding _generated) have frontmatter `---`
 # and contain the required fields.
-DOC_FILES=$(find docs/ -type f -name "*.md" -not -path "docs/_generated/*" -not -name "index.md")
-
 REQUIRED_FIELDS=(
     "id"
     "title"
@@ -24,7 +22,7 @@ REQUIRED_FIELDS=(
     "summary"
 )
 
-for file in $DOC_FILES; do
+find docs/ -type f -name "*.md" -not -path "docs/_generated/*" -print0 | while IFS= read -r -d '' file; do
     if ! head -n 1 "$file" | grep -q "^---$"; then
         fail "Markdown document '$file' is missing YAML frontmatter (must start with '---')."
     fi

--- a/scripts/ci/generated-files-guard.sh
+++ b/scripts/ci/generated-files-guard.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log_info() { echo "→ $1"; }
+log_success() { echo "✓ $1"; }
+log_error() { echo "❌ $1" >&2; }
+fail() { log_error "$1"; exit 1; }
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+
+log_info "Running Generated Files Guard..."
+
+GENERATED_DIR="docs/_generated"
+HEADER="<!-- This is a generated file. Do not edit manually. -->"
+
+if [[ -d "$GENERATED_DIR" ]]; then
+    FILES=$(find "$GENERATED_DIR" -type f -name "*.md")
+    for file in $FILES; do
+        if ! grep -Fq "$HEADER" "$file"; then
+            fail "Generated file '$file' is missing the required warning header."
+        fi
+    done
+fi
+
+log_success "Generated Files Guard passed."

--- a/scripts/ci/generated-files-guard.sh
+++ b/scripts/ci/generated-files-guard.sh
@@ -14,13 +14,29 @@ log_info "Running Generated Files Guard..."
 GENERATED_DIR="docs/_generated"
 HEADER="<!-- This is a generated file. Do not edit manually. -->"
 
-if [[ -d "$GENERATED_DIR" ]]; then
-    FILES=$(find "$GENERATED_DIR" -type f -name "*.md")
-    for file in $FILES; do
-        if ! grep -Fq "$HEADER" "$file"; then
-            fail "Generated file '$file' is missing the required warning header."
-        fi
-    done
+REQUIRED_FILES=(
+    "doc-index.md"
+    "system-map.md"
+    "orphans.md"
+    "impl-index.md"
+    "backlinks.md"
+    "supersession-map.md"
+    "agent-readiness.md"
+)
+
+if [[ ! -d "$GENERATED_DIR" ]]; then
+    fail "Required directory '$GENERATED_DIR' is missing."
 fi
+
+for filename in "${REQUIRED_FILES[@]}"; do
+    file="$GENERATED_DIR/$filename"
+    if [[ ! -f "$file" ]]; then
+        fail "Required generated file placeholder '$file' is missing."
+    fi
+
+    if ! head -n 1 "$file" | grep -Fq "$HEADER"; then
+        fail "Generated file '$file' is missing the required warning header on the first line."
+    fi
+done
 
 log_success "Generated Files Guard passed."

--- a/scripts/ci/repo-structure-guard.sh
+++ b/scripts/ci/repo-structure-guard.sh
@@ -15,6 +15,7 @@ FILES=(
     "README.md"
     "AGENTS.md"
     "repo.meta.yaml"
+    "agent-policy.yaml"
     "docs/index.md"
 )
 

--- a/scripts/ci/repo-structure-guard.sh
+++ b/scripts/ci/repo-structure-guard.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log_info() { echo "→ $1"; }
+log_success() { echo "✓ $1"; }
+log_error() { echo "❌ $1" >&2; }
+fail() { log_error "$1"; exit 1; }
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+
+log_info "Running Repo Structure Guard..."
+
+FILES=(
+    "repo.meta.yaml"
+    "docs/index.md"
+)
+
+for file in "${FILES[@]}"; do
+    if [[ ! -f "$file" ]]; then
+        fail "Required core artifact '$file' is missing."
+    fi
+done
+
+if [[ ! -d "docs/_generated" ]]; then
+    fail "Required directory 'docs/_generated' is missing."
+fi
+
+log_success "Repo Structure Guard passed."

--- a/scripts/ci/repo-structure-guard.sh
+++ b/scripts/ci/repo-structure-guard.sh
@@ -12,6 +12,8 @@ cd "$REPO_ROOT"
 log_info "Running Repo Structure Guard..."
 
 FILES=(
+    "README.md"
+    "AGENTS.md"
     "repo.meta.yaml"
     "docs/index.md"
 )
@@ -24,6 +26,15 @@ done
 
 if [[ ! -d "docs/_generated" ]]; then
     fail "Required directory 'docs/_generated' is missing."
+fi
+
+# Basic check: repo.meta.yaml contains repo_name and repo_type
+if ! grep -q "^repo_name:" "repo.meta.yaml"; then
+    fail "repo.meta.yaml must contain 'repo_name:'."
+fi
+
+if ! grep -q "^repo_type:" "repo.meta.yaml"; then
+    fail "repo.meta.yaml must contain 'repo_type:'."
 fi
 
 log_success "Repo Structure Guard passed."


### PR DESCRIPTION
This PR implements Phase 1 and Phase 2 of the "Ideale Blaupause für agentenfreundliche Repositories" as requested.

**Changes:**
1. **Core Artifacts:** Established the repository's programmatic identity by creating `repo.meta.yaml`, `AGENTS.md`, and `agent-policy.yaml`.
2. **Structural Discovery:** Generated placeholders for `docs/_generated/` and created `audit/impl-registry.yaml` for tracking critical implementations.
3. **Guard System:** Implemented basic Posix-compliant CI guards (`repo-structure-guard.sh`, `docs-relations-guard.sh`, `generated-files-guard.sh`) and integrated them into `.github/workflows/ci.yml`.
4. **Frontmatter Retrofit:** Added compliant YAML frontmatter to all existing markdown files under `docs/` so they successfully pass the newly added `docs-relations-guard`.
5. **Entrypoint Updates:** Updated `README.md` and `docs/index.md` to point to the new structures.

All tests, linting, and typechecks pass with these changes.

---
*PR created automatically by Jules for task [9027901235117398144](https://jules.google.com/task/9027901235117398144) started by @alexdermohr*