### PR TITLE
security: fix XSS via innerHTML in observatory and ops views

### DIFF
--- a/observatory_debug.html
+++ b/observatory_debug.html
@@ -190,7 +190,7 @@
             <td style="padding: 10px; color: #666;">2023-10-27T10:00:00Z</td>
             <td style="padding: 10px; text-align: right;">
 
-                  <a href="https://example.com/meta" target="_blank" style="text-decoration: none; color: #1976d2;">&rarr;</a>
+                  <a href="https://example.com/meta" target="_blank" rel="noopener noreferrer" style="text-decoration: none; color: #1976d2;">&rarr;</a>
 
             </td>
           </tr>
@@ -207,7 +207,7 @@
             <td style="padding: 10px; color: #666;">2023-10-27T10:00:00Z</td>
             <td style="padding: 10px; text-align: right;">
 
-                  <a href="https://example.com/reports/integrity/semantAH.summary.json" target="_blank" style="text-decoration: none; color: #1976d2;">&rarr;</a>
+                  <a href="https://example.com/reports/integrity/semantAH.summary.json" target="_blank" rel="noopener noreferrer" style="text-decoration: none; color: #1976d2;">&rarr;</a>
 
             </td>
           </tr>
@@ -224,7 +224,7 @@
             <td style="padding: 10px; color: #666;">2023-10-27T11:00:00Z</td>
             <td style="padding: 10px; text-align: right;">
 
-                  <a href="https://example.com/wgx" target="_blank" style="text-decoration: none; color: #1976d2;">&rarr;</a>
+                  <a href="https://example.com/wgx" target="_blank" rel="noopener noreferrer" style="text-decoration: none; color: #1976d2;">&rarr;</a>
 
             </td>
           </tr>

--- a/observatory_debug.html
+++ b/observatory_debug.html
@@ -102,13 +102,21 @@
         }
 
         // Debug Output
-        statusEl.innerHTML = "<strong>Live data loaded!</strong>";
+        statusEl.textContent = "";
+        const strong = document.createElement("strong");
+        strong.textContent = "Live data loaded!";
+        statusEl.appendChild(strong);
         statusEl.style.color = "green";
         if (isDebug) {
           preEl.textContent = JSON.stringify(data, null, 2);
         }
       } catch (e) {
-        statusEl.innerHTML = "<strong>Runtime fetch failed.</strong><br>" + String(e);
+        statusEl.textContent = "";
+        const strong = document.createElement("strong");
+        strong.textContent = "Runtime fetch failed.";
+        statusEl.appendChild(strong);
+        statusEl.appendChild(document.createElement("br"));
+        statusEl.appendChild(document.createTextNode(String(e)));
         statusEl.style.color = "red";
         if (isDebug) console.error("Observatory Runtime Fetch Error:", e);
       }

--- a/src/views/observatory.ejs
+++ b/src/views/observatory.ejs
@@ -136,13 +136,21 @@
         }
 
         // Debug Output
-        statusEl.innerHTML = "<strong>Live data loaded!</strong>";
+        statusEl.textContent = "";
+        const strong = document.createElement("strong");
+        strong.textContent = "Live data loaded!";
+        statusEl.appendChild(strong);
         statusEl.style.color = "green";
         if (isDebug) {
           preEl.textContent = JSON.stringify(data, null, 2);
         }
       } catch (e) {
-        statusEl.innerHTML = "<strong>Runtime fetch failed.</strong><br>" + String(e);
+        statusEl.textContent = "";
+        const strong = document.createElement("strong");
+        strong.textContent = "Runtime fetch failed.";
+        statusEl.appendChild(strong);
+        statusEl.appendChild(document.createElement("br"));
+        statusEl.appendChild(document.createTextNode(String(e)));
         statusEl.style.color = "red";
         if (isDebug) console.error("Observatory Runtime Fetch Error:", e);
       }

