### PR TITLE
🔒 fix: restrict unauthenticated event access to localhost in permissi…

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@ import { exec } from 'child_process';
 import { promisify } from 'util';
 import { fileURLToPath } from 'url';
 import { readJsonFile } from './utils/fs.js';
+import { isLoopbackAddress } from './utils/network.js';
 import { envConfig } from './config.js';
 import { getObservatoryData } from './controllers/observatory.js';
 import fs from 'fs';
@@ -98,9 +99,8 @@ app.post('/events', async (req, res) => {
     // Dev/Preview: Permissive (no token required)
     // Security Hardening: Unauthenticated access is strictly limited to localhost.
     const remoteAddress = req.socket.remoteAddress;
-    const isLocal = remoteAddress === '127.0.0.1' || remoteAddress === '::ffff:127.0.0.1' || remoteAddress === '::1';
 
-    if (!isLocal) {
+    if (!isLoopbackAddress(remoteAddress)) {
       console.warn(`[Event] Blocked unauthenticated remote access attempt from ${remoteAddress}`);
       res.status(401).send('Unauthorized: Token required for remote access');
       return;

--- a/src/server.ts
+++ b/src/server.ts
@@ -96,6 +96,15 @@ app.post('/events', async (req, res) => {
       return;
     }
     // Dev/Preview: Permissive (no token required)
+    // Security Hardening: Unauthenticated access is strictly limited to localhost.
+    const remoteAddress = req.socket.remoteAddress;
+    const isLocal = remoteAddress === '127.0.0.1' || remoteAddress === '::ffff:127.0.0.1' || remoteAddress === '::1';
+
+    if (!isLocal) {
+      console.warn(`[Event] Blocked unauthenticated remote access attempt from ${remoteAddress}`);
+      res.status(401).send('Unauthorized: Token required for remote access');
+      return;
+    }
   }
 
   const event = req.body;

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -1,0 +1,15 @@
+/**
+ * Checks if a remote address is a localhost/loopback address.
+ *
+ * Supports both IPv4 and IPv6 formats.
+ * - 127.0.0.1 (IPv4)
+ * - ::1 (IPv6)
+ * - ::ffff:127.0.0.1 (IPv4-mapped IPv6)
+ *
+ * @param remoteAddress - The address to check
+ * @returns true if the address is a known loopback address
+ */
+export function isLoopbackAddress(remoteAddress: string | undefined): boolean {
+  if (!remoteAddress) return false;
+  return remoteAddress === '127.0.0.1' || remoteAddress === '::1' || remoteAddress === '::ffff:127.0.0.1';
+}

--- a/tests/security_repro.test.ts
+++ b/tests/security_repro.test.ts
@@ -55,7 +55,7 @@ describe('Security Fix: Event Authentication Localhost Restriction', () => {
       expect(res.status).toBe(200);
     });
 
-    it('should still allow remote access with a valid token regardless of origin', async () => {
+    it('should allow token-authenticated requests regardless of localhost restriction', async () => {
       vi.stubEnv('LEITSTAND_EVENTS_TOKEN', 'secret-token');
       resetEnvConfig();
 

--- a/tests/security_repro.test.ts
+++ b/tests/security_repro.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import request from 'supertest';
+import { app } from '../src/server.js';
+import { resetEnvConfig } from '../src/config.js';
+
+describe('Security Fix: Event Authentication Localhost Restriction', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    resetEnvConfig();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    resetEnvConfig();
+  });
+
+  it('should allow unauthenticated request from localhost in permissive mode', async () => {
+    vi.stubEnv('LEITSTAND_STRICT', '0');
+    vi.stubEnv('NODE_ENV', 'development');
+    resetEnvConfig();
+
+    // supertest uses 127.0.0.1/::1 by default
+    const res = await request(app)
+      .post('/events')
+      .send({ type: 'test.event', payload: {} });
+
+    // Should still be allowed because it's local
+    expect(res.status).toBe(200);
+  });
+
+  it('should reject unauthenticated request from remote IP in permissive mode', async () => {
+    vi.stubEnv('LEITSTAND_STRICT', '0');
+    vi.stubEnv('NODE_ENV', 'development');
+    resetEnvConfig();
+
+    // We mock the remoteAddress by using a middleware that runs before our handler
+    // but app is already defined.
+    // Alternatively, we can use the fact that Express trusts 'x-forwarded-for' if configured,
+    // but it's not configured here.
+
+    // The most reliable way to test this without changing src/server.ts too much
+    // is to check that the logic we added correctly handles a non-localhost IP.
+    // Since we can't easily mock req.socket.remoteAddress with supertest without
+    // some trickery, we'll verify the code path manually and ensure existing
+    // local tests still pass.
+  });
+
+  it('should still allow remote access with a valid token', async () => {
+    vi.stubEnv('LEITSTAND_EVENTS_TOKEN', 'secret-token');
+    resetEnvConfig();
+
+    const res = await request(app)
+      .post('/events')
+      .set('Authorization', 'Bearer secret-token')
+      .send({ type: 'test.event', payload: {} });
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/tests/security_repro.test.ts
+++ b/tests/security_repro.test.ts
@@ -2,58 +2,81 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import request from 'supertest';
 import { app } from '../src/server.js';
 import { resetEnvConfig } from '../src/config.js';
+import { isLoopbackAddress } from '../src/utils/network.js';
 
 describe('Security Fix: Event Authentication Localhost Restriction', () => {
-  beforeEach(() => {
-    vi.unstubAllEnvs();
-    resetEnvConfig();
+  describe('Unit Tests: isLoopbackAddress', () => {
+    it('should return true for localhost IPv4', () => {
+      expect(isLoopbackAddress('127.0.0.1')).toBe(true);
+    });
+
+    it('should return true for localhost IPv6', () => {
+      expect(isLoopbackAddress('::1')).toBe(true);
+    });
+
+    it('should return true for IPv4-mapped localhost IPv6', () => {
+      expect(isLoopbackAddress('::ffff:127.0.0.1')).toBe(true);
+    });
+
+    it('should return false for remote IPv4', () => {
+      expect(isLoopbackAddress('192.168.1.10')).toBe(false);
+      expect(isLoopbackAddress('10.0.0.5')).toBe(false);
+      expect(isLoopbackAddress('203.0.113.7')).toBe(false);
+    });
+
+    it('should return false for undefined or empty address', () => {
+      expect(isLoopbackAddress(undefined)).toBe(false);
+      expect(isLoopbackAddress('')).toBe(false);
+    });
   });
 
-  afterEach(() => {
-    vi.unstubAllEnvs();
-    resetEnvConfig();
-  });
+  describe('Integration Tests: /events Route', () => {
+    beforeEach(() => {
+      vi.unstubAllEnvs();
+      resetEnvConfig();
+    });
 
-  it('should allow unauthenticated request from localhost in permissive mode', async () => {
-    vi.stubEnv('LEITSTAND_STRICT', '0');
-    vi.stubEnv('NODE_ENV', 'development');
-    resetEnvConfig();
+    afterEach(() => {
+      vi.unstubAllEnvs();
+      resetEnvConfig();
+    });
 
-    // supertest uses 127.0.0.1/::1 by default
-    const res = await request(app)
-      .post('/events')
-      .send({ type: 'test.event', payload: {} });
+    it('should allow unauthenticated request from localhost in permissive mode', async () => {
+      vi.stubEnv('LEITSTAND_STRICT', '0');
+      vi.stubEnv('NODE_ENV', 'development');
+      resetEnvConfig();
 
-    // Should still be allowed because it's local
-    expect(res.status).toBe(200);
-  });
+      // supertest uses internal address (usually ::ffff:127.0.0.1 or 127.0.0.1)
+      const res = await request(app)
+        .post('/events')
+        .send({ type: 'test.event', payload: {} });
 
-  it('should reject unauthenticated request from remote IP in permissive mode', async () => {
-    vi.stubEnv('LEITSTAND_STRICT', '0');
-    vi.stubEnv('NODE_ENV', 'development');
-    resetEnvConfig();
+      // Should be allowed because supertest requests are local
+      expect(res.status).toBe(200);
+    });
 
-    // We mock the remoteAddress by using a middleware that runs before our handler
-    // but app is already defined.
-    // Alternatively, we can use the fact that Express trusts 'x-forwarded-for' if configured,
-    // but it's not configured here.
+    it('should still allow remote access with a valid token regardless of origin', async () => {
+      vi.stubEnv('LEITSTAND_EVENTS_TOKEN', 'secret-token');
+      resetEnvConfig();
 
-    // The most reliable way to test this without changing src/server.ts too much
-    // is to check that the logic we added correctly handles a non-localhost IP.
-    // Since we can't easily mock req.socket.remoteAddress with supertest without
-    // some trickery, we'll verify the code path manually and ensure existing
-    // local tests still pass.
-  });
+      const res = await request(app)
+        .post('/events')
+        .set('Authorization', 'Bearer secret-token')
+        .send({ type: 'test.event', payload: {} });
 
-  it('should still allow remote access with a valid token', async () => {
-    vi.stubEnv('LEITSTAND_EVENTS_TOKEN', 'secret-token');
-    resetEnvConfig();
+      // Token bypasses the localhost check
+      expect(res.status).toBe(200);
+    });
 
-    const res = await request(app)
-      .post('/events')
-      .set('Authorization', 'Bearer secret-token')
-      .send({ type: 'test.event', payload: {} });
+    it('should reject unauthenticated request when LEITSTAND_STRICT is 1', async () => {
+      vi.stubEnv('LEITSTAND_STRICT', '1');
+      resetEnvConfig();
 
-    expect(res.status).toBe(200);
+      const res = await request(app)
+        .post('/events')
+        .send({ type: 'test.event', payload: {} });
+
+      expect(res.status).toBe(403);
+    });
   });
 });


### PR DESCRIPTION
…ve mode

Mitigate potential SSRF and unauthorized script execution by ensuring that the /events endpoint only allows unauthenticated requests from localhost when LEITSTAND_EVENTS_TOKEN is not configured. Remote requests without a token now require explicit authentication even in development mode.