### PR TITLE
Add Observer Invariant Guard CI script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,7 @@ jobs:
     - name: Drift Gates
       if: success()
       run: bash scripts/ci/check-drift-gates.sh
+
+    - name: Observer Invariant Guard
+      if: success()
+      run: bash scripts/ci/observer-invariant-guard.sh

--- a/scripts/ci/observer-invariant-guard.sh
+++ b/scripts/ci/observer-invariant-guard.sh
@@ -1,27 +1,29 @@
 #!/usr/bin/env bash
-set -eo pipefail
+set -euo pipefail
+
+# Observer Invariant Guard (Heuristic)
+#
+# NOTICE: This is a heuristical guard. It protects the `src/` directory against 
+# obvious new outgoing mutating requests. It is not a complete semantic proof 
+# (e.g., AST parsing), but blocks common patterns like `method: 'POST'` or `.post(`.
 
 echo "Running Observer Invariant Guard..."
 
-# This script enforces that Leitstand acts as a read-only observer.
-# It searches for outgoing POST, PUT, DELETE, PATCH requests in the `src/` directory.
-
-# Find matches for mutating HTTP methods
-MATCHES=$(grep -rnI -E "method:[[:space:]]*['\"](POST|PUT|DELETE|PATCH)['\"]" src/ || true)
+# Find matches for mutating HTTP methods, excluding incoming Express routes (app.post, router.post)
+MATCHES=$(grep -rnI -E "(method:[[:space:]]*['\"](POST|PUT|DELETE|PATCH)['\"]|\.(post|put|delete|patch)\()" src/ | grep -vE "(app|router)\.(post|put|delete|patch)\(" || true)
 
 if [ -z "$MATCHES" ]; then
     echo "✅ No mutating HTTP methods found. Observer invariant is intact."
     exit 0
 fi
 
-# Filter out the known exceptions
+# Filter out the known exceptions explicitly marked in code
 VIOLATIONS=$(echo "$MATCHES" | grep -v "observer-invariant-guard: allow-known-exception" || true)
 
 if [ -n "$VIOLATIONS" ]; then
-    echo "❌ ERROR: Found mutating HTTP methods not marked as known exceptions!"
-    echo "Leitstand is an Observer. It should not mutate external state."
+    echo "❌ Observer Invariant Guard failed: unexpected outbound mutating request pattern detected in src/"
     echo ""
-    echo "Violations found:"
+    echo "File/Line violations found:"
     echo "$VIOLATIONS"
     echo ""
     echo "If this is a justified exception, mark the line with: // observer-invariant-guard: allow-known-exception"

--- a/scripts/ci/observer-invariant-guard.sh
+++ b/scripts/ci/observer-invariant-guard.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 
 echo "Running Observer Invariant Guard..."
 
-# Find matches for mutating HTTP methods, excluding incoming Express routes (app.post, router.post)
+# Find matches for mutating HTTP methods, excluding common incoming Express route definitions (app.post, router.post)
 MATCHES=$(grep -rnI -E "(method:[[:space:]]*['\"](POST|PUT|DELETE|PATCH)['\"]|\.(post|put|delete|patch)\()" src/ | grep -vE "(app|router)\.(post|put|delete|patch)\(" || true)
 
 if [ -z "$MATCHES" ]; then

--- a/scripts/ci/observer-invariant-guard.sh
+++ b/scripts/ci/observer-invariant-guard.sh
@@ -13,6 +13,7 @@ cd "$REPO_ROOT"
 echo "Running Observer Invariant Guard..."
 
 # Find matches for mutating HTTP methods, excluding common incoming Express route definitions (app.post, router.post)
+# grep exits 0=matches found, 1=no matches, >1=real error; only >1 indicates a scan failure.
 set +e
 MATCHES=$(grep -rnI -E "(method:[[:space:]]*['\"](POST|PUT|DELETE|PATCH)['\"]|\.(post|put|delete|patch)[[:space:]]*\()" src/ | grep -vE "(app|router)\.(post|put|delete|patch)[[:space:]]*\(")
 grep_status=$?

--- a/scripts/ci/observer-invariant-guard.sh
+++ b/scripts/ci/observer-invariant-guard.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+echo "Running Observer Invariant Guard..."
+
+# This script enforces that Leitstand acts as a read-only observer.
+# It searches for outgoing POST, PUT, DELETE, PATCH requests in the `src/` directory.
+
+# Find matches for mutating HTTP methods
+MATCHES=$(grep -rnI -E "method:[[:space:]]*['\"](POST|PUT|DELETE|PATCH)['\"]" src/ || true)
+
+if [ -z "$MATCHES" ]; then
+    echo "✅ No mutating HTTP methods found. Observer invariant is intact."
+    exit 0
+fi
+
+# Filter out the known exceptions
+VIOLATIONS=$(echo "$MATCHES" | grep -v "observer-invariant-guard: allow-known-exception" || true)
+
+if [ -n "$VIOLATIONS" ]; then
+    echo "❌ ERROR: Found mutating HTTP methods not marked as known exceptions!"
+    echo "Leitstand is an Observer. It should not mutate external state."
+    echo ""
+    echo "Violations found:"
+    echo "$VIOLATIONS"
+    echo ""
+    echo "If this is a justified exception, mark the line with: // observer-invariant-guard: allow-known-exception"
+    exit 1
+fi
+
+echo "✅ Observer invariant is intact. (All found methods are allowed exceptions)"
+exit 0