--- a/src/views/observatory.ejs
+++ b/src/views/observatory.ejs
@@ -54,7 +54,7 @@
            <%= locals.view_meta.forensics.observatory.bytes %> bytes |
            Source: <%= locals.view_meta.forensics.observatory.source_url %>
            <% if (locals.view_meta.forensics.observatory.sha) { %> | SHA: <span title="<%= locals.view_meta.forensics.observatory.sha %>"><%= locals.view_meta.forensics.observatory.sha.substring(0, 7) %>...</span><% } %>
-           <% if (locals.view_meta.forensics.observatory.schema_ref) { %> | Schema: <a href="<%= locals.view_meta.forensics.observatory.schema_ref %>" target="_blank" style="color: #555; text-decoration: underline;">ref</a><% } %><br>
+           <% if (locals.view_meta.forensics.observatory.schema_ref) { %> | Schema: <a href="<%= locals.view_meta.forensics.observatory.schema_ref %>" target="_blank" rel="noopener noreferrer" style="color: #555; text-decoration: underline;">ref</a><% } %><br>
         <% } %>
         <% if (locals.view_meta.forensics.integrity) { %>
            <strong>Integrity:</strong>
@@ -553,7 +553,7 @@
             </td>
             <td style="padding: 10px; text-align: right;">
                <% if (s.summary_url) { %>
-                  <a href="<%= s.summary_url %>" target="_blank" style="text-decoration: none; color: #1976d2;">&rarr;</a>
+                  <a href="<%= s.summary_url %>" target="_blank" rel="noopener noreferrer" style="text-decoration: none; color: #1976d2;">&rarr;</a>
                <% } %>
             </td>
           </tr>

--- a/src/views/ops.ejs
+++ b/src/views/ops.ejs
@@ -408,6 +408,7 @@
             acsLink.href = `${ACS_URL}/`;
             acsLink.className = 'acs-link';
             acsLink.target = '_blank';
+            acsLink.rel = 'noopener noreferrer';
             acsLink.textContent = 'Open in acs →';
 
             actionsDiv.appendChild(actionLabel);

--- a/src/views/ops.ejs
+++ b/src/views/ops.ejs
@@ -382,17 +382,41 @@
             if (routine.risk === 'low') riskColor = 'green';
             if (routine.risk === 'medium') riskColor = 'orange';
 
-            card.innerHTML = `
-              <div class="routine-header">
-                <span>${routine.id}</span>
-                <span style="color: ${riskColor}">Risk: ${routine.risk}</span>
-              </div>
-              <p>${routine.reason}</p>
-              <div class="routine-actions">
-                <span>Action required in acs:</span>
-                <a href="${ACS_URL}/" class="acs-link" target="_blank">Open in acs &rarr;</a>
-              </div>
-            `;
+            const headerDiv = document.createElement('div');
+            headerDiv.className = 'routine-header';
+
+            const idSpan = document.createElement('span');
+            idSpan.textContent = routine.id;
+
+            const riskSpan = document.createElement('span');
+            riskSpan.style.color = riskColor;
+            riskSpan.textContent = `Risk: ${routine.risk}`;
+
+            headerDiv.appendChild(idSpan);
+            headerDiv.appendChild(riskSpan);
+
+            const reasonP = document.createElement('p');
+            reasonP.textContent = routine.reason;
+
+            const actionsDiv = document.createElement('div');
+            actionsDiv.className = 'routine-actions';
+
+            const actionLabel = document.createElement('span');
+            actionLabel.textContent = 'Action required in acs:';
+
+            const acsLink = document.createElement('a');
+            acsLink.href = `${ACS_URL}/`;
+            acsLink.className = 'acs-link';
+            acsLink.target = '_blank';
+            acsLink.textContent = 'Open in acs →';
+
+            actionsDiv.appendChild(actionLabel);
+            actionsDiv.appendChild(document.createTextNode(' '));
+            actionsDiv.appendChild(acsLink);
+
+            card.appendChild(headerDiv);
+            card.appendChild(reasonP);
+            card.appendChild(actionsDiv);
             routinesList.appendChild(card);
           });
         }

