### PR TITLE
umsetzung

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,8 @@ This repository provides the dashboard and control-room for the heimgewebe organ
 
 ## Read This First
 - **Primary read path**: Start with `README.md` and this `AGENTS.md` file. Then review `docs/index.md` for normative invariants and runbooks.
-- Understand that this is a UI / Observer. It does not generate raw insights or execute motorik actions (except for self-healing).
+- Understand that this is a UI / Observer: it does not generate raw insights and does not execute motorik actions.
+- If actions are required, Leitstand may **request** them explicitly via the agent-control-surface (acs), but authorization and execution remain outside Leitstand.
 
 ## Canonical Sources
 - `repo.meta.yaml` (Repo identity and structure truth)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Er hat genau drei Kernfunktionen:
 Leitstand ist ausdrücklich **nicht**:
 - ein Orchestrator
 - eine Steuerinstanz
-- eine schreibende Systemkomponente
+- eine extern mutierende bzw. gegenüber anderen Systemen schreibende Systemkomponente
 
 Alle Änderungen im Repo müssen dieser Invariante entsprechen.
 Lokale Artefaktschreibvorgänge (Caches, Digests, Build-Outputs) sind zulässig, solange sie der reinen Darstellungs- und Observer-Pipeline dienen.
@@ -173,7 +173,7 @@ Leitstand acts strictly as a viewer; authentication and authorization enforcemen
 
 ## Data Flow & Contracts
 