--- a/scripts/ci/observer-invariant-guard.sh
+++ b/scripts/ci/observer-invariant-guard.sh
@@ -1,16 +1,27 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+
 # Observer Invariant Guard (Heuristic)
 #
-# NOTICE: This is a heuristical guard. It protects the `src/` directory against 
-# obvious new outgoing mutating requests. It is not a complete semantic proof 
+# NOTICE: This is a heuristic guard. It protects the `src/` directory against
+# obvious new outgoing mutating requests. It is not a complete semantic proof
 # (e.g., AST parsing), but blocks common patterns like `method: 'POST'` or `.post(`.
 
 echo "Running Observer Invariant Guard..."
 
 # Find matches for mutating HTTP methods, excluding common incoming Express route definitions (app.post, router.post)
-MATCHES=$(grep -rnI -E "(method:[[:space:]]*['\"](POST|PUT|DELETE|PATCH)['\"]|\.(post|put|delete|patch)\()" src/ | grep -vE "(app|router)\.(post|put|delete|patch)\(" || true)
+set +e
+MATCHES=$(grep -rnI -E "(method:[[:space:]]*['\"](POST|PUT|DELETE|PATCH)['\"]|\.(post|put|delete|patch)[[:space:]]*\()" src/ | grep -vE "(app|router)\.(post|put|delete|patch)[[:space:]]*\(")
+grep_status=$?
+set -e
+
+if [ "$grep_status" -gt 1 ]; then
+    echo "❌ Observer Invariant Guard failed: error while scanning src/ for mutating HTTP methods." >&2
+    exit "$grep_status"
+fi
 
 if [ -z "$MATCHES" ]; then
     echo "✅ No mutating HTTP methods found. Observer invariant is intact."
@@ -18,7 +29,15 @@ if [ -z "$MATCHES" ]; then
 fi
 
 # Filter out the known exceptions explicitly marked in code
-VIOLATIONS=$(echo "$MATCHES" | grep -v "observer-invariant-guard: allow-known-exception" || true)
+set +e
+VIOLATIONS=$(echo "$MATCHES" | grep -v "observer-invariant-guard: allow-known-exception")
+violations_status=$?
+set -e
+
+if [ "$violations_status" -gt 1 ]; then
+    echo "❌ Observer Invariant Guard failed: error while filtering known exceptions." >&2
+    exit "$violations_status"
+fi
 
 if [ -n "$VIOLATIONS" ]; then
     echo "❌ Observer Invariant Guard failed: unexpected outbound mutating request pattern detected in src/"

--- a/src/dummy-test-violation.ts
+++ b/src/dummy-test-violation.ts
@@ -1,0 +1,1 @@
+export const dummy = true;

--- a/src/dummy-test-violation.ts
+++ b/src/dummy-test-violation.ts
@@ -1,1 +1,0 @@
-export const dummy = true;

--- a/src/views/ops.ejs
+++ b/src/views/ops.ejs
@@ -195,7 +195,7 @@
                   // Sync endpoint not available, fallback to Job Flow (POST)
                   console.log(`Sync endpoint missing (${res.status}), falling back to Job Flow (POST)`);
                   res = await fetch(`${ACS_URL}/api/audit/git?repo=${encodeURIComponent(repo)}`, {
-                      method: 'POST',
+                      method: 'POST', // observer-invariant-guard: allow-known-exception
                       headers: getAuthHeaders()
                   });
               } else {


### PR DESCRIPTION
Adds a new CI "Observer Invariant Guard" to heuristically prevent new outbound mutating HTTP request patterns from being introduced under `src/`, while allowing explicitly annotated exceptions.

## Changes Made

- **`scripts/ci/observer-invariant-guard.sh`**: New heuristic CI guard that scans `src/` for common mutating-request patterns (`method: 'POST'`, `.post(`, etc.) and fails CI on unapproved matches. The guard:
  - Resolves `REPO_ROOT` via `git rev-parse --show-toplevel` before scanning, consistent with other CI guards in the repo
  - Uses widened regex (`[[:space:]]*\(`) to catch call styles like `.post (` with optional whitespace
  - Fails closed on real scan errors (grep exit code > 1) instead of masking them with `|| true`
  - Allows lines explicitly annotated with `// observer-invariant-guard: allow-known-exception`
- **`src/views/ops.ejs`**: Annotates the known `fetch(..., { method: 'POST' })` fallback with the allowlist marker to keep the guard green.
- **`.github/workflows/ci.yml`**: Wires the new guard into CI after existing guard steps.

<!-- START COPILOT CODING AGENT TIPS -->
---

✨ Let Copilot coding agent [set things up for you](https://github.com/heimgewebe/leitstand/issues/new?title=✨+Set+up+Copilot+instructions&body=Configure%20instructions%20for%20this%20repository%20as%20documented%20in%20%5BBest%20practices%20for%20Copilot%20coding%20agent%20in%20your%20repository%5D%28https://gh.io/copilot-coding-agent-tips%29%2E%0A%0A%3COnboard%20this%20repo%3E&assignees=copilot) — coding agent works faster and does higher quality work when set up for your repo.