--- a/tests/security_hardening.test.ts
+++ b/tests/security_hardening.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+describe('Security Hardening - Client-side XSS Prevention', () => {
+  it('src/views/ops.ejs should not use innerHTML for routine rendering', () => {
+    const filePath = path.join(process.cwd(), 'src/views/ops.ejs');
+    const content = fs.readFileSync(filePath, 'utf-8');
+
+    // We want to ensure that inside the routine loop, innerHTML is not used to build the card
+    // The previous vulnerable code was card.innerHTML = `...`
+    // We expect the use of createElement/textContent instead.
+
+    // Check that we are using textContent for dynamic routine data
+    expect(content).toContain('idSpan.textContent = routine.id');
+    expect(content).toContain('riskSpan.textContent = `Risk: ${routine.risk}`');
+    expect(content).toContain('reasonP.textContent = routine.reason');
+
+    // Ensure the old vulnerable pattern is gone
+    expect(content).not.toContain('card.innerHTML = `');
+  });
+
+  it('src/views/observatory.ejs should not use innerHTML for error/status rendering', () => {
+    const filePath = path.join(process.cwd(), 'src/views/observatory.ejs');
+    const content = fs.readFileSync(filePath, 'utf-8');
+
+    // Vulnerable code: statusEl.innerHTML = "<strong>Runtime fetch failed.</strong><br>" + String(e);
+    // Fixed code uses textContent and appendChild
+
+    expect(content).toContain('statusEl.textContent = ""');
+    expect(content).toContain('strong.textContent = "Runtime fetch failed."');
+    expect(content).not.toMatch(/statusEl\.innerHTML\s*=\s*".*String\(e\)/);
+  });
+
+  it('src/views/ops.ejs should have rel="noopener noreferrer" for external links', () => {
+    const filePath = path.join(process.cwd(), 'src/views/ops.ejs');
+    const content = fs.readFileSync(filePath, 'utf-8');
+
+    expect(content).toContain('acsLink.rel = \'noopener noreferrer\'');
+  });
+});

--- a/tests/security_hardening.test.ts
+++ b/tests/security_hardening.test.ts
@@ -3,39 +3,39 @@ import fs from 'fs';
 import path from 'path';
 
 describe('Security Hardening - Client-side XSS Prevention', () => {
-  it('src/views/ops.ejs should not use innerHTML for routine rendering', () => {
-    const filePath = path.join(process.cwd(), 'src/views/ops.ejs');
+  const checkXSSPrevention = (filePath: string) => {
     const content = fs.readFileSync(filePath, 'utf-8');
 
-    // We want to ensure that inside the routine loop, innerHTML is not used to build the card
-    // The previous vulnerable code was card.innerHTML = `...`
-    // We expect the use of createElement/textContent instead.
+    // Ensure dangerous innerHTML pattern with dynamic data is removed
+    // We specifically look for the patterns we fixed:
+    // 1. routine card rendering in ops.ejs
+    // 2. error status rendering in observatory.ejs / observatory_debug.html
 
-    // Check that we are using textContent for dynamic routine data
-    expect(content).toContain('idSpan.textContent = routine.id');
-    expect(content).toContain('riskSpan.textContent = `Risk: ${routine.risk}`');
-    expect(content).toContain('reasonP.textContent = routine.reason');
+    if (filePath.endsWith('ops.ejs')) {
+      expect(content).not.toContain('card.innerHTML = `');
+      expect(content).toContain('.textContent = routine.');
+      expect(content).toContain('acsLink.rel = \'noopener noreferrer\'');
+    }
 
-    // Ensure the old vulnerable pattern is gone
-    expect(content).not.toContain('card.innerHTML = `');
+    if (filePath.includes('observatory')) {
+      // Should not concatenate Error string into innerHTML
+      expect(content).not.toMatch(/statusEl\.innerHTML\s*=\s*".*String\(e\)/);
+      // Should use textContent for clearing or setting static text
+      expect(content).toContain('statusEl.textContent = ""');
+      // Should use textContent on strong element for the failure message
+      expect(content).toContain('.textContent = "Runtime fetch failed."');
+    }
+  };
+
+  it('src/views/ops.ejs should use safe DOM APIs and have hardened links', () => {
+    checkXSSPrevention(path.join(process.cwd(), 'src/views/ops.ejs'));
   });
 
-  it('src/views/observatory.ejs should not use innerHTML for error/status rendering', () => {
-    const filePath = path.join(process.cwd(), 'src/views/observatory.ejs');
-    const content = fs.readFileSync(filePath, 'utf-8');
-
-    // Vulnerable code: statusEl.innerHTML = "<strong>Runtime fetch failed.</strong><br>" + String(e);
-    // Fixed code uses textContent and appendChild
-
-    expect(content).toContain('statusEl.textContent = ""');
-    expect(content).toContain('strong.textContent = "Runtime fetch failed."');
-    expect(content).not.toMatch(/statusEl\.innerHTML\s*=\s*".*String\(e\)/);
+  it('src/views/observatory.ejs should use safe DOM APIs for error rendering', () => {
+    checkXSSPrevention(path.join(process.cwd(), 'src/views/observatory.ejs'));
   });
 
-  it('src/views/ops.ejs should have rel="noopener noreferrer" for external links', () => {
-    const filePath = path.join(process.cwd(), 'src/views/ops.ejs');
-    const content = fs.readFileSync(filePath, 'utf-8');
-
-    expect(content).toContain('acsLink.rel = \'noopener noreferrer\'');
+  it('observatory_debug.html should use safe DOM APIs for error rendering', () => {
+    checkXSSPrevention(path.join(process.cwd(), 'observatory_debug.html'));
   });
 });

--- a/tests/security_hardening.test.ts
+++ b/tests/security_hardening.test.ts
@@ -24,6 +24,11 @@ describe('Security Hardening - Client-side XSS Prevention', () => {
       expect(content).toContain('statusEl.textContent = ""');
       // Should use textContent on strong element for the failure message
       expect(content).toContain('.textContent = "Runtime fetch failed."');
+
+      // Ensure target="_blank" links have noopener noreferrer
+      if (content.includes('target="_blank"')) {
+        expect(content).toContain('rel="noopener noreferrer"');
+      }
     }
   };
 

--- a/tests/security_hardening.test.ts
+++ b/tests/security_hardening.test.ts
@@ -12,23 +12,25 @@ describe('Security Hardening - Client-side XSS Prevention', () => {
     // 2. error status rendering in observatory.ejs / observatory_debug.html
 
     if (filePath.endsWith('ops.ejs')) {
-      expect(content).not.toContain('card.innerHTML = `');
-      expect(content).toContain('.textContent = routine.');
-      expect(content).toContain('acsLink.rel = \'noopener noreferrer\'');
+      // Ensure dangerous innerHTML usage with routine data is removed
+      expect(content).not.toMatch(/card\.innerHTML\s*=\s*`/);
+      // Ensure safe textContent is used for dynamic data
+      expect(content).toMatch(/\.textContent\s*=\s*routine\./);
+      // Ensure security attribute is set for dynamically created links
+      expect(content).toMatch(/\.rel\s*=\s*['"]noopener noreferrer['"]/);
     }
 
     if (filePath.includes('observatory')) {
       // Should not concatenate Error string into innerHTML
       expect(content).not.toMatch(/statusEl\.innerHTML\s*=\s*".*String\(e\)/);
-      // Should use textContent for clearing or setting static text
-      expect(content).toContain('statusEl.textContent = ""');
-      // Should use textContent on strong element for the failure message
-      expect(content).toContain('.textContent = "Runtime fetch failed."');
+      // Should use safe textContent or individual node construction
+      expect(content).toMatch(/\.textContent\s*=\s*""/);
+      expect(content).toMatch(/\.textContent\s*=\s*['"]Runtime fetch failed\.['"]/);
+    }
 
-      // Ensure target="_blank" links have noopener noreferrer
-      if (content.includes('target="_blank"')) {
-        expect(content).toContain('rel="noopener noreferrer"');
-      }
+    // Global check for all target="_blank" links
+    if (content.includes('target="_blank"')) {
+      expect(content).toContain('rel="noopener noreferrer"');
     }
   };
 

--- a/tests/security_hardening.test.ts
+++ b/tests/security_hardening.test.ts
@@ -14,35 +14,44 @@ describe('Security Hardening - Client-side XSS Prevention', () => {
     if (filePath.endsWith('ops.ejs')) {
       // Ensure dangerous innerHTML usage with routine data is removed
       expect(content).not.toMatch(/card\.innerHTML\s*=\s*`/);
+
       // Ensure safe textContent is used for dynamic data
-      expect(content).toMatch(/\.textContent\s*=\s*routine\./);
-      // Ensure security attribute is set for dynamically created links
+      expect(content).toContain('.textContent = routine.id');
+      expect(content).toContain('.textContent = routine.reason');
+
+      // Ensure security attribute is set for dynamically created links in JS
       expect(content).toMatch(/\.rel\s*=\s*['"]noopener noreferrer['"]/);
     }
 
     if (filePath.includes('observatory')) {
       // Should not concatenate Error string into innerHTML
       expect(content).not.toMatch(/statusEl\.innerHTML\s*=\s*".*String\(e\)/);
-      // Should use safe textContent or individual node construction
-      expect(content).toMatch(/\.textContent\s*=\s*""/);
-      expect(content).toMatch(/\.textContent\s*=\s*['"]Runtime fetch failed\.['"]/);
+
+      // Should use safe node construction for the error message
+      expect(content).toContain('strong.textContent = "Runtime fetch failed."');
+      expect(content).toContain('document.createTextNode(String(e))');
+
+      // Should use textContent for clearing
+      expect(content).toContain('statusEl.textContent = ""');
     }
 
-    // Global check for all target="_blank" links
-    if (content.includes('target="_blank"')) {
-      expect(content).toContain('rel="noopener noreferrer"');
-    }
+    // Verify all static HTML links with target="_blank" have rel="noopener noreferrer"
+    // Use a regex that looks for the presence of target="_blank" and rel="noopener noreferrer" in the same tag
+    const linkTags = content.match(/<a[^>]+target=["']_blank["'][^>]*>/g) || [];
+    linkTags.forEach(tag => {
+      expect(tag, `Link tag missing rel="noopener noreferrer": ${tag}`).toContain('rel="noopener noreferrer"');
+    });
   };
 
   it('src/views/ops.ejs should use safe DOM APIs and have hardened links', () => {
     checkXSSPrevention(path.join(process.cwd(), 'src/views/ops.ejs'));
   });
 
-  it('src/views/observatory.ejs should use safe DOM APIs for error rendering', () => {
+  it('src/views/observatory.ejs should use safe DOM APIs for error rendering and have hardened links', () => {
     checkXSSPrevention(path.join(process.cwd(), 'src/views/observatory.ejs'));
   });
 
-  it('observatory_debug.html should use safe DOM APIs for error rendering', () => {
+  it('observatory_debug.html should use safe DOM APIs for error rendering and have hardened links', () => {
     checkXSSPrevention(path.join(process.cwd(), 'observatory_debug.html'));
   });
 });


### PR DESCRIPTION
This commit addresses Cross-Site Scripting (XSS) vulnerabilities where dynamic data (such as exception strings or API responses) was being directly concatenated into `innerHTML`.

Changes:
- In `src/views/observatory.ejs` and `observatory_debug.html`, replaced `innerHTML` with `textContent` and safe DOM manipulation for the runtime fetch status display.
- In `src/views/ops.ejs`, refactored `renderAudit` to use `document.createElement` and `textContent` instead of template literals with `innerHTML` when building routine cards.

These changes ensure that all dynamic content is treated as literal text, preventing malicious HTML or script injection.