-Leitstand is the **visual control center** of the Heimgewebe organism. To provide accurate and stable views, Leitstand relies on clearly defined data contracts and a strict separation of concerns.
+Leitstand is the **visual monitoring center** of the Heimgewebe organism. To provide accurate and stable views, Leitstand relies on clearly defined data contracts and a strict separation of concerns.
 
 ```mermaid
 flowchart TD

--- a/README.md
+++ b/README.md
@@ -18,11 +18,10 @@ Er hat genau drei Kernfunktionen:
 Leitstand ist ausdrücklich **nicht**:
 - ein Orchestrator
 - eine Steuerinstanz
-- eine schreibende Steuerkomponente gegenüber anderen Systemen
-
-Lokale Artefaktschreibvorgänge (Digests, Rendering-Cache) dienen ausschließlich Darstellung und Verdichtung und gelten nicht als systemsteuernde Schreibvorgänge.
+- eine schreibende Systemkomponente
 
 Alle Änderungen im Repo müssen dieser Invariante entsprechen.
+Lokale Artefaktschreibvorgänge (Caches, Digests, Build-Outputs) sind zulässig, solange sie der reinen Darstellungs- und Observer-Pipeline dienen.
 
 ### The Heimgewebe Organism
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,8 @@ Please report privately via:
 - or direct contact with the maintainers
 
 ## Non-Goals
-- No authentication logic
+- No user/session authentication logic (no accounts, no login flows)
+- A small token-based ingestion guard exists for POST /events to prevent unauthorized triggers.
 - No secret storage
 - No dynamic schema fetching beyond allowlisted references
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ Please report privately via:
 
 ## Non-Goals
 - No user/session authentication logic (no accounts, no login flows)
-- A small token-based ingestion guard exists for POST /events to prevent unauthorized triggers.
+- POST `/events` has an optional token guard: if `LEITSTAND_EVENTS_TOKEN` is set, the token is required; otherwise the route is disabled in strict mode or only accepts unauthenticated requests from localhost (remote requests are blocked).
 - No secret storage
 - No dynamic schema fetching beyond allowlisted references
 

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -17,9 +17,10 @@ Es ist die verbindliche Sicht auf den Organismus-Fluss:
 
 Leitstand ist damit das **Beobachtungs- und Visualisierungszentrum** des Heimgewebes.
 
-Wichtig (Invariante):
-- Leitstand **orchestriert nicht** und **mutiert keine externen Systeme**.
-- Leitstand konsumiert Artefakte/Events und erzeugt lediglich **lokale Darstellungs-/Digest-Artefakte**.
+Wichtig (Invariante, bezogen auf den Kern-Datenpfad `aussensensor → chronik → semantAH → leitstand → hausKI → chronik`):
+- Leitstand **orchestriert nicht** und **mutiert keine externen Systeme** im Normalbetrieb entlang dieses Datenpfads.
+- Leitstand konsumiert Artefakte/Events und erzeugt entlang dieses Pfads lediglich **lokale Darstellungs-/Digest-Artefakte**.
+- Ausnahme (bewusstes, optionales Fallback): Wenn `LEITSTAND_OPS_ALLOW_JOB_FALLBACK=true` gesetzt ist, kann der Ops Viewer POST-Requests an acs (`/api/audit/git`) auslösen; dies ist ein explizit opt-in konfigurierter externer Seiteneffekt außerhalb des Kern-Datenpfads.
 
 ---
 

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -15,7 +15,11 @@ Es ist die verbindliche Sicht auf den Organismus-Fluss:
 
     aussensensor → chronik → semantAH → leitstand → hausKI → chronik
 
-Leitstand ist damit das „Regelzentrum“ des Heimgewebes.
+Leitstand ist damit das **Beobachtungs- und Visualisierungszentrum** des Heimgewebes.
+
+Wichtig (Invariante):
+- Leitstand **orchestriert nicht** und **mutiert keine externen Systeme**.
+- Leitstand konsumiert Artefakte/Events und erzeugt lediglich **lokale Darstellungs-/Digest-Artefakte**.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ summary: >
 
 # Leitstand Documentation Router
 
-Leitstand is the visual monitoring center of the Heimgewebe organism. It strictly adheres to the Observer Invariant: It does not orchestrate or mutate external systems (see [Non-Goals](architecture/non-goals.md) and [Feature Classification](architecture/feature-classification.md)). It is organized into strict normative invariants (contracts) and operative runbooks. This router connects the "What is true?" (Contracts) with the "How does it stay true?" (Checks).
+Leitstand is the visual monitoring center of the Heimgewebe organism. In its default, strict viewer-only mode it adheres to the Observer Invariant: it does not orchestrate or mutate external systems (see [Non-Goals](architecture/non-goals.md) and [Feature Classification](architecture/feature-classification.md)). Some deployments may optionally enable an Ops Viewer fallback that can POST to `agent-control-surface` (acs) to trigger audit jobs; this is a controlled, opt-in exception explicitly classified outside the core Observer Invariant. Leitstand is organized into strict normative invariants (contracts) and operative runbooks. This router connects the "What is true?" (Contracts) with the "How does it stay true?" (Checks).
 
 ## Canonicality & Discovery
 * *Note: Generated files are currently structural placeholders. A full semantic graph generator is not yet active.*

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ summary: >
 
 # Leitstand Documentation Router
 
-Leitstand is the visual control center of the Heimgewebe organism. It strictly adheres to the Observer Invariant: It does not orchestrate or mutate external systems (see [Non-Goals](architecture/non-goals.md) and [Feature Classification](architecture/feature-classification.md)). It is organized into strict normative invariants (contracts) and operative runbooks. This router connects the "What is true?" (Contracts) with the "How does it stay true?" (Checks).
+Leitstand is the visual monitoring center of the Heimgewebe organism. It strictly adheres to the Observer Invariant: It does not orchestrate or mutate external systems (see [Non-Goals](architecture/non-goals.md) and [Feature Classification](architecture/feature-classification.md)). It is organized into strict normative invariants (contracts) and operative runbooks. This router connects the "What is true?" (Contracts) with the "How does it stay true?" (Checks).
 
 ## Canonicality & Discovery
 * *Note: Generated files are currently structural placeholders. A full semantic graph generator is not yet active.*

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ summary: >
 
 # Leitstand Documentation Router
 
-Leitstand is the visual control center of the Heimgewebe organism. It is organized into strict normative invariants (contracts) and operative runbooks. This router connects the "What is true?" (Contracts) with the "How does it stay true?" (Checks).
+Leitstand is the visual control center of the Heimgewebe organism. It strictly adheres to the Observer Invariant: It does not orchestrate or mutate external systems (see [Non-Goals](architecture/non-goals.md) and [Feature Classification](architecture/feature-classification.md)). It is organized into strict normative invariants (contracts) and operative runbooks. This router connects the "What is true?" (Contracts) with the "How does it stay true?" (Checks).
 
 ## Canonicality & Discovery
 * *Note: Generated files are currently structural placeholders. A full semantic graph generator is not yet active.*


### PR DESCRIPTION
Dokumentarischer Schnitt zur Bereinigung semantischer Driftstellen in den zentralen Architekturtexten. Leitstand wird konsistent als Observer/Visualizer/Verdichter positioniert; Steuerungssprache und Selbstwidersprüche werden entfernt.

## Changes Made

- **README.md**: Negativabgrenzung präzisiert — „keine schreibende Systemkomponente" → „keine extern mutierende bzw. gegenüber anderen Systemen schreibende Systemkomponente", um den expliziten Erlaubnissatz für lokale Artefakt-Writes (Caches, Digests, Build-Outputs) widerspruchsfrei zu halten.
- **README.md / Data Flow section**: „visual control center" → „visual monitoring center" — Steuerungskonnotation entfernt.
- **docs/index.md**: „visual control center" → „visual monitoring center"; Observer-Invariante auf den Default-/Strict-Viewer-Modus gescoped; optionaler ACS-Job-Trigger-Fallback als explizit opt-in, kontrollierte Ausnahme außerhalb des Observer-Kerns dokumentiert.
- **docs/data-flow.md**: Invariantenblock auf den kanonischen Kern-Datenpfad (`aussensensor → chronik → semantAH → leitstand → hausKI → chronik`) gescoped; optionaler ACS-Fallback (`LEITSTAND_OPS_ALLOW_JOB_FALLBACK=true`) als explizit separierter, opt-in externer Seiteneffekt außerhalb dieses Pfads dokumentiert.
- **SECURITY.md**: `/events`-Guard-Beschreibung präzisiert — Token erforderlich wenn `LEITSTAND_EVENTS_TOKEN` gesetzt; sonst im Strict Mode deaktiviert bzw. nur localhost-Requests zulässig (Remote blockiert). Überschätzung der Schutzwirkung vermieden.
- **AGENTS.md**: „may request" statt impliziter Aktor-Rolle für die ACS-Interaktion.

<!-- START COPILOT CODING AGENT TIPS -->
---

📍 Connect Copilot coding agent with [Jira](https://gh.io/cca-jira-docs), [Azure Boards](https://gh.io/cca-azure-boards-docs) or [Linear](https://gh.io/cca-linear-docs) to delegate work to Copilot in one click without leaving your project management tool.