### PR TITLE
Visualisierungs-Blaupause: Phase 1 + Phase 3 Umsetzung

### DIFF
--- a/src/anatomy.ts
+++ b/src/anatomy.ts
@@ -1,0 +1,110 @@
+import { readJsonFile } from './utils/fs.js';
+
+/**
+ * Node in the Heimgewebe anatomy graph – represents a repository/organ
+ */
+export interface AnatomyNode {
+  /** Unique identifier (repo slug) */
+  id: string;
+  /** Human-readable label */
+  label: string;
+  /** Functional role description */
+  role: string;
+  /** Functional axis (achse) this organ belongs to */
+  achse: string;
+  /** Detailed description */
+  description: string;
+}
+
+/**
+ * Edge in the anatomy graph – represents a contract-based relationship
+ */
+export interface AnatomyEdge {
+  /** Source node ID */
+  source: string;
+  /** Target node ID */
+  target: string;
+  /** Contract name governing this relationship */
+  contract: string;
+  /** Human-readable label */
+  label: string;
+  /** Edge type: data flow, control flow, or governance */
+  type: 'data' | 'control' | 'governance';
+}
+
+/**
+ * Axis definition – functional grouping of organs
+ */
+export interface Achse {
+  /** Display label */
+  label: string;
+  /** Color code for visualization */
+  color: string;
+  /** Description of the functional axis */
+  description: string;
+}
+
+/**
+ * Complete anatomy snapshot – structural model of the Heimgewebe organism
+ */
+export interface AnatomySnapshot {
+  /** Schema version identifier */
+  schema: string;
+  /** Timestamp of snapshot generation */
+  generated_at: string;
+  /** Source identifier (fixture, artifact, etc.) */
+  source: string;
+  /** All organs/repos as graph nodes */
+  nodes: AnatomyNode[];
+  /** All contract-based relationships as edges */
+  edges: AnatomyEdge[];
+  /** Functional axis definitions with colors */
+  achsen: Record<string, Achse>;
+}
+
+const ANATOMY_SCHEMA_V1 = 'anatomy.snapshot.v1';
+
+/**
+ * Loads an anatomy snapshot from a JSON file.
+ *
+ * Performs basic structural validation without enforcing the full schema,
+ * to remain resilient against upstream changes while catching corrupt data.
+ *
+ * @param path - Path to the anatomy JSON file
+ * @returns Parsed anatomy snapshot
+ * @throws Error if file cannot be read or has invalid structure
+ */
+export async function loadAnatomySnapshot(path: string): Promise<AnatomySnapshot> {
+  const raw = await readJsonFile<AnatomySnapshot>(path);
+
+  // Structural validation
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('Invalid anatomy snapshot: expected a JSON object');
+  }
+
+  if (!Array.isArray(raw.nodes) || raw.nodes.length === 0) {
+    throw new Error('Invalid anatomy snapshot: nodes array is missing or empty');
+  }
+
+  if (!Array.isArray(raw.edges)) {
+    throw new Error('Invalid anatomy snapshot: edges array is missing');
+  }
+
+  if (!raw.achsen || typeof raw.achsen !== 'object') {
+    throw new Error('Invalid anatomy snapshot: achsen map is missing');
+  }
+
+  // Schema version check (warn, don't fail – forward compatibility)
+  if (raw.schema && raw.schema !== ANATOMY_SCHEMA_V1) {
+    console.warn(`[Anatomy] Schema version mismatch: expected ${ANATOMY_SCHEMA_V1}, got ${raw.schema}`);
+  }
+
+  return {
+    schema: raw.schema || ANATOMY_SCHEMA_V1,
+    generated_at: raw.generated_at || new Date().toISOString(),
+    source: raw.source || 'unknown',
+    nodes: raw.nodes,
+    edges: raw.edges,
+    achsen: raw.achsen,
+  };
+}

--- a/src/anatomy.ts
+++ b/src/anatomy.ts
@@ -62,7 +62,49 @@ export interface AnatomySnapshot {
   achsen: Record<string, Achse>;
 }
 
-const ANATOMY_SCHEMA_V1 = 'anatomy.snapshot.v1';
+export const ANATOMY_SCHEMA_V1 = 'anatomy.snapshot.v1';
+
+export interface AnatomyValidationResult {
+  valid: boolean;
+  schemaValid: boolean;
+  error?: string;
+}
+
+/**
+ * Validates the structural integrity of an anatomy snapshot.
+ *
+ * Checks for required fields (nodes, edges, achsen) and schema version.
+ * Does not throw – returns a result object for the caller to act on.
+ *
+ * @param data - Parsed JSON data to validate
+ * @returns Validation result with structural and schema validity
+ */
+export function validateAnatomySnapshot(data: unknown): AnatomyValidationResult {
+  if (!data || typeof data !== 'object') {
+    return { valid: false, schemaValid: false, error: 'expected a JSON object' };
+  }
+
+  const snapshot = data as Record<string, unknown>;
+
+  if (!Array.isArray(snapshot.nodes) || snapshot.nodes.length === 0) {
+    return { valid: false, schemaValid: false, error: 'nodes array is missing or empty' };
+  }
+
+  if (!Array.isArray(snapshot.edges)) {
+    return { valid: false, schemaValid: false, error: 'edges array is missing' };
+  }
+
+  if (!snapshot.achsen || typeof snapshot.achsen !== 'object') {
+    return { valid: false, schemaValid: false, error: 'achsen map is missing' };
+  }
+
+  const schemaValid = snapshot.schema === ANATOMY_SCHEMA_V1;
+  if (!schemaValid && snapshot.schema) {
+    console.warn(`[Anatomy] Schema mismatch: expected ${ANATOMY_SCHEMA_V1}, got ${snapshot.schema}`);
+  }
+
+  return { valid: true, schemaValid };
+}
 
 /**
  * Loads an anatomy snapshot from a JSON file.
@@ -77,26 +119,9 @@ const ANATOMY_SCHEMA_V1 = 'anatomy.snapshot.v1';
 export async function loadAnatomySnapshot(path: string): Promise<AnatomySnapshot> {
   const raw = await readJsonFile<AnatomySnapshot>(path);
 
-  // Structural validation
-  if (!raw || typeof raw !== 'object') {
-    throw new Error('Invalid anatomy snapshot: expected a JSON object');
-  }
-
-  if (!Array.isArray(raw.nodes) || raw.nodes.length === 0) {
-    throw new Error('Invalid anatomy snapshot: nodes array is missing or empty');
-  }
-
-  if (!Array.isArray(raw.edges)) {
-    throw new Error('Invalid anatomy snapshot: edges array is missing');
-  }
-
-  if (!raw.achsen || typeof raw.achsen !== 'object') {
-    throw new Error('Invalid anatomy snapshot: achsen map is missing');
-  }
-
-  // Schema version check (warn, don't fail – forward compatibility)
-  if (raw.schema && raw.schema !== ANATOMY_SCHEMA_V1) {
-    console.warn(`[Anatomy] Schema version mismatch: expected ${ANATOMY_SCHEMA_V1}, got ${raw.schema}`);
+  const validation = validateAnatomySnapshot(raw);
+  if (!validation.valid) {
+    throw new Error(`Invalid anatomy snapshot: ${validation.error}`);
   }
 
   return {

--- a/src/anatomy.ts
+++ b/src/anatomy.ts
@@ -98,8 +98,10 @@ export function validateAnatomySnapshot(data: unknown): AnatomyValidationResult 
     return { valid: false, schemaValid: false, error: 'achsen map is missing' };
   }
 
-  const schemaValid = snapshot.schema === ANATOMY_SCHEMA_V1;
-  if (!schemaValid && snapshot.schema) {
+  // Treat a missing schema as v1 — consistent with loadAnatomySnapshot() defaulting to ANATOMY_SCHEMA_V1.
+  // The warning only fires for an explicit, non-matching schema value (never for undefined).
+  const schemaValid = snapshot.schema === undefined || snapshot.schema === ANATOMY_SCHEMA_V1;
+  if (!schemaValid) {
     console.warn(`[Anatomy] Schema mismatch: expected ${ANATOMY_SCHEMA_V1}, got ${snapshot.schema}`);
   }
 

--- a/src/controllers/anatomy.ts
+++ b/src/controllers/anatomy.ts
@@ -2,6 +2,7 @@ import { join } from 'path';
 import { loadWithFallback } from '../utils/loader.js';
 import { envConfig } from '../config.js';
 import type { AnatomySnapshot } from '../anatomy.js';
+import { validateAnatomySnapshot } from '../anatomy.js';
 
 export interface AnatomyViewData {
   anatomy: AnatomySnapshot | null;
@@ -16,8 +17,10 @@ export interface AnatomyViewData {
 /**
  * Controller for loading Anatomy view data.
  *
- * Follows the same loadWithFallback pattern as the Observatory controller:
- * artifact → fixture → null (in strict mode, fixture fallback is disabled).
+ * Uses loadWithFallback for artifact→fixture resolution, then pipes the
+ * result through validateAnatomySnapshot for structural integrity checks
+ * (nodes, edges, achsen present). This ensures the dedicated loader logic
+ * from anatomy.ts is actually in the data path.
  */
 export async function getAnatomyData(): Promise<AnatomyViewData> {
   const { isStrict, isStrictFail, paths } = envConfig;
@@ -31,23 +34,43 @@ export async function getAnatomyData(): Promise<AnatomyViewData> {
     name: 'Anatomy',
   });
 
-  const anatomy = loaded.data;
-  let schemaValid = false;
+  const raw = loaded.data;
 
-  if (anatomy) {
-    schemaValid = anatomy.schema === 'anatomy.snapshot.v1';
-    if (!schemaValid) {
-      console.warn(`[Anatomy] Schema mismatch: expected anatomy.snapshot.v1, got ${anatomy.schema}`);
+  // Structural validation via the dedicated anatomy validator
+  if (raw) {
+    const validation = validateAnatomySnapshot(raw);
+
+    if (!validation.valid) {
+      console.warn(`[Anatomy] Structural validation failed: ${validation.error}`);
+      return {
+        anatomy: null,
+        view_meta: {
+          source_kind: loaded.source,
+          missing_reason: `invalid_structure: ${validation.error}`,
+          is_strict: isStrict,
+          schema_valid: false,
+        },
+      };
     }
+
+    return {
+      anatomy: raw,
+      view_meta: {
+        source_kind: loaded.source,
+        missing_reason: loaded.reason,
+        is_strict: isStrict,
+        schema_valid: validation.schemaValid,
+      },
+    };
   }
 
   return {
-    anatomy,
+    anatomy: null,
     view_meta: {
       source_kind: loaded.source,
       missing_reason: loaded.reason,
       is_strict: isStrict,
-      schema_valid: schemaValid,
+      schema_valid: false,
     },
   };
 }

--- a/src/controllers/anatomy.ts
+++ b/src/controllers/anatomy.ts
@@ -1,0 +1,53 @@
+import { join } from 'path';
+import { loadWithFallback } from '../utils/loader.js';
+import { envConfig } from '../config.js';
+import type { AnatomySnapshot } from '../anatomy.js';
+
+export interface AnatomyViewData {
+  anatomy: AnatomySnapshot | null;
+  view_meta: {
+    source_kind: string;
+    missing_reason: string;
+    is_strict: boolean;
+    schema_valid: boolean;
+  };
+}
+
+/**
+ * Controller for loading Anatomy view data.
+ *
+ * Follows the same loadWithFallback pattern as the Observatory controller:
+ * artifact → fixture → null (in strict mode, fixture fallback is disabled).
+ */
+export async function getAnatomyData(): Promise<AnatomyViewData> {
+  const { isStrict, isStrictFail, paths } = envConfig;
+
+  const artifactPath = join(paths.artifacts, 'anatomy.snapshot.json');
+  const fixturePath = join(paths.fixtures, 'anatomy.snapshot.json');
+
+  const loaded = await loadWithFallback<AnatomySnapshot>(artifactPath, fixturePath, {
+    strict: isStrict,
+    strictFail: isStrictFail,
+    name: 'Anatomy',
+  });
+
+  const anatomy = loaded.data;
+  let schemaValid = false;
+
+  if (anatomy) {
+    schemaValid = anatomy.schema === 'anatomy.snapshot.v1';
+    if (!schemaValid) {
+      console.warn(`[Anatomy] Schema mismatch: expected anatomy.snapshot.v1, got ${anatomy.schema}`);
+    }
+  }
+
+  return {
+    anatomy,
+    view_meta: {
+      source_kind: loaded.source,
+      missing_reason: loaded.reason,
+      is_strict: isStrict,
+      schema_valid: schemaValid,
+    },
+  };
+}

--- a/src/controllers/anatomy.ts
+++ b/src/controllers/anatomy.ts
@@ -7,7 +7,7 @@ import { validateAnatomySnapshot } from '../anatomy.js';
 export interface AnatomyViewData {
   anatomy: AnatomySnapshot | null;
   view_meta: {
-    source_kind: string;
+    source_kind: 'artifact' | 'fixture' | 'missing';
     missing_reason: string;
     is_strict: boolean;
     schema_valid: boolean;
@@ -18,9 +18,12 @@ export interface AnatomyViewData {
  * Controller for loading Anatomy view data.
  *
  * Uses loadWithFallback for artifact→fixture resolution, then pipes the
- * result through validateAnatomySnapshot for structural integrity checks
- * (nodes, edges, achsen present). This ensures the dedicated loader logic
- * from anatomy.ts is actually in the data path.
+ * result through validateAnatomySnapshot (from anatomy.ts) for structural
+ * integrity checks (nodes, edges, achsen present).
+ *
+ * Note: loadAnatomySnapshot() in anatomy.ts provides a throwing single-file
+ * loader; the controller intentionally uses loadWithFallback instead so the
+ * artifact→fixture fallback logic is available here.
  */
 export async function getAnatomyData(): Promise<AnatomyViewData> {
   const { isStrict, isStrictFail, paths } = envConfig;

--- a/src/controllers/timeline.ts
+++ b/src/controllers/timeline.ts
@@ -93,12 +93,24 @@ export async function getTimelineData(
     }
 
     // Last fallback: fixture JSON array
+    // Apply the same time-window filtering as the JSONL path for consistent semantics.
     try {
       const fixturePath = join(envConfig.paths.fixtures, 'events.json');
       const raw = await readFile(fixturePath, 'utf-8');
-      const events = JSON.parse(raw) as TimelineEvent[];
+      const allEvents = JSON.parse(raw) as TimelineEvent[];
+
+      const filtered = allEvents.filter((e) => {
+        if (!e.timestamp) return false;
+        const ts = new Date(e.timestamp).toISOString();
+        return ts >= sinceIso && ts < untilIso;
+      });
+
+      // Sort newest first (same as JSONL path)
+      filtered.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+
+      const events = filtered.slice(0, maxEvents);
       return {
-        events: events.slice(0, maxEvents),
+        events,
         view_meta: {
           source_kind: 'fixture',
           missing_reason: 'chronik_enoent',
@@ -108,8 +120,8 @@ export async function getTimelineData(
           total_loaded: events.length,
         },
       };
-    } catch (e) {
-      // Ignore
+    } catch {
+      // Ignore ENOENT
     }
   }
 

--- a/src/controllers/timeline.ts
+++ b/src/controllers/timeline.ts
@@ -59,7 +59,7 @@ export async function getTimelineData(
       events,
       view_meta: {
         source_kind: 'chronik',
-        missing_reason: 'ok',
+        missing_reason: events.length === 0 ? 'empty_window' : 'ok',
         is_strict: isStrict,
         since: sinceIso,
         until: untilIso,
@@ -150,8 +150,10 @@ export async function getTimelineData(
  * Uses readline streaming to avoid loading entire files into memory —
  * important for large append-only chronik logs. Files are processed in
  * batches of 8 to limit concurrent file descriptor usage.
+ *
+ * Exported for unit testing.
  */
-async function loadEventsFromDir(
+export async function loadEventsFromDir(
   dir: string,
   sinceIso: string,
   untilIso: string,

--- a/src/controllers/timeline.ts
+++ b/src/controllers/timeline.ts
@@ -102,7 +102,7 @@ export async function getTimelineData(
       const filtered = allEvents.filter((e) => {
         if (!e.timestamp) return false;
         const ts = new Date(e.timestamp).toISOString();
-        return ts >= sinceIso && ts < untilIso;
+        return ts >= sinceIso && ts <= untilIso;
       });
 
       // Sort newest first (same as JSONL path)
@@ -168,7 +168,7 @@ async function loadEventsFromDir(
         if (!data.timestamp || !data.kind) continue;
 
         const ts = new Date(data.timestamp).toISOString();
-        if (ts >= sinceIso && ts < untilIso) {
+        if (ts >= sinceIso && ts <= untilIso) {
           events.push({
             timestamp: ts,
             kind: data.kind,

--- a/src/controllers/timeline.ts
+++ b/src/controllers/timeline.ts
@@ -1,0 +1,179 @@
+import { join } from 'path';
+import { envConfig } from '../config.js';
+import type { EventLine } from '../events.js';
+import { readdir, readFile } from 'fs/promises';
+
+/**
+ * Event data for the timeline, extended for display purposes.
+ */
+export interface TimelineEvent extends EventLine {
+  // Inherited: timestamp, kind, repo, job, severity, payload
+}
+
+export interface TimelineViewData {
+  events: TimelineEvent[];
+  view_meta: {
+    source_kind: 'chronik' | 'fixture' | 'missing';
+    missing_reason: string;
+    is_strict: boolean;
+    since: string;
+    until: string;
+    total_loaded: number;
+  };
+}
+
+/**
+ * Loads events for the timeline view.
+ *
+ * Tries to load from the chronik data directory first,
+ * then falls back to a fixture file in dev mode.
+ *
+ * @param hoursBack - How many hours of history to load (default: 48)
+ * @param maxEvents - Maximum events to return (default: 200)
+ */
+export async function getTimelineData(
+  hoursBack: number = 48,
+  maxEvents: number = 200
+): Promise<TimelineViewData> {
+  const { isStrict } = envConfig;
+
+  const until = new Date();
+  const since = new Date(until.getTime() - hoursBack * 60 * 60 * 1000);
+
+  const sinceIso = since.toISOString();
+  const untilIso = until.toISOString();
+
+  // Try chronik data directory (from main config)
+  // The config file path resolution requires loadConfig, but for the web server
+  // we use a convention: artifacts/chronik/ or a configured path.
+  const chronikDir = join(envConfig.paths.artifacts, 'chronik');
+
+  try {
+    const events = await loadEventsFromDir(chronikDir, sinceIso, untilIso, maxEvents);
+    if (events.length > 0) {
+      return {
+        events,
+        view_meta: {
+          source_kind: 'chronik',
+          missing_reason: 'ok',
+          is_strict: isStrict,
+          since: sinceIso,
+          until: untilIso,
+          total_loaded: events.length,
+        },
+      };
+    }
+  } catch (e) {
+    // Ignore ENOENT – directory may not exist
+    if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
+      console.warn('[Timeline] Error loading chronik data:', e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  // Fallback to fixture
+  if (!isStrict) {
+    try {
+      const fixtureDir = join(envConfig.paths.fixtures, 'chronik');
+      const events = await loadEventsFromDir(fixtureDir, sinceIso, untilIso, maxEvents);
+      if (events.length > 0) {
+        return {
+          events,
+          view_meta: {
+            source_kind: 'fixture',
+            missing_reason: 'chronik_enoent',
+            is_strict: isStrict,
+            since: sinceIso,
+            until: untilIso,
+            total_loaded: events.length,
+          },
+        };
+      }
+    } catch (e) {
+      // Ignore ENOENT
+    }
+
+    // Last fallback: fixture JSON array
+    try {
+      const fixturePath = join(envConfig.paths.fixtures, 'events.json');
+      const raw = await readFile(fixturePath, 'utf-8');
+      const events = JSON.parse(raw) as TimelineEvent[];
+      return {
+        events: events.slice(0, maxEvents),
+        view_meta: {
+          source_kind: 'fixture',
+          missing_reason: 'chronik_enoent',
+          is_strict: isStrict,
+          since: sinceIso,
+          until: untilIso,
+          total_loaded: events.length,
+        },
+      };
+    } catch (e) {
+      // Ignore
+    }
+  }
+
+  // Nothing found
+  return {
+    events: [],
+    view_meta: {
+      source_kind: 'missing',
+      missing_reason: isStrict ? 'strict_mode' : 'no_events_found',
+      is_strict: isStrict,
+      since: sinceIso,
+      until: untilIso,
+      total_loaded: 0,
+    },
+  };
+}
+
+/**
+ * Loads events from a directory of JSONL files within a time window.
+ * Replicates the core logic of events.ts loadRecentEvents but is usable
+ * from the web controller context.
+ */
+async function loadEventsFromDir(
+  dir: string,
+  sinceIso: string,
+  untilIso: string,
+  maxEvents: number
+): Promise<TimelineEvent[]> {
+  const files = await readdir(dir);
+  const jsonlFiles = files.filter((f: string) => f.endsWith('.jsonl'));
+
+  const events: TimelineEvent[] = [];
+
+  for (const file of jsonlFiles) {
+    const content = await readFile(join(dir, file), 'utf-8');
+    const lines = content.split('\n');
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+
+      try {
+        const data = JSON.parse(trimmed);
+        if (!data.timestamp || !data.kind) continue;
+
+        const ts = new Date(data.timestamp).toISOString();
+        if (ts >= sinceIso && ts < untilIso) {
+          events.push({
+            timestamp: ts,
+            kind: data.kind,
+            repo: data.repo,
+            job: data.job,
+            severity: data.severity,
+            payload: data.payload,
+          });
+        }
+      } catch {
+        // Skip invalid lines
+      }
+    }
+  }
+
+  // Sort newest first
+  events.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+
+  return events.slice(0, maxEvents);
+}

--- a/src/controllers/timeline.ts
+++ b/src/controllers/timeline.ts
@@ -16,6 +16,9 @@ export interface TimelineViewData {
   events: TimelineEvent[];
   view_meta: {
     source_kind: 'chronik' | 'fixture' | 'missing';
+    /** Machine state of the time window — used by the UI to choose display text. */
+    window_state: 'has_events' | 'empty_window';
+    /** Error / fallback reason — machine token, not for direct UI rendering. */
     missing_reason: string;
     is_strict: boolean;
     since: string;
@@ -51,7 +54,7 @@ export async function getTimelineData(
   const chronikDir = join(envConfig.paths.artifacts, 'chronik');
 
   try {
-    const events = await loadEventsFromDir(chronikDir, sinceIso, untilIso, maxEvents);
+    const events = await __loadEventsFromDir(chronikDir, sinceIso, untilIso, maxEvents);
     // Chronik directory is accessible — return chronik result even if no events
     // are in the current window (avoids masking a valid-but-empty chronik as
     // "fixture" or "missing").
@@ -59,7 +62,8 @@ export async function getTimelineData(
       events,
       view_meta: {
         source_kind: 'chronik',
-        missing_reason: events.length === 0 ? 'empty_window' : 'ok',
+        window_state: events.length === 0 ? 'empty_window' : 'has_events',
+        missing_reason: 'ok',
         is_strict: isStrict,
         since: sinceIso,
         until: untilIso,
@@ -77,12 +81,13 @@ export async function getTimelineData(
   if (!isStrict) {
     try {
       const fixtureDir = join(envConfig.paths.fixtures, 'chronik');
-      const events = await loadEventsFromDir(fixtureDir, sinceIso, untilIso, maxEvents);
+      const events = await __loadEventsFromDir(fixtureDir, sinceIso, untilIso, maxEvents);
       if (events.length > 0) {
         return {
           events,
           view_meta: {
             source_kind: 'fixture',
+            window_state: 'has_events',
             missing_reason: 'chronik_enoent',
             is_strict: isStrict,
             since: sinceIso,
@@ -118,6 +123,7 @@ export async function getTimelineData(
         events,
         view_meta: {
           source_kind: 'fixture',
+          window_state: 'has_events',
           missing_reason: 'chronik_enoent',
           is_strict: isStrict,
           since: sinceIso,
@@ -135,6 +141,7 @@ export async function getTimelineData(
     events: [],
     view_meta: {
       source_kind: 'missing',
+      window_state: 'empty_window',
       missing_reason: isStrict ? 'strict_mode' : 'no_events_found',
       is_strict: isStrict,
       since: sinceIso,
@@ -151,9 +158,9 @@ export async function getTimelineData(
  * important for large append-only chronik logs. Files are processed in
  * batches of 8 to limit concurrent file descriptor usage.
  *
- * Exported for unit testing.
+ * Exported for unit testing only — not part of the controller's public API.
  */
-export async function loadEventsFromDir(
+export async function __loadEventsFromDir(
   dir: string,
   sinceIso: string,
   untilIso: string,

--- a/src/controllers/timeline.ts
+++ b/src/controllers/timeline.ts
@@ -102,7 +102,7 @@ export async function getTimelineData(
       const filtered = allEvents.filter((e) => {
         if (!e.timestamp) return false;
         const ts = new Date(e.timestamp).toISOString();
-        return ts >= sinceIso && ts <= untilIso;
+        return ts >= sinceIso && ts < untilIso;
       });
 
       // Sort newest first (same as JSONL path)
@@ -168,7 +168,7 @@ async function loadEventsFromDir(
         if (!data.timestamp || !data.kind) continue;
 
         const ts = new Date(data.timestamp).toISOString();
-        if (ts >= sinceIso && ts <= untilIso) {
+        if (ts >= sinceIso && ts < untilIso) {
           events.push({
             timestamp: ts,
             kind: data.kind,

--- a/src/controllers/timeline.ts
+++ b/src/controllers/timeline.ts
@@ -2,6 +2,8 @@ import { join } from 'path';
 import { envConfig } from '../config.js';
 import type { EventLine } from '../events.js';
 import { readdir, readFile } from 'fs/promises';
+import { createReadStream } from 'fs';
+import { createInterface } from 'readline';
 
 /**
  * Event data for the timeline, extended for display purposes.
@@ -50,21 +52,22 @@ export async function getTimelineData(
 
   try {
     const events = await loadEventsFromDir(chronikDir, sinceIso, untilIso, maxEvents);
-    if (events.length > 0) {
-      return {
-        events,
-        view_meta: {
-          source_kind: 'chronik',
-          missing_reason: 'ok',
-          is_strict: isStrict,
-          since: sinceIso,
-          until: untilIso,
-          total_loaded: events.length,
-        },
-      };
-    }
+    // Chronik directory is accessible — return chronik result even if no events
+    // are in the current window (avoids masking a valid-but-empty chronik as
+    // "fixture" or "missing").
+    return {
+      events,
+      view_meta: {
+        source_kind: 'chronik',
+        missing_reason: 'ok',
+        is_strict: isStrict,
+        since: sinceIso,
+        until: untilIso,
+        total_loaded: events.length,
+      },
+    };
   } catch (e) {
-    // Ignore ENOENT – directory may not exist
+    // Ignore ENOENT – directory may not exist yet
     if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
       console.warn('[Timeline] Error loading chronik data:', e instanceof Error ? e.message : String(e));
     }
@@ -101,7 +104,9 @@ export async function getTimelineData(
 
       const filtered = allEvents.filter((e) => {
         if (!e.timestamp) return false;
-        const ts = new Date(e.timestamp).toISOString();
+        const d = new Date(e.timestamp);
+        if (Number.isNaN(d.getTime())) return false;
+        const ts = d.toISOString();
         return ts >= sinceIso && ts < untilIso;
       });
 
@@ -141,8 +146,10 @@ export async function getTimelineData(
 
 /**
  * Loads events from a directory of JSONL files within a time window.
- * Replicates the core logic of events.ts loadRecentEvents but is usable
- * from the web controller context.
+ *
+ * Uses readline streaming to avoid loading entire files into memory —
+ * important for large append-only chronik logs. Files are processed in
+ * batches of 8 to limit concurrent file descriptor usage.
  */
 async function loadEventsFromDir(
   dir: string,
@@ -154,32 +161,59 @@ async function loadEventsFromDir(
   const jsonlFiles = files.filter((f: string) => f.endsWith('.jsonl'));
 
   const events: TimelineEvent[] = [];
+  // Limit concurrent file streams to avoid EMFILE errors on systems with low fd limits.
+  const BATCH_SIZE = 8;
 
-  for (const file of jsonlFiles) {
-    const content = await readFile(join(dir, file), 'utf-8');
-    const lines = content.split('\n');
+  for (let i = 0; i < jsonlFiles.length; i += BATCH_SIZE) {
+    const batch = jsonlFiles.slice(i, i + BATCH_SIZE);
 
-    for (const line of lines) {
-      const trimmed = line.trim();
-      if (!trimmed) continue;
+    const batchResults = await Promise.all(
+      batch.map(async (file) => {
+        const filePath = join(dir, file);
+        const fileEvents: TimelineEvent[] = [];
 
-      try {
-        const data = JSON.parse(trimmed);
-        if (!data.timestamp || !data.kind) continue;
+        const fileStream = createReadStream(filePath, { encoding: 'utf-8' });
+        const rl = createInterface({ input: fileStream, crlfDelay: Infinity });
 
-        const ts = new Date(data.timestamp).toISOString();
-        if (ts >= sinceIso && ts < untilIso) {
-          events.push({
-            timestamp: ts,
-            kind: data.kind,
-            repo: data.repo,
-            job: data.job,
-            severity: data.severity,
-            payload: data.payload,
-          });
+        try {
+          for await (const line of rl) {
+            const trimmed = line.trim();
+            if (!trimmed) continue;
+
+            try {
+              const data = JSON.parse(trimmed);
+              if (!data.timestamp || !data.kind) continue;
+
+              const d = new Date(data.timestamp);
+              if (Number.isNaN(d.getTime())) continue;
+              const ts = d.toISOString();
+
+              if (ts >= sinceIso && ts < untilIso) {
+                fileEvents.push({
+                  timestamp: ts,
+                  kind: data.kind,
+                  repo: data.repo,
+                  job: data.job,
+                  severity: data.severity,
+                  payload: data.payload,
+                });
+              }
+            } catch {
+              // Skip lines with invalid JSON
+            }
+          }
+        } finally {
+          rl.close();
+          fileStream.destroy();
         }
-      } catch {
-        // Skip invalid lines
+
+        return fileEvents;
+      })
+    );
+
+    for (const fileEvents of batchResults) {
+      for (const event of fileEvents) {
+        events.push(event);
       }
     }
   }

--- a/src/fixtures/anatomy.snapshot.json
+++ b/src/fixtures/anatomy.snapshot.json
@@ -1,0 +1,271 @@
+{
+  "schema": "anatomy.snapshot.v1",
+  "generated_at": "2026-03-28T06:00:00Z",
+  "source": "fixture",
+  "nodes": [
+    {
+      "id": "metarepo",
+      "label": "Metarepo",
+      "role": "Governance & Contracts",
+      "achse": "governance",
+      "description": "Zentrale Architektur-Dokumente, Contract-Definitionen, Cross-Repo-Richtlinien."
+    },
+    {
+      "id": "chronik",
+      "label": "Chronik",
+      "role": "Ereignis-Organ (Gedächtnis)",
+      "achse": "speicherung",
+      "description": "Zentraler Event-Store (event.line Append-only Log). Repräsentiert die Vergangenheit des Organismus."
+    },
+    {
+      "id": "semantah",
+      "label": "SemantAH",
+      "role": "Wissens-Organ",
+      "achse": "semantik",
+      "description": "Analysiert und rekonstruiert Wissen aus Events und anderen Quellen – Insights, Einbettungen, Graph-Strukturen."
+    },
+    {
+      "id": "hauski",
+      "label": "HausKI",
+      "role": "Entscheidungszentrum",
+      "achse": "entscheidung",
+      "description": "Trifft als KI-Agent Entscheidungen auf Basis von Events, Insights und Metriken."
+    },
+    {
+      "id": "wgx",
+      "label": "WGX",
+      "role": "Fleet-Motorik",
+      "achse": "motorik",
+      "description": "Orchestriert als Nervensystem die Fleet in CI/CD: Standard-Checks, Metriken, Fleet-Zustandsbilder."
+    },
+    {
+      "id": "leitstand",
+      "label": "Leitstand",
+      "role": "User-Interface (Observer)",
+      "achse": "interface",
+      "description": "Dashboard und Auge des Organismus. Visualisierung von Events, Insights und Fleet-Status."
+    },
+    {
+      "id": "heimgeist",
+      "label": "Heimgeist",
+      "role": "Meta-Agent (Reflexion)",
+      "achse": "reflexion",
+      "description": "Beobachtet Systemzustände, erkennt Muster, Lücken, Drift. Reflexionszentrum des Organismus."
+    },
+    {
+      "id": "aussensensor",
+      "label": "Aussensensor",
+      "role": "Externe Sensorik",
+      "achse": "sensorik",
+      "description": "Erfasst externe Umweltdaten und sendet sie als Events in den Organismus."
+    },
+    {
+      "id": "heimlern",
+      "label": "Heimlern",
+      "role": "Mustererkennung & Lernen",
+      "achse": "reflexion",
+      "description": "Erkennt wiederkehrende Muster und gibt Policy-Feedback. Lernende Adaption."
+    },
+    {
+      "id": "plexer",
+      "label": "Plexer",
+      "role": "Event-Router",
+      "achse": "motorik",
+      "description": "Vermittelt Events in Echtzeit zwischen Komponenten. Schnelles Routing."
+    },
+    {
+      "id": "mitschreiber",
+      "label": "Mitschreiber",
+      "role": "OS-Kontext-Sensor",
+      "achse": "sensorik",
+      "description": "Erzeugt OS-Kontext-Events (Fenster, Aktivität, Umgebungsdaten)."
+    },
+    {
+      "id": "lenskit",
+      "label": "Lenskit",
+      "role": "Struktur-Analyse-Tooling",
+      "achse": "semantik",
+      "description": "Sammelt Strukturdaten aus Repos, erzeugt mehrstufige Repräsentationen und Snapshots."
+    },
+    {
+      "id": "sichter",
+      "label": "Sichter",
+      "role": "Code-Review-Agent",
+      "achse": "motorik",
+      "description": "Automatisierte Code-Reviews und Qualitätsprüfungen."
+    },
+    {
+      "id": "vault-gewebe",
+      "label": "Vault-Gewebe",
+      "role": "Statisches Wissen (Obsidian)",
+      "achse": "speicherung",
+      "description": "Obsidian Vault mit statischem Wissen, das in den semantischen Graphen einfließt."
+    }
+  ],
+  "edges": [
+    {
+      "source": "aussensensor",
+      "target": "chronik",
+      "contract": "aussen.event.*",
+      "label": "Sensor-Events",
+      "type": "data"
+    },
+    {
+      "source": "mitschreiber",
+      "target": "chronik",
+      "contract": "os.context.*",
+      "label": "OS-Kontext-Events",
+      "type": "data"
+    },
+    {
+      "source": "hauski",
+      "target": "chronik",
+      "contract": "event.line",
+      "label": "Entscheidungs-Events",
+      "type": "data"
+    },
+    {
+      "source": "wgx",
+      "target": "chronik",
+      "contract": "event.line",
+      "label": "CI/Fleet-Events",
+      "type": "data"
+    },
+    {
+      "source": "chronik",
+      "target": "semantah",
+      "contract": "event.line",
+      "label": "Event-Stream",
+      "type": "data"
+    },
+    {
+      "source": "chronik",
+      "target": "leitstand",
+      "contract": "event.line",
+      "label": "Event-Stream",
+      "type": "data"
+    },
+    {
+      "source": "chronik",
+      "target": "heimgeist",
+      "contract": "event.line",
+      "label": "Event-Stream",
+      "type": "data"
+    },
+    {
+      "source": "semantah",
+      "target": "leitstand",
+      "contract": "insights.daily",
+      "label": "Tages-Insights",
+      "type": "data"
+    },
+    {
+      "source": "semantah",
+      "target": "leitstand",
+      "contract": "knowledge.observatory",
+      "label": "Observatory-Daten",
+      "type": "data"
+    },
+    {
+      "source": "wgx",
+      "target": "leitstand",
+      "contract": "metrics.snapshot",
+      "label": "Fleet-Metriken",
+      "type": "data"
+    },
+    {
+      "source": "heimgeist",
+      "target": "leitstand",
+      "contract": "heimgeist.self_state",
+      "label": "Self-State",
+      "type": "data"
+    },
+    {
+      "source": "plexer",
+      "target": "leitstand",
+      "contract": "plexer.delivery.report",
+      "label": "Delivery-Report",
+      "type": "data"
+    },
+    {
+      "source": "lenskit",
+      "target": "leitstand",
+      "contract": "anatomy.snapshot",
+      "label": "Struktur-Snapshot",
+      "type": "data"
+    },
+    {
+      "source": "vault-gewebe",
+      "target": "semantah",
+      "contract": "vault.content",
+      "label": "Statisches Wissen",
+      "type": "data"
+    },
+    {
+      "source": "heimgeist",
+      "target": "hauski",
+      "contract": "policy.feedback",
+      "label": "Policy-Feedback",
+      "type": "control"
+    },
+    {
+      "source": "heimlern",
+      "target": "heimgeist",
+      "contract": "pattern.signal",
+      "label": "Muster-Signale",
+      "type": "data"
+    },
+    {
+      "source": "plexer",
+      "target": "heimgeist",
+      "contract": "event.line",
+      "label": "Echtzeit-Events",
+      "type": "data"
+    },
+    {
+      "source": "metarepo",
+      "target": "wgx",
+      "contract": "fleet.config",
+      "label": "Fleet-Konfiguration",
+      "type": "governance"
+    },
+    {
+      "source": "metarepo",
+      "target": "chronik",
+      "contract": "event.line.schema",
+      "label": "Event-Schema",
+      "type": "governance"
+    },
+    {
+      "source": "metarepo",
+      "target": "semantah",
+      "contract": "insights.daily.schema",
+      "label": "Insights-Schema",
+      "type": "governance"
+    },
+    {
+      "source": "lenskit",
+      "target": "semantah",
+      "contract": "lens.snapshot",
+      "label": "Strukturdaten",
+      "type": "data"
+    },
+    {
+      "source": "wgx",
+      "target": "sichter",
+      "contract": "fleet.review.trigger",
+      "label": "Review-Aufträge",
+      "type": "control"
+    }
+  ],
+  "achsen": {
+    "governance": { "label": "Governance", "color": "#8B5CF6", "description": "Richtlinien, Contracts, Architektur" },
+    "sensorik": { "label": "Sensorik", "color": "#06B6D4", "description": "Externe und OS-Datenerfassung" },
+    "speicherung": { "label": "Speicherung", "color": "#F59E0B", "description": "Event-Store, Knowledge-Vault" },
+    "semantik": { "label": "Semantik", "color": "#10B981", "description": "Wissensbildung, Analyse, Lens" },
+    "entscheidung": { "label": "Entscheidung", "color": "#EF4444", "description": "KI-gesteuerte Aktionsplanung" },
+    "motorik": { "label": "Motorik / Fleet", "color": "#F97316", "description": "CI/CD-Orchestrierung, Routing, Reviews" },
+    "interface": { "label": "Interface", "color": "#3B82F6", "description": "User-facing Dashboard" },
+    "reflexion": { "label": "Reflexion", "color": "#EC4899", "description": "Meta-Analyse, Mustererkennung, Drift" }
+  }
+}

--- a/src/fixtures/events.json
+++ b/src/fixtures/events.json
@@ -1,0 +1,146 @@
+[
+  {
+    "timestamp": "2026-03-28T05:30:00Z",
+    "kind": "ci.guard.pass",
+    "repo": "leitstand",
+    "severity": "info",
+    "payload": { "guard": "observer-invariant-guard", "result": "pass" }
+  },
+  {
+    "timestamp": "2026-03-28T04:45:00Z",
+    "kind": "knowledge.observatory.published.v1",
+    "repo": "semantah",
+    "severity": "info",
+    "payload": { "topics_count": 7, "observatory_id": "obs-2026-03-28" }
+  },
+  {
+    "timestamp": "2026-03-28T03:12:00Z",
+    "kind": "insights.daily.generated",
+    "repo": "semantah",
+    "severity": "info",
+    "payload": { "topics": 5, "questions": 3, "deltas": 2 }
+  },
+  {
+    "timestamp": "2026-03-28T02:00:00Z",
+    "kind": "fleet.health.snapshot",
+    "repo": "wgx",
+    "severity": "info",
+    "payload": { "ok": 10, "warn": 2, "fail": 0, "total": 12 }
+  },
+  {
+    "timestamp": "2026-03-28T01:30:00Z",
+    "kind": "ci.test.fail",
+    "repo": "heimlern",
+    "severity": "error",
+    "job": "smoke-test",
+    "payload": { "failed_tests": 2, "total_tests": 47, "exit_code": 1 }
+  },
+  {
+    "timestamp": "2026-03-28T01:00:00Z",
+    "kind": "heimgeist.self_state.update",
+    "repo": "heimgeist",
+    "severity": "info",
+    "payload": { "autonomy_level": "aware", "confidence": 0.72, "fatigue": 0.15 }
+  },
+  {
+    "timestamp": "2026-03-27T23:45:00Z",
+    "kind": "plexer.delivery.complete",
+    "repo": "plexer",
+    "severity": "info",
+    "payload": { "delivered": 14, "failed": 0, "pending": 1 }
+  },
+  {
+    "timestamp": "2026-03-27T22:30:00Z",
+    "kind": "ci.guard.pass",
+    "repo": "metarepo",
+    "severity": "info",
+    "payload": { "guard": "contract-schema-guard", "result": "pass" }
+  },
+  {
+    "timestamp": "2026-03-27T21:15:00Z",
+    "kind": "aussen.event.weather",
+    "repo": "aussensensor",
+    "severity": "info",
+    "payload": { "temperature": 12.4, "humidity": 67, "condition": "cloudy" }
+  },
+  {
+    "timestamp": "2026-03-27T20:00:00Z",
+    "kind": "os.context.session.start",
+    "repo": "mitschreiber",
+    "severity": "info",
+    "payload": { "user": "alex", "workspace": "leitstand" }
+  },
+  {
+    "timestamp": "2026-03-27T19:30:00Z",
+    "kind": "ci.deploy.success",
+    "repo": "leitstand",
+    "severity": "info",
+    "job": "deploy-preview",
+    "payload": { "env": "preview", "duration_ms": 12450 }
+  },
+  {
+    "timestamp": "2026-03-27T18:00:00Z",
+    "kind": "hauski.decision.v1",
+    "repo": "hauski",
+    "severity": "warn",
+    "payload": { "decision": "defer_action", "reason": "insufficient_confidence", "confidence": 0.42 }
+  },
+  {
+    "timestamp": "2026-03-27T16:45:00Z",
+    "kind": "integrity.summary.published.v1",
+    "repo": "wgx",
+    "severity": "info",
+    "payload": { "repos_checked": 12, "status": "WARN", "gaps": 1 }
+  },
+  {
+    "timestamp": "2026-03-27T15:30:00Z",
+    "kind": "ci.lint.warn",
+    "repo": "chronik",
+    "severity": "warn",
+    "job": "eslint",
+    "payload": { "warnings": 3, "errors": 0 }
+  },
+  {
+    "timestamp": "2026-03-27T14:00:00Z",
+    "kind": "vault.sync.complete",
+    "repo": "vault-gewebe",
+    "severity": "info",
+    "payload": { "notes_synced": 42, "new_notes": 2 }
+  },
+  {
+    "timestamp": "2026-03-27T12:30:00Z",
+    "kind": "lenskit.snapshot.generated",
+    "repo": "lenskit",
+    "severity": "info",
+    "payload": { "repos_analyzed": 14, "relations_found": 22, "detail_level": "dev" }
+  },
+  {
+    "timestamp": "2026-03-27T11:00:00Z",
+    "kind": "ci.test.pass",
+    "repo": "wgx",
+    "severity": "info",
+    "job": "vitest",
+    "payload": { "passed": 89, "failed": 0, "duration_ms": 4520 }
+  },
+  {
+    "timestamp": "2026-03-27T09:30:00Z",
+    "kind": "heimlern.pattern.detected",
+    "repo": "heimlern",
+    "severity": "info",
+    "payload": { "pattern": "monday_failure_spike", "confidence": 0.78, "occurrences": 4 }
+  },
+  {
+    "timestamp": "2026-03-27T08:00:00Z",
+    "kind": "fleet.health.snapshot",
+    "repo": "wgx",
+    "severity": "warn",
+    "payload": { "ok": 9, "warn": 2, "fail": 1, "total": 12, "degraded": "sichter" }
+  },
+  {
+    "timestamp": "2026-03-27T06:00:00Z",
+    "kind": "sichter.review.error",
+    "repo": "sichter",
+    "severity": "error",
+    "payload": { "error": "GitHub API rate limit exceeded", "retry_at": "2026-03-27T07:00:00Z" }
+  }
+]

--- a/src/server.ts
+++ b/src/server.ts
@@ -336,9 +336,12 @@ app.get('/anatomy', async (_req, res) => {
 });
 
 // Timeline View – Phase 3: Temporal event chronology
-app.get('/timeline', async (_req, res) => {
+app.get('/timeline', async (req, res) => {
   try {
-    const hoursBack = Math.min(Number(_req.query.hours) || 48, 168); // Max 7 days
+    const parsedHours = Number(req.query.hours);
+    const hoursBack = Number.isFinite(parsedHours) && parsedHours > 0
+      ? Math.min(parsedHours, 168)
+      : 48; // Default 48 h; max 7 days
     const data = await getTimelineData(hoursBack);
     res.render('timeline', data);
   } catch (error) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,6 +8,8 @@ import { readJsonFile } from './utils/fs.js';
 import { isLoopbackAddress } from './utils/network.js';
 import { envConfig } from './config.js';
 import { getObservatoryData } from './controllers/observatory.js';
+import { getAnatomyData } from './controllers/anatomy.js';
+import { getTimelineData } from './controllers/timeline.js';
 import fs from 'fs';
 import { validatePlexerReport } from './validation/validators.js';
 import { randomBytes } from 'crypto';
@@ -312,6 +314,38 @@ app.get('/intent', async (_req, res) => {
   } catch (error) {
     console.error(error);
     res.status(500).send('Error loading intent data');
+  }
+});
+
+// Anatomy View – Phase 1: Structural overview of the Heimgewebe organism
+app.get('/anatomy', async (_req, res) => {
+  try {
+    const data = await getAnatomyData();
+    res.render('anatomy', data);
+  } catch (error) {
+    if (!res.headersSent) {
+      console.error('[Anatomy] Error:', error);
+      const msg = error instanceof Error ? error.message : String(error);
+      if (msg.includes('Strict')) {
+        res.status(503).send('Service Unavailable');
+      } else {
+        res.status(500).send('Error loading anatomy data');
+      }
+    }
+  }
+});
+
+// Timeline View – Phase 3: Temporal event chronology
+app.get('/timeline', async (_req, res) => {
+  try {
+    const hoursBack = Math.min(Number(_req.query.hours) || 48, 168); // Max 7 days
+    const data = await getTimelineData(hoursBack);
+    res.render('timeline', data);
+  } catch (error) {
+    if (!res.headersSent) {
+      console.error('[Timeline] Error:', error);
+      res.status(500).send('Error loading timeline data');
+    }
   }
 });
 

--- a/src/views/anatomy.ejs
+++ b/src/views/anatomy.ejs
@@ -6,8 +6,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Structural topology of the Heimgewebe organism – interactive graph of all organs and their contract-based relationships.">
   <style>
-    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
-
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
     :root {
@@ -21,11 +19,10 @@
       --text-secondary: #94a3b8;
       --text-muted: #64748b;
       --accent: #3b82f6;
-      --glow-strength: 0.35;
     }
 
     body {
-      font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
       background: var(--bg-primary);
       color: var(--text-primary);
       overflow: hidden;
@@ -252,9 +249,7 @@
       margin-top: 2px;
     }
 
-    .connection-details {
-      flex: 1;
-    }
+    .connection-details { flex: 1; }
 
     .connection-target {
       color: var(--text-primary);
@@ -298,35 +293,6 @@
       font-size: 1.4em;
       margin-bottom: 8px;
       color: var(--text-secondary);
-    }
-
-    /* D3 Node Styles */
-    .node-circle {
-      cursor: pointer;
-      transition: filter 0.2s ease;
-    }
-
-    .node-label-text {
-      font-family: 'Inter', sans-serif;
-      font-size: 11px;
-      font-weight: 500;
-      fill: var(--text-primary);
-      pointer-events: none;
-      text-anchor: middle;
-      dominant-baseline: central;
-      text-shadow: 0 1px 4px rgba(0, 0, 0, 0.8), 0 0 8px rgba(0, 0, 0, 0.6);
-    }
-
-    .edge-line {
-      stroke-linecap: round;
-    }
-
-    .edge-label {
-      font-family: 'Inter', sans-serif;
-      font-size: 9px;
-      fill: var(--text-muted);
-      pointer-events: none;
-      text-anchor: middle;
     }
 
     /* Tooltip */
@@ -414,7 +380,7 @@
 
   <!-- Detail Panel -->
   <div id="detail-panel">
-    <button class="close-btn" onclick="closeDetail()" title="Schließen">&times;</button>
+    <button class="close-btn" id="close-detail-btn" title="Schließen">&times;</button>
     <div class="node-label" id="dp-label"></div>
     <div class="node-role" id="dp-role"></div>
     <div class="node-achse" id="dp-achse"></div>
@@ -438,266 +404,454 @@
     <% } %>
   </div>
 
-  <!-- D3.js v7 from CDN -->
-  <script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>
+  <!--
+    Dependency-free force-directed graph.
+    No external CDN or npm dependency required.
+    Implements a minimal force simulation (repulsion + link spring + centering)
+    and renders to SVG via direct DOM manipulation.
+  -->
   <script>
-    // --- Data from server ---
-    const graphData = <%- JSON.stringify({ nodes: anatomy.nodes, edges: anatomy.edges, achsen: anatomy.achsen }) %>;
+    // --- Hardened data injection ---
+    // Neutralize </script> and similar sequences that could break out of script context.
+    // Using EJS unescaped output (<%- %>) for valid JSON, then replacing dangerous sequences.
+    var graphData = JSON.parse(
+      '<%= JSON.stringify({ nodes: anatomy.nodes, edges: anatomy.edges, achsen: anatomy.achsen }).replace(/\\/g, "\\\\").replace(/'/g, "\\'").replace(/<\\//g, "<\\/").replace(/\\u2028/g, "\\\\u2028").replace(/\\u2029/g, "\\\\u2029") %>'
+    );
 
-    const nodes = graphData.nodes.map(n => ({ ...n }));
-    const edges = graphData.edges.map(e => ({ ...e }));
-    const achsen = graphData.achsen;
+    var nodes = graphData.nodes.map(function(n) {
+      return { id: n.id, label: n.label, role: n.role, achse: n.achse, description: n.description, x: 0, y: 0, vx: 0, vy: 0, fx: null, fy: null };
+    });
+    var edges = graphData.edges.map(function(e) {
+      return { source: e.source, target: e.target, contract: e.contract, label: e.label, type: e.type };
+    });
+    var achsen = graphData.achsen;
 
-    // --- Dimensions ---
-    const width = window.innerWidth;
-    const height = window.innerHeight;
+    // Build index for fast lookup
+    var nodeIndex = {};
+    nodes.forEach(function(n) { nodeIndex[n.id] = n; });
+
+    // Resolve edge source/target to node references
+    edges.forEach(function(e) {
+      e.sourceNode = nodeIndex[e.source];
+      e.targetNode = nodeIndex[e.target];
+    });
+
+    // Filter out edges with missing nodes
+    edges = edges.filter(function(e) { return e.sourceNode && e.targetNode; });
 
     // --- SVG Setup ---
-    const svg = d3.select('#graph-container')
-      .append('svg')
-      .attr('viewBox', [0, 0, width, height]);
+    var width = window.innerWidth;
+    var height = window.innerHeight;
+    var svgNS = 'http://www.w3.org/2000/svg';
 
-    // Defs for glow effects and arrow markers
-    const defs = svg.append('defs');
+    var container = document.getElementById('graph-container');
+    var svg = document.createElementNS(svgNS, 'svg');
+    svg.setAttribute('viewBox', '0 0 ' + width + ' ' + height);
+    container.appendChild(svg);
+
+    // Defs for arrow markers and glow
+    var defs = document.createElementNS(svgNS, 'defs');
+    svg.appendChild(defs);
 
     // Glow filter
-    const glowFilter = defs.append('filter')
-      .attr('id', 'glow')
-      .attr('x', '-50%').attr('y', '-50%')
-      .attr('width', '200%').attr('height', '200%');
-    glowFilter.append('feGaussianBlur')
-      .attr('stdDeviation', '4')
-      .attr('result', 'blur');
-    const glowMerge = glowFilter.append('feMerge');
-    glowMerge.append('feMergeNode').attr('in', 'blur');
-    glowMerge.append('feMergeNode').attr('in', 'SourceGraphic');
-
-    // Background gradient
-    const bgGrad = defs.append('radialGradient')
-      .attr('id', 'bg-gradient')
-      .attr('cx', '50%').attr('cy', '50%').attr('r', '70%');
-    bgGrad.append('stop').attr('offset', '0%').attr('stop-color', '#111827');
-    bgGrad.append('stop').attr('offset', '100%').attr('stop-color', '#0a0e1a');
-
-    svg.append('rect')
-      .attr('width', width)
-      .attr('height', height)
-      .attr('fill', 'url(#bg-gradient)');
+    var glowFilter = document.createElementNS(svgNS, 'filter');
+    glowFilter.setAttribute('id', 'glow');
+    glowFilter.setAttribute('x', '-50%');
+    glowFilter.setAttribute('y', '-50%');
+    glowFilter.setAttribute('width', '200%');
+    glowFilter.setAttribute('height', '200%');
+    var blur = document.createElementNS(svgNS, 'feGaussianBlur');
+    blur.setAttribute('stdDeviation', '3');
+    blur.setAttribute('result', 'blur');
+    glowFilter.appendChild(blur);
+    var merge = document.createElementNS(svgNS, 'feMerge');
+    var mn1 = document.createElementNS(svgNS, 'feMergeNode');
+    mn1.setAttribute('in', 'blur');
+    merge.appendChild(mn1);
+    var mn2 = document.createElementNS(svgNS, 'feMergeNode');
+    mn2.setAttribute('in', 'SourceGraphic');
+    merge.appendChild(mn2);
+    glowFilter.appendChild(merge);
+    defs.appendChild(glowFilter);
 
     // Arrow markers per edge type
-    const arrowColors = {
+    var arrowDefs = {
       data: 'rgba(148, 163, 184, 0.5)',
       control: 'rgba(239, 68, 68, 0.6)',
       governance: 'rgba(139, 92, 246, 0.5)'
     };
 
-    Object.entries(arrowColors).forEach(([type, color]) => {
-      defs.append('marker')
-        .attr('id', `arrow-${type}`)
-        .attr('viewBox', '0 -5 10 10')
-        .attr('refX', 28)
-        .attr('refY', 0)
-        .attr('markerWidth', 6)
-        .attr('markerHeight', 6)
-        .attr('orient', 'auto')
-        .append('path')
-        .attr('d', 'M0,-4L10,0L0,4')
-        .attr('fill', color);
+    Object.keys(arrowDefs).forEach(function(type) {
+      var marker = document.createElementNS(svgNS, 'marker');
+      marker.setAttribute('id', 'arrow-' + type);
+      marker.setAttribute('viewBox', '0 -5 10 10');
+      marker.setAttribute('refX', '28');
+      marker.setAttribute('refY', '0');
+      marker.setAttribute('markerWidth', '6');
+      marker.setAttribute('markerHeight', '6');
+      marker.setAttribute('orient', 'auto');
+      var path = document.createElementNS(svgNS, 'path');
+      path.setAttribute('d', 'M0,-4L10,0L0,4');
+      path.setAttribute('fill', arrowDefs[type]);
+      marker.appendChild(path);
+      defs.appendChild(marker);
     });
 
-    // --- Zoom ---
-    const g = svg.append('g');
+    // Background
+    var bg = document.createElementNS(svgNS, 'rect');
+    bg.setAttribute('width', width);
+    bg.setAttribute('height', height);
+    bg.setAttribute('fill', '#0a0e1a');
+    svg.appendChild(bg);
 
-    const zoom = d3.zoom()
-      .scaleExtent([0.2, 4])
-      .on('zoom', (event) => {
-        g.attr('transform', event.transform);
-      });
+    // Main group for pan/zoom
+    var gMain = document.createElementNS(svgNS, 'g');
+    svg.appendChild(gMain);
 
-    svg.call(zoom);
+    // Edge group
+    var gEdges = document.createElementNS(svgNS, 'g');
+    gMain.appendChild(gEdges);
 
-    // Initial zoom to center
-    svg.call(zoom.transform, d3.zoomIdentity.translate(width * 0.08, height * 0.05).scale(0.9));
+    // Node group
+    var gNodes = document.createElementNS(svgNS, 'g');
+    gMain.appendChild(gNodes);
 
-    // --- Simulation ---
-    const simulation = d3.forceSimulation(nodes)
-      .force('link', d3.forceLink(edges).id(d => d.id).distance(180).strength(0.4))
-      .force('charge', d3.forceManyBody().strength(-800).distanceMax(600))
-      .force('center', d3.forceCenter(width / 2, height / 2))
-      .force('collision', d3.forceCollide().radius(45))
-      .force('x', d3.forceX(width / 2).strength(0.04))
-      .force('y', d3.forceY(height / 2).strength(0.04));
+    var NODE_R = 22;
 
-    // --- Edge rendering ---
-    function edgeColor(type) {
+    // --- Edge color/dash helpers ---
+    function edgeStroke(type) {
       if (type === 'control') return 'rgba(239, 68, 68, 0.35)';
       if (type === 'governance') return 'rgba(139, 92, 246, 0.3)';
       return 'rgba(148, 163, 184, 0.18)';
     }
 
     function edgeDash(type) {
-      if (type === 'governance') return '4,4';
-      return 'none';
+      return type === 'governance' ? '4,4' : '';
     }
 
-    const edgeGroup = g.append('g').attr('class', 'edges');
+    function nodeColor(achse) {
+      return (achsen[achse] || { color: '#64748b' }).color;
+    }
 
-    const link = edgeGroup.selectAll('line')
-      .data(edges)
-      .join('line')
-      .attr('class', 'edge-line')
-      .attr('stroke', d => edgeColor(d.type))
-      .attr('stroke-width', d => d.type === 'governance' ? 1 : 1.5)
-      .attr('stroke-dasharray', d => edgeDash(d.type))
-      .attr('marker-end', d => `url(#arrow-${d.type})`);
+    // --- Create SVG elements ---
+    // Edges
+    var edgeEls = edges.map(function(e) {
+      var line = document.createElementNS(svgNS, 'line');
+      line.setAttribute('stroke', edgeStroke(e.type));
+      line.setAttribute('stroke-width', e.type === 'governance' ? '1' : '1.5');
+      line.setAttribute('stroke-linecap', 'round');
+      var dash = edgeDash(e.type);
+      if (dash) line.setAttribute('stroke-dasharray', dash);
+      line.setAttribute('marker-end', 'url(#arrow-' + e.type + ')');
+      gEdges.appendChild(line);
+      return line;
+    });
 
-    // --- Node rendering ---
-    const nodeGroup = g.append('g').attr('class', 'nodes');
+    // Nodes
+    var nodeEls = nodes.map(function(n) {
+      var g = document.createElementNS(svgNS, 'g');
+      g.style.cursor = 'pointer';
 
-    const nodeRadius = 22;
+      // Glow ring
+      var ring = document.createElementNS(svgNS, 'circle');
+      ring.setAttribute('r', NODE_R + 6);
+      ring.setAttribute('fill', 'none');
+      ring.setAttribute('stroke', nodeColor(n.achse));
+      ring.setAttribute('stroke-width', '1.5');
+      ring.setAttribute('stroke-opacity', '0.2');
+      g.appendChild(ring);
 
-    const node = nodeGroup.selectAll('g')
-      .data(nodes)
-      .join('g')
-      .attr('class', 'node-group')
-      .call(d3.drag()
-        .on('start', dragStarted)
-        .on('drag', dragged)
-        .on('end', dragEnded));
+      // Main circle
+      var circle = document.createElementNS(svgNS, 'circle');
+      circle.setAttribute('r', NODE_R);
+      circle.setAttribute('fill', nodeColor(n.achse) + '20');
+      circle.setAttribute('stroke', nodeColor(n.achse));
+      circle.setAttribute('stroke-width', '2');
+      circle.setAttribute('filter', 'url(#glow)');
+      g.appendChild(circle);
+      n._circle = circle;
 
-    // Glow ring (outer)
-    node.append('circle')
-      .attr('r', nodeRadius + 6)
-      .attr('fill', 'none')
-      .attr('stroke', d => (achsen[d.achse] || { color: '#64748b' }).color)
-      .attr('stroke-width', 1.5)
-      .attr('stroke-opacity', 0.2)
-      .attr('class', 'glow-ring');
+      // Initials inside
+      var initials = document.createElementNS(svgNS, 'text');
+      initials.setAttribute('text-anchor', 'middle');
+      initials.setAttribute('dominant-baseline', 'central');
+      initials.setAttribute('font-size', '13');
+      initials.setAttribute('font-weight', '700');
+      initials.setAttribute('font-family', '-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif');
+      initials.setAttribute('fill', nodeColor(n.achse));
+      initials.setAttribute('pointer-events', 'none');
+      initials.textContent = n.label.substring(0, 2).toUpperCase();
+      g.appendChild(initials);
 
-    // Main circle
-    node.append('circle')
-      .attr('r', nodeRadius)
-      .attr('fill', d => {
-        const color = (achsen[d.achse] || { color: '#64748b' }).color;
-        return color + '20'; // 12% opacity fill
-      })
-      .attr('stroke', d => (achsen[d.achse] || { color: '#64748b' }).color)
-      .attr('stroke-width', 2)
-      .attr('class', 'node-circle')
-      .attr('filter', 'url(#glow)');
+      // Label below
+      var label = document.createElementNS(svgNS, 'text');
+      label.setAttribute('text-anchor', 'middle');
+      label.setAttribute('dy', NODE_R + 16);
+      label.setAttribute('font-size', '11');
+      label.setAttribute('font-weight', '500');
+      label.setAttribute('font-family', '-apple-system, BlinkMacSystemFont, Segoe UI, sans-serif');
+      label.setAttribute('fill', '#f1f5f9');
+      label.setAttribute('pointer-events', 'none');
+      label.textContent = n.label;
+      g.appendChild(label);
+      n._label = label;
 
-    // Node label (abbreviated)
-    node.append('text')
-      .attr('class', 'node-label-text')
-      .attr('dy', nodeRadius + 16)
-      .text(d => d.label);
+      gNodes.appendChild(g);
+      n._el = g;
+      return g;
+    });
 
-    // Node icon (first letter as fallback)
-    node.append('text')
-      .attr('class', 'node-label-text')
-      .attr('font-size', '13px')
-      .attr('font-weight', '700')
-      .attr('fill', d => (achsen[d.achse] || { color: '#64748b' }).color)
-      .text(d => d.label.substring(0, 2).toUpperCase());
+    // --- Initialize positions (circular layout as starting point) ---
+    var cx = width / 2;
+    var cy = height / 2;
+    var layoutR = Math.min(width, height) * 0.3;
+    nodes.forEach(function(n, i) {
+      var angle = (2 * Math.PI * i) / nodes.length - Math.PI / 2;
+      n.x = cx + layoutR * Math.cos(angle);
+      n.y = cy + layoutR * Math.sin(angle);
+    });
 
-    // --- Tooltip ---
-    const tooltip = document.getElementById('tooltip');
-    const ttLabel = tooltip.querySelector('.tt-label');
-    const ttRole = tooltip.querySelector('.tt-role');
+    // --- Force Simulation (vanilla) ---
+    var alpha = 1;
+    var alphaDecay = 0.02;
+    var alphaMin = 0.001;
+    var REPULSION = 12000;
+    var LINK_STRENGTH = 0.06;
+    var LINK_DIST = 180;
+    var CENTER_STRENGTH = 0.01;
+    var DAMPING = 0.6;
 
-    node.on('mouseenter', (event, d) => {
-      const color = (achsen[d.achse] || { color: '#64748b' }).color;
-      ttLabel.textContent = d.label;
-      ttLabel.style.color = color;
-      ttRole.textContent = d.role;
-      tooltip.classList.add('visible');
+    function simulate() {
+      if (alpha < alphaMin) return;
 
-      // Highlight connected edges
-      link.attr('stroke-opacity', e =>
-        (e.source.id === d.id || e.target.id === d.id) ? 1 : 0.15
-      ).attr('stroke-width', e =>
-        (e.source.id === d.id || e.target.id === d.id) ? 2.5 : 1
-      );
+      // Repulsion (all pairs)
+      for (var i = 0; i < nodes.length; i++) {
+        for (var j = i + 1; j < nodes.length; j++) {
+          var dx = nodes[j].x - nodes[i].x;
+          var dy = nodes[j].y - nodes[i].y;
+          var dist = Math.sqrt(dx * dx + dy * dy) || 1;
+          var force = alpha * REPULSION / (dist * dist);
+          var fx = (dx / dist) * force;
+          var fy = (dy / dist) * force;
+          nodes[i].vx -= fx;
+          nodes[i].vy -= fy;
+          nodes[j].vx += fx;
+          nodes[j].vy += fy;
+        }
+      }
 
-      // Dim unconnected nodes
-      const connectedIds = new Set();
-      connectedIds.add(d.id);
-      edges.forEach(e => {
-        const sid = typeof e.source === 'object' ? e.source.id : e.source;
-        const tid = typeof e.target === 'object' ? e.target.id : e.target;
-        if (sid === d.id) connectedIds.add(tid);
-        if (tid === d.id) connectedIds.add(sid);
+      // Link spring
+      edges.forEach(function(e) {
+        var s = e.sourceNode;
+        var t = e.targetNode;
+        var dx = t.x - s.x;
+        var dy = t.y - s.y;
+        var dist = Math.sqrt(dx * dx + dy * dy) || 1;
+        var displacement = dist - LINK_DIST;
+        var force = alpha * LINK_STRENGTH * displacement;
+        var fx = (dx / dist) * force;
+        var fy = (dy / dist) * force;
+        s.vx += fx;
+        s.vy += fy;
+        t.vx -= fx;
+        t.vy -= fy;
       });
 
-      node.select('.node-circle')
-        .attr('stroke-opacity', n => connectedIds.has(n.id) ? 1 : 0.2)
-        .attr('fill-opacity', n => connectedIds.has(n.id) ? 1 : 0.3);
+      // Center gravity
+      nodes.forEach(function(n) {
+        n.vx += (cx - n.x) * CENTER_STRENGTH * alpha;
+        n.vy += (cy - n.y) * CENTER_STRENGTH * alpha;
+      });
 
-      node.select('.node-label-text')
-        .attr('fill-opacity', n => connectedIds.has(n.id) ? 1 : 0.3);
-    });
+      // Apply velocities
+      nodes.forEach(function(n) {
+        if (n.fx !== null) { n.x = n.fx; n.vx = 0; }
+        else { n.vx *= DAMPING; n.x += n.vx; }
+        if (n.fy !== null) { n.y = n.fy; n.vy = 0; }
+        else { n.vy *= DAMPING; n.y += n.vy; }
+      });
 
-    node.on('mousemove', (event) => {
-      tooltip.style.left = (event.clientX + 16) + 'px';
-      tooltip.style.top = (event.clientY - 10) + 'px';
-    });
+      alpha -= alphaDecay;
 
-    node.on('mouseleave', () => {
-      tooltip.classList.remove('visible');
-      // Restore
-      link.attr('stroke-opacity', 1).attr('stroke-width', d => d.type === 'governance' ? 1 : 1.5);
-      node.select('.node-circle').attr('stroke-opacity', 1).attr('fill-opacity', 1);
-      node.select('.node-label-text').attr('fill-opacity', 1);
-    });
-
-    node.on('click', (event, d) => {
-      event.stopPropagation();
-      showDetail(d);
-    });
-
-    svg.on('click', () => closeDetail());
-
-    // --- Tick ---
-    simulation.on('tick', () => {
-      link
-        .attr('x1', d => d.source.x)
-        .attr('y1', d => d.source.y)
-        .attr('x2', d => d.target.x)
-        .attr('y2', d => d.target.y);
-
-      node.attr('transform', d => `translate(${d.x},${d.y})`);
-    });
-
-    // --- Drag ---
-    function dragStarted(event, d) {
-      if (!event.active) simulation.alphaTarget(0.3).restart();
-      d.fx = d.x;
-      d.fy = d.y;
+      render();
+      requestAnimationFrame(simulate);
     }
 
-    function dragged(event, d) {
-      d.fx = event.x;
-      d.fy = event.y;
+    function render() {
+      edges.forEach(function(e, i) {
+        edgeEls[i].setAttribute('x1', e.sourceNode.x);
+        edgeEls[i].setAttribute('y1', e.sourceNode.y);
+        edgeEls[i].setAttribute('x2', e.targetNode.x);
+        edgeEls[i].setAttribute('y2', e.targetNode.y);
+      });
+
+      nodes.forEach(function(n) {
+        n._el.setAttribute('transform', 'translate(' + n.x + ',' + n.y + ')');
+      });
     }
 
-    function dragEnded(event, d) {
-      if (!event.active) simulation.alphaTarget(0);
-      d.fx = null;
-      d.fy = null;
+    // Start simulation
+    simulate();
+
+    // --- Pan & Zoom (vanilla) ---
+    var transform = { x: 0, y: 0, k: 1 };
+
+    function applyTransform() {
+      gMain.setAttribute('transform', 'translate(' + transform.x + ',' + transform.y + ') scale(' + transform.k + ')');
     }
+
+    svg.addEventListener('wheel', function(e) {
+      e.preventDefault();
+      var scaleFactor = e.deltaY < 0 ? 1.08 : 1 / 1.08;
+      var newK = Math.max(0.2, Math.min(4, transform.k * scaleFactor));
+      // Zoom towards cursor
+      var rect = svg.getBoundingClientRect();
+      var mx = e.clientX - rect.left;
+      var my = e.clientY - rect.top;
+      transform.x = mx - (mx - transform.x) * (newK / transform.k);
+      transform.y = my - (my - transform.y) * (newK / transform.k);
+      transform.k = newK;
+      applyTransform();
+    }, { passive: false });
+
+    // Pan
+    var isPanning = false;
+    var panStart = { x: 0, y: 0 };
+
+    svg.addEventListener('mousedown', function(e) {
+      if (e.target === svg || e.target === bg) {
+        isPanning = true;
+        panStart.x = e.clientX - transform.x;
+        panStart.y = e.clientY - transform.y;
+        svg.style.cursor = 'grabbing';
+      }
+    });
+
+    window.addEventListener('mousemove', function(e) {
+      if (isPanning) {
+        transform.x = e.clientX - panStart.x;
+        transform.y = e.clientY - panStart.y;
+        applyTransform();
+      }
+    });
+
+    window.addEventListener('mouseup', function() {
+      isPanning = false;
+      svg.style.cursor = '';
+    });
+
+    // --- Node Drag ---
+    var dragNode = null;
+
+    nodes.forEach(function(n) {
+      n._el.addEventListener('mousedown', function(e) {
+        e.stopPropagation();
+        dragNode = n;
+        n.fx = n.x;
+        n.fy = n.y;
+        // Reheat simulation
+        alpha = 0.3;
+        simulate();
+      });
+    });
+
+    window.addEventListener('mousemove', function(e) {
+      if (dragNode) {
+        var rect = svg.getBoundingClientRect();
+        dragNode.fx = (e.clientX - rect.left - transform.x) / transform.k;
+        dragNode.fy = (e.clientY - rect.top - transform.y) / transform.k;
+      }
+    });
+
+    window.addEventListener('mouseup', function() {
+      if (dragNode) {
+        dragNode.fx = null;
+        dragNode.fy = null;
+        dragNode = null;
+      }
+    });
+
+    // --- Tooltip ---
+    var tooltip = document.getElementById('tooltip');
+    var ttLabel = tooltip.querySelector('.tt-label');
+    var ttRole = tooltip.querySelector('.tt-role');
+
+    nodes.forEach(function(n) {
+      n._el.addEventListener('mouseenter', function() {
+        var color = nodeColor(n.achse);
+        ttLabel.textContent = n.label;
+        ttLabel.style.color = color;
+        ttRole.textContent = n.role;
+        tooltip.classList.add('visible');
+
+        // Highlight: find connected IDs
+        var connected = {};
+        connected[n.id] = true;
+        edges.forEach(function(e) {
+          if (e.sourceNode.id === n.id) connected[e.targetNode.id] = true;
+          if (e.targetNode.id === n.id) connected[e.sourceNode.id] = true;
+        });
+
+        // Dim unconnected
+        edges.forEach(function(e, i) {
+          var isConn = (e.sourceNode.id === n.id || e.targetNode.id === n.id);
+          edgeEls[i].setAttribute('stroke-opacity', isConn ? '1' : '0.08');
+          edgeEls[i].setAttribute('stroke-width', isConn ? '2.5' : '1');
+        });
+
+        nodes.forEach(function(nn) {
+          var opacity = connected[nn.id] ? '1' : '0.2';
+          nn._circle.setAttribute('stroke-opacity', opacity);
+          nn._circle.setAttribute('fill-opacity', connected[nn.id] ? '1' : '0.3');
+          nn._label.setAttribute('fill-opacity', connected[nn.id] ? '1' : '0.3');
+        });
+      });
+
+      n._el.addEventListener('mousemove', function(e) {
+        tooltip.style.left = (e.clientX + 16) + 'px';
+        tooltip.style.top = (e.clientY - 10) + 'px';
+      });
+
+      n._el.addEventListener('mouseleave', function() {
+        tooltip.classList.remove('visible');
+        // Restore
+        edges.forEach(function(e, i) {
+          edgeEls[i].setAttribute('stroke-opacity', '1');
+          edgeEls[i].setAttribute('stroke-width', e.type === 'governance' ? '1' : '1.5');
+        });
+        nodes.forEach(function(nn) {
+          nn._circle.setAttribute('stroke-opacity', '1');
+          nn._circle.setAttribute('fill-opacity', '1');
+          nn._label.setAttribute('fill-opacity', '1');
+        });
+      });
+
+      // Click → detail panel
+      n._el.addEventListener('click', function(e) {
+        e.stopPropagation();
+        showDetail(n);
+      });
+    });
+
+    // Close detail on background click
+    svg.addEventListener('click', function(e) {
+      if (e.target === svg || e.target === bg) closeDetail();
+    });
 
     // --- Detail Panel ---
-    const detailPanel = document.getElementById('detail-panel');
+    var detailPanel = document.getElementById('detail-panel');
+
+    document.getElementById('close-detail-btn').addEventListener('click', closeDetail);
 
     function showDetail(d) {
-      const color = (achsen[d.achse] || { color: '#64748b', label: d.achse }).color;
-      const achseLabel = (achsen[d.achse] || { label: d.achse }).label;
+      var color = nodeColor(d.achse);
+      var achseLabel = (achsen[d.achse] || { label: d.achse }).label;
 
       document.getElementById('dp-label').textContent = d.label;
       document.getElementById('dp-label').style.color = color;
       document.getElementById('dp-role').textContent = d.role;
 
-      const achseEl = document.getElementById('dp-achse');
+      var achseEl = document.getElementById('dp-achse');
       achseEl.textContent = achseLabel;
       achseEl.style.background = color + '20';
       achseEl.style.color = color;
@@ -705,77 +859,80 @@
 
       document.getElementById('dp-desc').textContent = d.description;
 
-      // Incoming edges
-      const incoming = edges.filter(e => {
-        const tid = typeof e.target === 'object' ? e.target.id : e.target;
-        return tid === d.id;
-      });
-
-      const incomingEl = document.getElementById('dp-incoming');
-      incomingEl.innerHTML = '';
+      // Build connection lists via textContent (safe against injection)
+      var incoming = edges.filter(function(e) { return e.targetNode.id === d.id; });
+      var incomingEl = document.getElementById('dp-incoming');
+      incomingEl.textContent = '';
       if (incoming.length === 0) {
-        incomingEl.innerHTML = '<div style="font-size: 0.8em; color: var(--text-muted); padding: 4px 0;">Keine</div>';
+        var empty = document.createElement('div');
+        empty.style.cssText = 'font-size: 0.8em; color: #64748b; padding: 4px 0;';
+        empty.textContent = 'Keine';
+        incomingEl.appendChild(empty);
       } else {
-        incoming.forEach(e => {
-          const sourceNode = nodes.find(n => n.id === (typeof e.source === 'object' ? e.source.id : e.source));
-          const item = document.createElement('div');
-          item.className = 'connection-item';
-          item.innerHTML = `
-            <span class="connection-arrow">←</span>
-            <div class="connection-details">
-              <div class="connection-target">${sourceNode ? sourceNode.label : e.source}</div>
-              <div class="connection-contract">${e.contract}</div>
-            </div>
-          `;
-          incomingEl.appendChild(item);
+        incoming.forEach(function(e) {
+          incomingEl.appendChild(createConnectionItem('←', e.sourceNode.label, e.contract));
         });
       }
 
-      // Outgoing edges
-      const outgoing = edges.filter(e => {
-        const sid = typeof e.source === 'object' ? e.source.id : e.source;
-        return sid === d.id;
-      });
-
-      const outgoingEl = document.getElementById('dp-outgoing');
-      outgoingEl.innerHTML = '';
+      var outgoing = edges.filter(function(e) { return e.sourceNode.id === d.id; });
+      var outgoingEl = document.getElementById('dp-outgoing');
+      outgoingEl.textContent = '';
       if (outgoing.length === 0) {
-        outgoingEl.innerHTML = '<div style="font-size: 0.8em; color: var(--text-muted); padding: 4px 0;">Keine</div>';
+        var emptyOut = document.createElement('div');
+        emptyOut.style.cssText = 'font-size: 0.8em; color: #64748b; padding: 4px 0;';
+        emptyOut.textContent = 'Keine';
+        outgoingEl.appendChild(emptyOut);
       } else {
-        outgoing.forEach(e => {
-          const targetNode = nodes.find(n => n.id === (typeof e.target === 'object' ? e.target.id : e.target));
-          const item = document.createElement('div');
-          item.className = 'connection-item';
-          item.innerHTML = `
-            <span class="connection-arrow">→</span>
-            <div class="connection-details">
-              <div class="connection-target">${targetNode ? targetNode.label : e.target}</div>
-              <div class="connection-contract">${e.contract}</div>
-            </div>
-          `;
-          outgoingEl.appendChild(item);
+        outgoing.forEach(function(e) {
+          outgoingEl.appendChild(createConnectionItem('→', e.targetNode.label, e.contract));
         });
       }
 
       detailPanel.classList.add('visible');
     }
 
+    function createConnectionItem(arrow, targetLabel, contract) {
+      var item = document.createElement('div');
+      item.className = 'connection-item';
+
+      var arrowSpan = document.createElement('span');
+      arrowSpan.className = 'connection-arrow';
+      arrowSpan.textContent = arrow;
+
+      var details = document.createElement('div');
+      details.className = 'connection-details';
+
+      var targetDiv = document.createElement('div');
+      targetDiv.className = 'connection-target';
+      targetDiv.textContent = targetLabel;
+
+      var contractDiv = document.createElement('div');
+      contractDiv.className = 'connection-contract';
+      contractDiv.textContent = contract;
+
+      details.appendChild(targetDiv);
+      details.appendChild(contractDiv);
+      item.appendChild(arrowSpan);
+      item.appendChild(details);
+      return item;
+    }
+
     function closeDetail() {
       detailPanel.classList.remove('visible');
     }
 
-    // Make closeDetail globally accessible for the inline onclick
-    window.closeDetail = closeDetail;
-
     // --- Responsive ---
-    window.addEventListener('resize', () => {
-      const w = window.innerWidth;
-      const h = window.innerHeight;
-      svg.attr('viewBox', [0, 0, w, h]);
-      simulation.force('center', d3.forceCenter(w / 2, h / 2));
-      simulation.force('x', d3.forceX(w / 2).strength(0.04));
-      simulation.force('y', d3.forceY(h / 2).strength(0.04));
-      simulation.alpha(0.3).restart();
+    window.addEventListener('resize', function() {
+      var w = window.innerWidth;
+      var h = window.innerHeight;
+      svg.setAttribute('viewBox', '0 0 ' + w + ' ' + h);
+      bg.setAttribute('width', w);
+      bg.setAttribute('height', h);
+      cx = w / 2;
+      cy = h / 2;
+      // Gentle reheat
+      alpha = 0.15;
+      simulate();
     });
   </script>
 

--- a/src/views/anatomy.ejs
+++ b/src/views/anatomy.ejs
@@ -410,13 +410,16 @@
     Implements a minimal force simulation (repulsion + link spring + centering)
     and renders to SVG via direct DOM manipulation.
   -->
+
+  <!-- Safe JSON data embed: <script type="application/json"> is never executed by the browser.
+       Using <%- %> for raw JSON output; only </script> sequences are neutralized. -->
+  <script type="application/json" id="anatomy-data"><%- JSON.stringify({ nodes: anatomy.nodes, edges: anatomy.edges, achsen: anatomy.achsen }).replace(/<\//g, '<\\/') %></script>
+
   <script>
     // --- Hardened data injection ---
-    // Neutralize </script> and similar sequences that could break out of script context.
-    // Using EJS unescaped output (<%- %>) for valid JSON, then replacing dangerous sequences.
-    var graphData = JSON.parse(
-      '<%= JSON.stringify({ nodes: anatomy.nodes, edges: anatomy.edges, achsen: anatomy.achsen }).replace(/\\/g, "\\\\").replace(/'/g, "\\'").replace(/<\\//g, "<\\/").replace(/\\u2028/g, "\\\\u2028").replace(/\\u2029/g, "\\\\u2029") %>'
-    );
+    // Read from the inert application/json script block via textContent.
+    // This avoids any HTML-escaping issues that would break JSON.parse().
+    var graphData = JSON.parse(document.getElementById('anatomy-data').textContent);
 
     var nodes = graphData.nodes.map(function(n) {
       return { id: n.id, label: n.label, role: n.role, achse: n.achse, description: n.description, x: 0, y: 0, vx: 0, vy: 0, fx: null, fy: null };

--- a/src/views/anatomy.ejs
+++ b/src/views/anatomy.ejs
@@ -1,0 +1,801 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Anatomie – Leitstand</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Structural topology of the Heimgewebe organism – interactive graph of all organs and their contract-based relationships.">
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg-primary: #0a0e1a;
+      --bg-secondary: #111827;
+      --bg-card: rgba(17, 24, 39, 0.85);
+      --bg-glass: rgba(255, 255, 255, 0.04);
+      --border-glass: rgba(255, 255, 255, 0.08);
+      --border-active: rgba(255, 255, 255, 0.15);
+      --text-primary: #f1f5f9;
+      --text-secondary: #94a3b8;
+      --text-muted: #64748b;
+      --accent: #3b82f6;
+      --glow-strength: 0.35;
+    }
+
+    body {
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+      background: var(--bg-primary);
+      color: var(--text-primary);
+      overflow: hidden;
+      height: 100vh;
+      width: 100vw;
+    }
+
+    /* Navigation Bar */
+    nav {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      z-index: 100;
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      padding: 10px 20px;
+      background: rgba(10, 14, 26, 0.92);
+      backdrop-filter: blur(20px);
+      -webkit-backdrop-filter: blur(20px);
+      border-bottom: 1px solid var(--border-glass);
+    }
+
+    nav a {
+      text-decoration: none;
+      color: var(--text-secondary);
+      font-size: 0.82em;
+      font-weight: 500;
+      padding: 6px 14px;
+      border-radius: 6px;
+      transition: all 0.2s ease;
+    }
+
+    nav a:hover { color: var(--text-primary); background: var(--bg-glass); }
+    nav a.active { color: var(--accent); background: rgba(59, 130, 246, 0.1); }
+
+    nav .title {
+      font-weight: 700;
+      font-size: 0.9em;
+      color: var(--text-primary);
+      margin-right: 16px;
+      letter-spacing: -0.01em;
+    }
+
+    /* Graph Canvas */
+    #graph-container {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100vw;
+      height: 100vh;
+    }
+
+    #graph-container svg {
+      width: 100%;
+      height: 100%;
+    }
+
+    /* Legend Panel */
+    #legend {
+      position: fixed;
+      bottom: 24px;
+      left: 24px;
+      z-index: 50;
+      background: var(--bg-card);
+      backdrop-filter: blur(16px);
+      -webkit-backdrop-filter: blur(16px);
+      border: 1px solid var(--border-glass);
+      border-radius: 14px;
+      padding: 18px 22px;
+      min-width: 220px;
+      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+    }
+
+    #legend h3 {
+      font-size: 0.72em;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--text-muted);
+      margin-bottom: 12px;
+    }
+
+    .legend-item {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin-bottom: 7px;
+      font-size: 0.82em;
+      color: var(--text-secondary);
+    }
+
+    .legend-dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      flex-shrink: 0;
+    }
+
+    .legend-section { margin-top: 14px; }
+    .legend-section h4 {
+      font-size: 0.68em;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--text-muted);
+      margin-bottom: 8px;
+    }
+
+    .legend-line {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin-bottom: 5px;
+      font-size: 0.78em;
+      color: var(--text-secondary);
+    }
+
+    .legend-line-sample {
+      width: 24px;
+      height: 2px;
+      flex-shrink: 0;
+      border-radius: 1px;
+    }
+
+    /* Detail Panel */
+    #detail-panel {
+      position: fixed;
+      top: 60px;
+      right: 24px;
+      z-index: 50;
+      background: var(--bg-card);
+      backdrop-filter: blur(16px);
+      -webkit-backdrop-filter: blur(16px);
+      border: 1px solid var(--border-glass);
+      border-radius: 14px;
+      padding: 24px;
+      width: 340px;
+      max-height: calc(100vh - 100px);
+      overflow-y: auto;
+      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+      transform: translateX(400px);
+      opacity: 0;
+      transition: transform 0.3s cubic-bezier(0.16, 1, 0.3, 1), opacity 0.3s ease;
+    }
+
+    #detail-panel.visible {
+      transform: translateX(0);
+      opacity: 1;
+    }
+
+    #detail-panel .close-btn {
+      position: absolute;
+      top: 14px;
+      right: 16px;
+      background: none;
+      border: none;
+      color: var(--text-muted);
+      cursor: pointer;
+      font-size: 1.2em;
+      padding: 4px;
+      border-radius: 4px;
+      transition: color 0.2s;
+    }
+
+    #detail-panel .close-btn:hover { color: var(--text-primary); }
+
+    #detail-panel .node-label {
+      font-size: 1.3em;
+      font-weight: 700;
+      margin-bottom: 4px;
+      letter-spacing: -0.01em;
+    }
+
+    #detail-panel .node-role {
+      font-size: 0.85em;
+      color: var(--text-secondary);
+      margin-bottom: 12px;
+    }
+
+    #detail-panel .node-achse {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 0.75em;
+      font-weight: 500;
+      padding: 4px 10px;
+      border-radius: 20px;
+      margin-bottom: 16px;
+    }
+
+    #detail-panel .node-desc {
+      font-size: 0.85em;
+      color: var(--text-secondary);
+      line-height: 1.6;
+      margin-bottom: 20px;
+    }
+
+    #detail-panel .connections-title {
+      font-size: 0.72em;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--text-muted);
+      margin-bottom: 10px;
+    }
+
+    .connection-item {
+      display: flex;
+      align-items: flex-start;
+      gap: 10px;
+      padding: 8px 0;
+      border-bottom: 1px solid var(--border-glass);
+      font-size: 0.82em;
+    }
+
+    .connection-item:last-child { border-bottom: none; }
+
+    .connection-arrow {
+      color: var(--text-muted);
+      font-size: 0.9em;
+      flex-shrink: 0;
+      margin-top: 2px;
+    }
+
+    .connection-details {
+      flex: 1;
+    }
+
+    .connection-target {
+      color: var(--text-primary);
+      font-weight: 500;
+    }
+
+    .connection-contract {
+      color: var(--text-muted);
+      font-size: 0.9em;
+      font-family: 'SF Mono', 'Fira Code', monospace;
+    }
+
+    /* Source Badge */
+    #source-badge {
+      position: fixed;
+      bottom: 24px;
+      right: 24px;
+      z-index: 50;
+      font-size: 0.72em;
+      color: var(--text-muted);
+      background: var(--bg-card);
+      backdrop-filter: blur(16px);
+      border: 1px solid var(--border-glass);
+      border-radius: 8px;
+      padding: 8px 14px;
+    }
+
+    #source-badge .warn { color: #f59e0b; }
+
+    /* Empty State */
+    .empty-state {
+      position: fixed;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      text-align: center;
+      color: var(--text-muted);
+    }
+
+    .empty-state h2 {
+      font-size: 1.4em;
+      margin-bottom: 8px;
+      color: var(--text-secondary);
+    }
+
+    /* D3 Node Styles */
+    .node-circle {
+      cursor: pointer;
+      transition: filter 0.2s ease;
+    }
+
+    .node-label-text {
+      font-family: 'Inter', sans-serif;
+      font-size: 11px;
+      font-weight: 500;
+      fill: var(--text-primary);
+      pointer-events: none;
+      text-anchor: middle;
+      dominant-baseline: central;
+      text-shadow: 0 1px 4px rgba(0, 0, 0, 0.8), 0 0 8px rgba(0, 0, 0, 0.6);
+    }
+
+    .edge-line {
+      stroke-linecap: round;
+    }
+
+    .edge-label {
+      font-family: 'Inter', sans-serif;
+      font-size: 9px;
+      fill: var(--text-muted);
+      pointer-events: none;
+      text-anchor: middle;
+    }
+
+    /* Tooltip */
+    #tooltip {
+      position: fixed;
+      z-index: 200;
+      background: rgba(17, 24, 39, 0.95);
+      backdrop-filter: blur(12px);
+      border: 1px solid var(--border-active);
+      border-radius: 10px;
+      padding: 12px 16px;
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.15s ease;
+      max-width: 260px;
+      box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+    }
+
+    #tooltip.visible { opacity: 1; }
+
+    #tooltip .tt-label {
+      font-size: 0.9em;
+      font-weight: 600;
+      margin-bottom: 3px;
+    }
+
+    #tooltip .tt-role {
+      font-size: 0.78em;
+      color: var(--text-secondary);
+    }
+
+    /* Scrollbar */
+    ::-webkit-scrollbar { width: 4px; }
+    ::-webkit-scrollbar-track { background: transparent; }
+    ::-webkit-scrollbar-thumb { background: var(--border-glass); border-radius: 2px; }
+  </style>
+</head>
+<body>
+  <nav>
+    <span class="title">Leitstand</span>
+    <a href="/">Home</a>
+    <a href="/observatory">Observatorium</a>
+    <a href="/anatomy" class="active">Anatomie</a>
+    <a href="/timeline">Zeitachse</a>
+    <a href="/ops">Ops</a>
+  </nav>
+
+  <div id="tooltip">
+    <div class="tt-label"></div>
+    <div class="tt-role"></div>
+  </div>
+
+  <% if (anatomy && anatomy.nodes && anatomy.nodes.length > 0) { %>
+
+  <div id="graph-container"></div>
+
+  <!-- Legend -->
+  <div id="legend">
+    <h3>Achsen</h3>
+    <% if (anatomy.achsen) { %>
+      <% Object.entries(anatomy.achsen).forEach(function([key, achse]) { %>
+        <div class="legend-item">
+          <div class="legend-dot" style="background: <%= achse.color %>; box-shadow: 0 0 6px <%= achse.color %>50;"></div>
+          <span><%= achse.label %></span>
+        </div>
+      <% }); %>
+    <% } %>
+
+    <div class="legend-section">
+      <h4>Kanten</h4>
+      <div class="legend-line">
+        <div class="legend-line-sample" style="background: rgba(148, 163, 184, 0.4);"></div>
+        <span>Datenfluss</span>
+      </div>
+      <div class="legend-line">
+        <div class="legend-line-sample" style="background: rgba(239, 68, 68, 0.5);"></div>
+        <span>Steuerung</span>
+      </div>
+      <div class="legend-line">
+        <div class="legend-line-sample" style="background: rgba(139, 92, 246, 0.5); border-top: 1px dashed rgba(139, 92, 246, 0.5); height: 0;"></div>
+        <span>Governance</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- Detail Panel -->
+  <div id="detail-panel">
+    <button class="close-btn" onclick="closeDetail()" title="Schließen">&times;</button>
+    <div class="node-label" id="dp-label"></div>
+    <div class="node-role" id="dp-role"></div>
+    <div class="node-achse" id="dp-achse"></div>
+    <div class="node-desc" id="dp-desc"></div>
+    <div class="connections-title">Eingehend</div>
+    <div id="dp-incoming"></div>
+    <div class="connections-title" style="margin-top: 16px;">Ausgehend</div>
+    <div id="dp-outgoing"></div>
+  </div>
+
+  <!-- Source Badge -->
+  <div id="source-badge">
+    <% if (view_meta.source_kind === 'fixture') { %>
+      <span class="warn">⚠ Fixture-Daten</span> · Kein Artefakt vorhanden
+    <% } else { %>
+      Quelle: Artefakt
+      <% if (anatomy.generated_at) { %> · <%= anatomy.generated_at %><% } %>
+    <% } %>
+    <% if (!view_meta.schema_valid) { %>
+       · <span class="warn">Schema-Mismatch</span>
+    <% } %>
+  </div>
+
+  <!-- D3.js v7 from CDN -->
+  <script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>
+  <script>
+    // --- Data from server ---
+    const graphData = <%- JSON.stringify({ nodes: anatomy.nodes, edges: anatomy.edges, achsen: anatomy.achsen }) %>;
+
+    const nodes = graphData.nodes.map(n => ({ ...n }));
+    const edges = graphData.edges.map(e => ({ ...e }));
+    const achsen = graphData.achsen;
+
+    // --- Dimensions ---
+    const width = window.innerWidth;
+    const height = window.innerHeight;
+
+    // --- SVG Setup ---
+    const svg = d3.select('#graph-container')
+      .append('svg')
+      .attr('viewBox', [0, 0, width, height]);
+
+    // Defs for glow effects and arrow markers
+    const defs = svg.append('defs');
+
+    // Glow filter
+    const glowFilter = defs.append('filter')
+      .attr('id', 'glow')
+      .attr('x', '-50%').attr('y', '-50%')
+      .attr('width', '200%').attr('height', '200%');
+    glowFilter.append('feGaussianBlur')
+      .attr('stdDeviation', '4')
+      .attr('result', 'blur');
+    const glowMerge = glowFilter.append('feMerge');
+    glowMerge.append('feMergeNode').attr('in', 'blur');
+    glowMerge.append('feMergeNode').attr('in', 'SourceGraphic');
+
+    // Background gradient
+    const bgGrad = defs.append('radialGradient')
+      .attr('id', 'bg-gradient')
+      .attr('cx', '50%').attr('cy', '50%').attr('r', '70%');
+    bgGrad.append('stop').attr('offset', '0%').attr('stop-color', '#111827');
+    bgGrad.append('stop').attr('offset', '100%').attr('stop-color', '#0a0e1a');
+
+    svg.append('rect')
+      .attr('width', width)
+      .attr('height', height)
+      .attr('fill', 'url(#bg-gradient)');
+
+    // Arrow markers per edge type
+    const arrowColors = {
+      data: 'rgba(148, 163, 184, 0.5)',
+      control: 'rgba(239, 68, 68, 0.6)',
+      governance: 'rgba(139, 92, 246, 0.5)'
+    };
+
+    Object.entries(arrowColors).forEach(([type, color]) => {
+      defs.append('marker')
+        .attr('id', `arrow-${type}`)
+        .attr('viewBox', '0 -5 10 10')
+        .attr('refX', 28)
+        .attr('refY', 0)
+        .attr('markerWidth', 6)
+        .attr('markerHeight', 6)
+        .attr('orient', 'auto')
+        .append('path')
+        .attr('d', 'M0,-4L10,0L0,4')
+        .attr('fill', color);
+    });
+
+    // --- Zoom ---
+    const g = svg.append('g');
+
+    const zoom = d3.zoom()
+      .scaleExtent([0.2, 4])
+      .on('zoom', (event) => {
+        g.attr('transform', event.transform);
+      });
+
+    svg.call(zoom);
+
+    // Initial zoom to center
+    svg.call(zoom.transform, d3.zoomIdentity.translate(width * 0.08, height * 0.05).scale(0.9));
+
+    // --- Simulation ---
+    const simulation = d3.forceSimulation(nodes)
+      .force('link', d3.forceLink(edges).id(d => d.id).distance(180).strength(0.4))
+      .force('charge', d3.forceManyBody().strength(-800).distanceMax(600))
+      .force('center', d3.forceCenter(width / 2, height / 2))
+      .force('collision', d3.forceCollide().radius(45))
+      .force('x', d3.forceX(width / 2).strength(0.04))
+      .force('y', d3.forceY(height / 2).strength(0.04));
+
+    // --- Edge rendering ---
+    function edgeColor(type) {
+      if (type === 'control') return 'rgba(239, 68, 68, 0.35)';
+      if (type === 'governance') return 'rgba(139, 92, 246, 0.3)';
+      return 'rgba(148, 163, 184, 0.18)';
+    }
+
+    function edgeDash(type) {
+      if (type === 'governance') return '4,4';
+      return 'none';
+    }
+
+    const edgeGroup = g.append('g').attr('class', 'edges');
+
+    const link = edgeGroup.selectAll('line')
+      .data(edges)
+      .join('line')
+      .attr('class', 'edge-line')
+      .attr('stroke', d => edgeColor(d.type))
+      .attr('stroke-width', d => d.type === 'governance' ? 1 : 1.5)
+      .attr('stroke-dasharray', d => edgeDash(d.type))
+      .attr('marker-end', d => `url(#arrow-${d.type})`);
+
+    // --- Node rendering ---
+    const nodeGroup = g.append('g').attr('class', 'nodes');
+
+    const nodeRadius = 22;
+
+    const node = nodeGroup.selectAll('g')
+      .data(nodes)
+      .join('g')
+      .attr('class', 'node-group')
+      .call(d3.drag()
+        .on('start', dragStarted)
+        .on('drag', dragged)
+        .on('end', dragEnded));
+
+    // Glow ring (outer)
+    node.append('circle')
+      .attr('r', nodeRadius + 6)
+      .attr('fill', 'none')
+      .attr('stroke', d => (achsen[d.achse] || { color: '#64748b' }).color)
+      .attr('stroke-width', 1.5)
+      .attr('stroke-opacity', 0.2)
+      .attr('class', 'glow-ring');
+
+    // Main circle
+    node.append('circle')
+      .attr('r', nodeRadius)
+      .attr('fill', d => {
+        const color = (achsen[d.achse] || { color: '#64748b' }).color;
+        return color + '20'; // 12% opacity fill
+      })
+      .attr('stroke', d => (achsen[d.achse] || { color: '#64748b' }).color)
+      .attr('stroke-width', 2)
+      .attr('class', 'node-circle')
+      .attr('filter', 'url(#glow)');
+
+    // Node label (abbreviated)
+    node.append('text')
+      .attr('class', 'node-label-text')
+      .attr('dy', nodeRadius + 16)
+      .text(d => d.label);
+
+    // Node icon (first letter as fallback)
+    node.append('text')
+      .attr('class', 'node-label-text')
+      .attr('font-size', '13px')
+      .attr('font-weight', '700')
+      .attr('fill', d => (achsen[d.achse] || { color: '#64748b' }).color)
+      .text(d => d.label.substring(0, 2).toUpperCase());
+
+    // --- Tooltip ---
+    const tooltip = document.getElementById('tooltip');
+    const ttLabel = tooltip.querySelector('.tt-label');
+    const ttRole = tooltip.querySelector('.tt-role');
+
+    node.on('mouseenter', (event, d) => {
+      const color = (achsen[d.achse] || { color: '#64748b' }).color;
+      ttLabel.textContent = d.label;
+      ttLabel.style.color = color;
+      ttRole.textContent = d.role;
+      tooltip.classList.add('visible');
+
+      // Highlight connected edges
+      link.attr('stroke-opacity', e =>
+        (e.source.id === d.id || e.target.id === d.id) ? 1 : 0.15
+      ).attr('stroke-width', e =>
+        (e.source.id === d.id || e.target.id === d.id) ? 2.5 : 1
+      );
+
+      // Dim unconnected nodes
+      const connectedIds = new Set();
+      connectedIds.add(d.id);
+      edges.forEach(e => {
+        const sid = typeof e.source === 'object' ? e.source.id : e.source;
+        const tid = typeof e.target === 'object' ? e.target.id : e.target;
+        if (sid === d.id) connectedIds.add(tid);
+        if (tid === d.id) connectedIds.add(sid);
+      });
+
+      node.select('.node-circle')
+        .attr('stroke-opacity', n => connectedIds.has(n.id) ? 1 : 0.2)
+        .attr('fill-opacity', n => connectedIds.has(n.id) ? 1 : 0.3);
+
+      node.select('.node-label-text')
+        .attr('fill-opacity', n => connectedIds.has(n.id) ? 1 : 0.3);
+    });
+
+    node.on('mousemove', (event) => {
+      tooltip.style.left = (event.clientX + 16) + 'px';
+      tooltip.style.top = (event.clientY - 10) + 'px';
+    });
+
+    node.on('mouseleave', () => {
+      tooltip.classList.remove('visible');
+      // Restore
+      link.attr('stroke-opacity', 1).attr('stroke-width', d => d.type === 'governance' ? 1 : 1.5);
+      node.select('.node-circle').attr('stroke-opacity', 1).attr('fill-opacity', 1);
+      node.select('.node-label-text').attr('fill-opacity', 1);
+    });
+
+    node.on('click', (event, d) => {
+      event.stopPropagation();
+      showDetail(d);
+    });
+
+    svg.on('click', () => closeDetail());
+
+    // --- Tick ---
+    simulation.on('tick', () => {
+      link
+        .attr('x1', d => d.source.x)
+        .attr('y1', d => d.source.y)
+        .attr('x2', d => d.target.x)
+        .attr('y2', d => d.target.y);
+
+      node.attr('transform', d => `translate(${d.x},${d.y})`);
+    });
+
+    // --- Drag ---
+    function dragStarted(event, d) {
+      if (!event.active) simulation.alphaTarget(0.3).restart();
+      d.fx = d.x;
+      d.fy = d.y;
+    }
+
+    function dragged(event, d) {
+      d.fx = event.x;
+      d.fy = event.y;
+    }
+
+    function dragEnded(event, d) {
+      if (!event.active) simulation.alphaTarget(0);
+      d.fx = null;
+      d.fy = null;
+    }
+
+    // --- Detail Panel ---
+    const detailPanel = document.getElementById('detail-panel');
+
+    function showDetail(d) {
+      const color = (achsen[d.achse] || { color: '#64748b', label: d.achse }).color;
+      const achseLabel = (achsen[d.achse] || { label: d.achse }).label;
+
+      document.getElementById('dp-label').textContent = d.label;
+      document.getElementById('dp-label').style.color = color;
+      document.getElementById('dp-role').textContent = d.role;
+
+      const achseEl = document.getElementById('dp-achse');
+      achseEl.textContent = achseLabel;
+      achseEl.style.background = color + '20';
+      achseEl.style.color = color;
+      achseEl.style.border = '1px solid ' + color + '40';
+
+      document.getElementById('dp-desc').textContent = d.description;
+
+      // Incoming edges
+      const incoming = edges.filter(e => {
+        const tid = typeof e.target === 'object' ? e.target.id : e.target;
+        return tid === d.id;
+      });
+
+      const incomingEl = document.getElementById('dp-incoming');
+      incomingEl.innerHTML = '';
+      if (incoming.length === 0) {
+        incomingEl.innerHTML = '<div style="font-size: 0.8em; color: var(--text-muted); padding: 4px 0;">Keine</div>';
+      } else {
+        incoming.forEach(e => {
+          const sourceNode = nodes.find(n => n.id === (typeof e.source === 'object' ? e.source.id : e.source));
+          const item = document.createElement('div');
+          item.className = 'connection-item';
+          item.innerHTML = `
+            <span class="connection-arrow">←</span>
+            <div class="connection-details">
+              <div class="connection-target">${sourceNode ? sourceNode.label : e.source}</div>
+              <div class="connection-contract">${e.contract}</div>
+            </div>
+          `;
+          incomingEl.appendChild(item);
+        });
+      }
+
+      // Outgoing edges
+      const outgoing = edges.filter(e => {
+        const sid = typeof e.source === 'object' ? e.source.id : e.source;
+        return sid === d.id;
+      });
+
+      const outgoingEl = document.getElementById('dp-outgoing');
+      outgoingEl.innerHTML = '';
+      if (outgoing.length === 0) {
+        outgoingEl.innerHTML = '<div style="font-size: 0.8em; color: var(--text-muted); padding: 4px 0;">Keine</div>';
+      } else {
+        outgoing.forEach(e => {
+          const targetNode = nodes.find(n => n.id === (typeof e.target === 'object' ? e.target.id : e.target));
+          const item = document.createElement('div');
+          item.className = 'connection-item';
+          item.innerHTML = `
+            <span class="connection-arrow">→</span>
+            <div class="connection-details">
+              <div class="connection-target">${targetNode ? targetNode.label : e.target}</div>
+              <div class="connection-contract">${e.contract}</div>
+            </div>
+          `;
+          outgoingEl.appendChild(item);
+        });
+      }
+
+      detailPanel.classList.add('visible');
+    }
+
+    function closeDetail() {
+      detailPanel.classList.remove('visible');
+    }
+
+    // Make closeDetail globally accessible for the inline onclick
+    window.closeDetail = closeDetail;
+
+    // --- Responsive ---
+    window.addEventListener('resize', () => {
+      const w = window.innerWidth;
+      const h = window.innerHeight;
+      svg.attr('viewBox', [0, 0, w, h]);
+      simulation.force('center', d3.forceCenter(w / 2, h / 2));
+      simulation.force('x', d3.forceX(w / 2).strength(0.04));
+      simulation.force('y', d3.forceY(h / 2).strength(0.04));
+      simulation.alpha(0.3).restart();
+    });
+  </script>
+
+  <% } else { %>
+    <!-- Empty State -->
+    <div class="empty-state">
+      <h2>Keine Anatomie-Daten</h2>
+      <p>
+        <% if (view_meta.is_strict) { %>
+          Strict Mode: Anatomie-Artefakt fehlt und Fixture-Fallback ist deaktiviert.
+        <% } else { %>
+          Anatomie-Snapshot nicht gefunden.
+        <% } %>
+      </p>
+      <% if (view_meta.missing_reason) { %>
+        <p style="margin-top: 12px; font-family: monospace; font-size: 0.85em;">
+          Grund: <strong><%= view_meta.missing_reason %></strong>
+        </p>
+      <% } %>
+    </div>
+  <% } %>
+</body>
+</html>

--- a/src/views/anatomy.ejs
+++ b/src/views/anatomy.ejs
@@ -616,6 +616,7 @@
 
     // --- Force Simulation (vanilla) ---
     var alpha = 1;
+    var rafId = null;
     var alphaDecay = 0.02;
     var alphaMin = 0.001;
     var REPULSION = 12000;
@@ -625,7 +626,10 @@
     var DAMPING = 0.6;
 
     function simulate() {
-      if (alpha < alphaMin) return;
+      if (alpha < alphaMin) {
+        rafId = null;
+        return;
+      }
 
       // Repulsion (all pairs)
       for (var i = 0; i < nodes.length; i++) {
@@ -677,7 +681,15 @@
       alpha -= alphaDecay;
 
       render();
-      requestAnimationFrame(simulate);
+      rafId = requestAnimationFrame(simulate);
+    }
+
+    // Starts the simulation loop if it is not already running.
+    // Reheat callers only need to set alpha; this guard prevents
+    // multiple concurrent requestAnimationFrame loops.
+    function startSimulation() {
+      if (rafId !== null) return;
+      simulate();
     }
 
     function render() {
@@ -694,7 +706,7 @@
     }
 
     // Start simulation
-    simulate();
+    startSimulation();
 
     // --- Pan & Zoom (vanilla) ---
     var transform = { x: 0, y: 0, k: 1 };
@@ -754,7 +766,7 @@
         n.fy = n.y;
         // Reheat simulation
         alpha = 0.3;
-        simulate();
+        startSimulation();
       });
     });
 
@@ -935,7 +947,7 @@
       cy = h / 2;
       // Gentle reheat
       alpha = 0.15;
-      simulate();
+      startSimulation();
     });
   </script>
 

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -13,6 +13,8 @@
   <nav>
     <a href="/">Home</a>
     <a href="/observatory">Observatorium</a>
+    <a href="/anatomy">Anatomie</a>
+    <a href="/timeline">Zeitachse</a>
     <a href="/ops">Ops</a>
     <a href="/intent">Intent</a>
   </nav>

--- a/src/views/intent.ejs
+++ b/src/views/intent.ejs
@@ -18,6 +18,9 @@
   <nav>
     <a href="/">Home</a>
     <a href="/observatory">Observatorium</a>
+    <a href="/anatomy">Anatomie</a>
+    <a href="/timeline">Zeitachse</a>
+    <a href="/ops">Ops</a>
     <a href="/intent">Intent</a>
   </nav>
   <h1>Aktueller Intent</h1>

--- a/src/views/observatory.ejs
+++ b/src/views/observatory.ejs
@@ -27,6 +27,8 @@
   <nav>
     <a href="/">Home</a>
     <a href="/observatory">Observatorium</a>
+    <a href="/anatomy">Anatomie</a>
+    <a href="/timeline">Zeitachse</a>
     <a href="/ops">Ops</a>
   </nav>
   <h1>Observatorium</h1>

--- a/src/views/ops.ejs
+++ b/src/views/ops.ejs
@@ -59,6 +59,8 @@
   <nav>
     <a href="/">Home</a>
     <a href="/observatory">Observatorium</a>
+    <a href="/anatomy">Anatomie</a>
+    <a href="/timeline">Zeitachse</a>
     <a href="/ops">Ops</a>
   </nav>
 

--- a/src/views/timeline.ejs
+++ b/src/views/timeline.ejs
@@ -539,6 +539,7 @@
 
     // --- Detail Toggle (event delegation, no inline onclick) ---
     document.addEventListener('click', function(e) {
+      if (!(e.target instanceof Element)) return;
       var item = e.target.closest('.event-item');
       if (!item) return;
       var idx = item.dataset.index;

--- a/src/views/timeline.ejs
+++ b/src/views/timeline.ejs
@@ -1,0 +1,554 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Zeitachse – Leitstand</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Chronological event timeline of the Heimgewebe organism – all system events in temporal order.">
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
+
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg-primary: #0a0e1a;
+      --bg-secondary: #111827;
+      --bg-card: rgba(17, 24, 39, 0.85);
+      --bg-glass: rgba(255, 255, 255, 0.04);
+      --border-glass: rgba(255, 255, 255, 0.08);
+      --border-active: rgba(255, 255, 255, 0.15);
+      --text-primary: #f1f5f9;
+      --text-secondary: #94a3b8;
+      --text-muted: #64748b;
+      --accent: #3b82f6;
+    }
+
+    body {
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+      background: var(--bg-primary);
+      color: var(--text-primary);
+      min-height: 100vh;
+    }
+
+    /* Navigation */
+    nav {
+      position: sticky;
+      top: 0;
+      z-index: 100;
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      padding: 10px 20px;
+      background: rgba(10, 14, 26, 0.92);
+      backdrop-filter: blur(20px);
+      border-bottom: 1px solid var(--border-glass);
+    }
+
+    nav a {
+      text-decoration: none;
+      color: var(--text-secondary);
+      font-size: 0.82em;
+      font-weight: 500;
+      padding: 6px 14px;
+      border-radius: 6px;
+      transition: all 0.2s ease;
+    }
+
+    nav a:hover { color: var(--text-primary); background: var(--bg-glass); }
+    nav a.active { color: var(--accent); background: rgba(59, 130, 246, 0.1); }
+    nav .title { font-weight: 700; font-size: 0.9em; color: var(--text-primary); margin-right: 16px; }
+
+    /* Main Layout */
+    .main {
+      max-width: 960px;
+      margin: 0 auto;
+      padding: 32px 24px;
+    }
+
+    /* Page Header */
+    .page-header {
+      margin-bottom: 28px;
+    }
+
+    .page-header h1 {
+      font-size: 1.6em;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+      margin-bottom: 6px;
+    }
+
+    .page-header .subtitle {
+      color: var(--text-secondary);
+      font-size: 0.88em;
+    }
+
+    /* Filter Bar */
+    .filter-bar {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      flex-wrap: wrap;
+      margin-bottom: 28px;
+      padding: 16px 20px;
+      background: var(--bg-card);
+      backdrop-filter: blur(16px);
+      border: 1px solid var(--border-glass);
+      border-radius: 12px;
+    }
+
+    .filter-bar label {
+      font-size: 0.78em;
+      font-weight: 500;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .filter-bar select,
+    .filter-bar input[type="number"] {
+      background: var(--bg-secondary);
+      border: 1px solid var(--border-glass);
+      color: var(--text-primary);
+      padding: 7px 12px;
+      border-radius: 8px;
+      font-size: 0.85em;
+      font-family: 'Inter', sans-serif;
+      outline: none;
+      transition: border-color 0.2s;
+    }
+
+    .filter-bar select:focus,
+    .filter-bar input:focus {
+      border-color: var(--accent);
+    }
+
+    .filter-bar input[type="number"] { width: 70px; }
+
+    .filter-bar .spacer { flex: 1; }
+
+    .filter-bar .stats {
+      font-size: 0.82em;
+      color: var(--text-muted);
+    }
+
+    .filter-bar .stats strong {
+      color: var(--text-secondary);
+    }
+
+    /* Timeline */
+    .timeline {
+      position: relative;
+    }
+
+    .timeline::before {
+      content: '';
+      position: absolute;
+      left: 17px;
+      top: 0;
+      bottom: 0;
+      width: 2px;
+      background: linear-gradient(180deg, var(--border-glass), transparent);
+      border-radius: 1px;
+    }
+
+    /* Date Separator */
+    .date-separator {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin: 24px 0 16px 0;
+      padding-left: 40px;
+    }
+
+    .date-separator .date-badge {
+      font-size: 0.72em;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--text-muted);
+      background: var(--bg-secondary);
+      border: 1px solid var(--border-glass);
+      padding: 4px 12px;
+      border-radius: 20px;
+      white-space: nowrap;
+    }
+
+    .date-separator .line {
+      flex: 1;
+      height: 1px;
+      background: var(--border-glass);
+    }
+
+    /* Event Item */
+    .event-item {
+      display: flex;
+      align-items: flex-start;
+      gap: 16px;
+      padding: 12px 0;
+      position: relative;
+      cursor: pointer;
+      transition: background 0.15s ease;
+      border-radius: 8px;
+    }
+
+    .event-item:hover {
+      background: var(--bg-glass);
+    }
+
+    .event-item .dot-container {
+      position: relative;
+      width: 36px;
+      flex-shrink: 0;
+      display: flex;
+      justify-content: center;
+      padding-top: 3px;
+    }
+
+    .event-item .dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      border: 2px solid;
+      background: var(--bg-primary);
+      z-index: 1;
+      position: relative;
+    }
+
+    .event-item .event-content {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .event-item .event-header {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin-bottom: 4px;
+    }
+
+    .event-item .event-kind {
+      font-size: 0.82em;
+      font-weight: 600;
+      font-family: 'JetBrains Mono', monospace;
+    }
+
+    .event-item .event-repo {
+      font-size: 0.75em;
+      font-weight: 500;
+      padding: 2px 8px;
+      border-radius: 12px;
+      background: var(--bg-glass);
+      border: 1px solid var(--border-glass);
+      color: var(--text-secondary);
+      white-space: nowrap;
+    }
+
+    .event-item .event-severity {
+      font-size: 0.72em;
+      font-weight: 600;
+      padding: 2px 8px;
+      border-radius: 12px;
+      white-space: nowrap;
+    }
+
+    .event-item .severity-error {
+      background: rgba(239, 68, 68, 0.15);
+      color: #f87171;
+      border: 1px solid rgba(239, 68, 68, 0.2);
+    }
+
+    .event-item .severity-warn {
+      background: rgba(245, 158, 11, 0.15);
+      color: #fbbf24;
+      border: 1px solid rgba(245, 158, 11, 0.2);
+    }
+
+    .event-item .severity-info {
+      background: rgba(59, 130, 246, 0.15);
+      color: #60a5fa;
+      border: 1px solid rgba(59, 130, 246, 0.2);
+    }
+
+    .event-item .event-time {
+      font-size: 0.78em;
+      color: var(--text-muted);
+      font-family: 'JetBrains Mono', monospace;
+    }
+
+    /* Event Detail (expandable) */
+    .event-detail {
+      display: none;
+      margin-top: 10px;
+      padding: 14px;
+      background: var(--bg-secondary);
+      border: 1px solid var(--border-glass);
+      border-radius: 8px;
+      font-size: 0.82em;
+    }
+
+    .event-detail.expanded { display: block; }
+
+    .event-detail pre {
+      color: var(--text-secondary);
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.9em;
+      white-space: pre-wrap;
+      word-break: break-all;
+      line-height: 1.5;
+    }
+
+    .event-detail .detail-label {
+      font-size: 0.72em;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--text-muted);
+      margin-bottom: 6px;
+    }
+
+    /* Empty State */
+    .empty-state {
+      text-align: center;
+      padding: 80px 20px;
+      color: var(--text-muted);
+    }
+
+    .empty-state h2 {
+      font-size: 1.3em;
+      color: var(--text-secondary);
+      margin-bottom: 8px;
+    }
+
+    .empty-state p {
+      font-size: 0.9em;
+      max-width: 480px;
+      margin: 0 auto;
+      line-height: 1.6;
+    }
+
+    /* Source Badge */
+    .source-badge {
+      text-align: center;
+      margin-top: 32px;
+      font-size: 0.75em;
+      color: var(--text-muted);
+    }
+
+    .source-badge .warn { color: #f59e0b; }
+  </style>
+</head>
+<body>
+  <nav>
+    <span class="title">Leitstand</span>
+    <a href="/">Home</a>
+    <a href="/observatory">Observatorium</a>
+    <a href="/anatomy">Anatomie</a>
+    <a href="/timeline" class="active">Zeitachse</a>
+    <a href="/ops">Ops</a>
+  </nav>
+
+  <div class="main">
+    <div class="page-header">
+      <h1>Zeitachse</h1>
+      <p class="subtitle">Chronologische Ereignisse des Heimgewebe-Organismus</p>
+    </div>
+
+    <% if (events && events.length > 0) { %>
+      <!-- Filter Bar -->
+      <div class="filter-bar" id="filterBar">
+        <label for="filterKind">Typ</label>
+        <select id="filterKind">
+          <option value="">Alle</option>
+          <% const kinds = [...new Set(events.map(e => e.kind))].sort(); %>
+          <% kinds.forEach(function(k) { %>
+            <option value="<%= k %>"><%= k %></option>
+          <% }); %>
+        </select>
+
+        <label for="filterRepo">Repo</label>
+        <select id="filterRepo">
+          <option value="">Alle</option>
+          <% const repos = [...new Set(events.filter(e => e.repo).map(e => e.repo))].sort(); %>
+          <% repos.forEach(function(r) { %>
+            <option value="<%= r %>"><%= r %></option>
+          <% }); %>
+        </select>
+
+        <label for="filterSeverity">Severity</label>
+        <select id="filterSeverity">
+          <option value="">Alle</option>
+          <option value="error">Error</option>
+          <option value="warn">Warn</option>
+          <option value="info">Info</option>
+        </select>
+
+        <div class="spacer"></div>
+
+        <div class="stats">
+          <strong id="visibleCount"><%= events.length %></strong> / <%= events.length %> Events
+        </div>
+      </div>
+
+      <!-- Filterable Timeline -->
+      <div class="timeline" id="timeline">
+        <%
+          let lastDate = '';
+          const kindColors = {};
+          const colorPalette = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#ec4899', '#06b6d4', '#f97316', '#14b8a6', '#6366f1'];
+          let colorIdx = 0;
+        %>
+        <% events.forEach(function(event, i) { %>
+          <%
+            const dt = new Date(event.timestamp);
+            const dateStr = dt.toISOString().split('T')[0];
+            const timeStr = dt.toISOString().split('T')[1].replace('Z', '').substring(0, 8);
+
+            // Assign color by kind
+            if (!kindColors[event.kind]) {
+              kindColors[event.kind] = colorPalette[colorIdx % colorPalette.length];
+              colorIdx++;
+            }
+            const dotColor = kindColors[event.kind];
+
+            const severityClass = event.severity === 'error' ? 'severity-error'
+              : event.severity === 'warn' ? 'severity-warn'
+              : event.severity === 'info' ? 'severity-info'
+              : '';
+          %>
+
+          <% if (dateStr !== lastDate) { %>
+            <div class="date-separator">
+              <div class="date-badge"><%= dateStr %></div>
+              <div class="line"></div>
+            </div>
+            <% lastDate = dateStr; %>
+          <% } %>
+
+          <div class="event-item"
+               data-kind="<%= event.kind %>"
+               data-repo="<%= event.repo || '' %>"
+               data-severity="<%= event.severity || '' %>"
+               onclick="toggleDetail(<%= i %>)">
+            <div class="dot-container">
+              <div class="dot" style="border-color: <%= dotColor %>;"></div>
+            </div>
+            <div class="event-content">
+              <div class="event-header">
+                <span class="event-kind" style="color: <%= dotColor %>;"><%= event.kind %></span>
+                <% if (event.repo) { %>
+                  <span class="event-repo"><%= event.repo %></span>
+                <% } %>
+                <% if (event.severity) { %>
+                  <span class="event-severity <%= severityClass %>"><%= event.severity %></span>
+                <% } %>
+              </div>
+              <div class="event-time"><%= timeStr %></div>
+              <div class="event-detail" id="detail-<%= i %>">
+                <% if (event.job) { %>
+                  <div class="detail-label">Job</div>
+                  <pre><%= event.job %></pre>
+                <% } %>
+                <% if (event.payload && Object.keys(event.payload).length > 0) { %>
+                  <div class="detail-label" style="<%= event.job ? 'margin-top: 10px;' : '' %>">Payload</div>
+                  <pre><%= JSON.stringify(event.payload, null, 2) %></pre>
+                <% } %>
+                <% if (!event.job && (!event.payload || Object.keys(event.payload).length === 0)) { %>
+                  <div style="color: var(--text-muted); font-style: italic;">Keine weiteren Details</div>
+                <% } %>
+              </div>
+            </div>
+          </div>
+        <% }); %>
+      </div>
+
+      <div class="source-badge">
+        <% if (view_meta.source_kind === 'fixture') { %>
+          <span class="warn">⚠ Fixture-Daten</span> · Chronik nicht erreichbar
+        <% } else { %>
+          Quelle: Chronik · <%= events.length %> Events
+        <% } %>
+        · Zeitfenster: <%= view_meta.since %> – <%= view_meta.until %>
+      </div>
+
+    <% } else { %>
+      <div class="empty-state">
+        <h2>Keine Events</h2>
+        <p>
+          <% if (view_meta.is_strict) { %>
+            Strict Mode: Chronik-Daten nicht verfügbar und Fixture-Fallback ist deaktiviert.
+          <% } else if (view_meta.missing_reason) { %>
+            <%= view_meta.missing_reason %>
+          <% } else { %>
+            Im gewählten Zeitfenster wurden keine Events gefunden.
+          <% } %>
+        </p>
+      </div>
+    <% } %>
+  </div>
+
+  <script>
+    // --- Filtering ---
+    const filterKind = document.getElementById('filterKind');
+    const filterRepo = document.getElementById('filterRepo');
+    const filterSeverity = document.getElementById('filterSeverity');
+    const visibleCount = document.getElementById('visibleCount');
+    const timeline = document.getElementById('timeline');
+
+    function applyFilters() {
+      if (!timeline) return;
+
+      const kind = filterKind ? filterKind.value : '';
+      const repo = filterRepo ? filterRepo.value : '';
+      const severity = filterSeverity ? filterSeverity.value : '';
+
+      const items = timeline.querySelectorAll('.event-item');
+      let count = 0;
+
+      items.forEach(item => {
+        const matchKind = !kind || item.dataset.kind === kind;
+        const matchRepo = !repo || item.dataset.repo === repo;
+        const matchSev = !severity || item.dataset.severity === severity;
+
+        if (matchKind && matchRepo && matchSev) {
+          item.style.display = '';
+          count++;
+        } else {
+          item.style.display = 'none';
+        }
+      });
+
+      // Show/hide date separators based on visible events
+      const separators = timeline.querySelectorAll('.date-separator');
+      separators.forEach(sep => {
+        let next = sep.nextElementSibling;
+        let hasVisible = false;
+        while (next && !next.classList.contains('date-separator')) {
+          if (next.classList.contains('event-item') && next.style.display !== 'none') {
+            hasVisible = true;
+            break;
+          }
+          next = next.nextElementSibling;
+        }
+        sep.style.display = hasVisible ? '' : 'none';
+      });
+
+      if (visibleCount) visibleCount.textContent = count;
+    }
+
+    if (filterKind) filterKind.addEventListener('change', applyFilters);
+    if (filterRepo) filterRepo.addEventListener('change', applyFilters);
+    if (filterSeverity) filterSeverity.addEventListener('change', applyFilters);
+
+    // --- Detail Toggle ---
+    function toggleDetail(idx) {
+      const el = document.getElementById('detail-' + idx);
+      if (el) {
+        el.classList.toggle('expanded');
+      }
+    }
+
+    // Make toggleDetail globally accessible
+    window.toggleDetail = toggleDetail;
+  </script>
+</body>
+</html>

--- a/src/views/timeline.ejs
+++ b/src/views/timeline.ejs
@@ -6,8 +6,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Chronological event timeline of the Heimgewebe organism – all system events in temporal order.">
   <style>
-    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
-
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
     :root {
@@ -24,7 +22,7 @@
     }
 
     body {
-      font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
       background: var(--bg-primary);
       color: var(--text-primary);
       min-height: 100vh;
@@ -112,7 +110,7 @@
       padding: 7px 12px;
       border-radius: 8px;
       font-size: 0.85em;
-      font-family: 'Inter', sans-serif;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
       outline: none;
       transition: border-color 0.2s;
     }
@@ -229,7 +227,7 @@
     .event-item .event-kind {
       font-size: 0.82em;
       font-weight: 600;
-      font-family: 'JetBrains Mono', monospace;
+      font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', 'Menlo', monospace;
     }
 
     .event-item .event-repo {
@@ -272,7 +270,7 @@
     .event-item .event-time {
       font-size: 0.78em;
       color: var(--text-muted);
-      font-family: 'JetBrains Mono', monospace;
+      font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', 'Menlo', monospace;
     }
 
     /* Event Detail (expandable) */
@@ -290,7 +288,7 @@
 
     .event-detail pre {
       color: var(--text-secondary);
-      font-family: 'JetBrains Mono', monospace;
+      font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', 'Menlo', monospace;
       font-size: 0.9em;
       white-space: pre-wrap;
       word-break: break-all;
@@ -428,7 +426,7 @@
                data-kind="<%= event.kind %>"
                data-repo="<%= event.repo || '' %>"
                data-severity="<%= event.severity || '' %>"
-               onclick="toggleDetail(<%= i %>)">
+               data-index="<%= i %>">
             <div class="dot-container">
               <div class="dot" style="border-color: <%= dotColor %>;"></div>
             </div>
@@ -539,16 +537,15 @@
     if (filterRepo) filterRepo.addEventListener('change', applyFilters);
     if (filterSeverity) filterSeverity.addEventListener('change', applyFilters);
 
-    // --- Detail Toggle ---
-    function toggleDetail(idx) {
-      const el = document.getElementById('detail-' + idx);
-      if (el) {
-        el.classList.toggle('expanded');
-      }
-    }
-
-    // Make toggleDetail globally accessible
-    window.toggleDetail = toggleDetail;
+    // --- Detail Toggle (event delegation, no inline onclick) ---
+    document.addEventListener('click', function(e) {
+      var item = e.target.closest('.event-item');
+      if (!item) return;
+      var idx = item.dataset.index;
+      if (idx === undefined) return;
+      var el = document.getElementById('detail-' + idx);
+      if (el) el.classList.toggle('expanded');
+    });
   </script>
 </body>
 </html>

--- a/src/views/timeline.ejs
+++ b/src/views/timeline.ejs
@@ -474,10 +474,10 @@
         <p>
           <% if (view_meta.is_strict) { %>
             Strict Mode: Chronik-Daten nicht verfügbar und Fixture-Fallback ist deaktiviert.
-          <% } else if (view_meta.missing_reason) { %>
-            <%= view_meta.missing_reason %>
-          <% } else { %>
+          <% } else if (view_meta.window_state === 'empty_window') { %>
             Im gewählten Zeitfenster wurden keine Events gefunden.
+          <% } else { %>
+            Keine Daten verfügbar.
           <% } %>
         </p>
       </div>

--- a/tests/controllers/anatomy.test.ts
+++ b/tests/controllers/anatomy.test.ts
@@ -96,4 +96,27 @@ describe('getAnatomyData controller', () => {
     expect(callArgs[1]).toContain('anatomy.snapshot.json');
     expect(callArgs[2]).toMatchObject({ name: 'Anatomy' });
   });
+
+  it('should reject structurally invalid data (missing nodes) and return null anatomy', async () => {
+    vi.mocked(loadWithFallback).mockResolvedValue({
+      data: {
+        schema: 'anatomy.snapshot.v1',
+        generated_at: '2026-03-28T00:00:00Z',
+        source: 'fixture',
+        // nodes is empty → structural validation fails
+        nodes: [],
+        edges: [],
+        achsen: {},
+      },
+      source: 'fixture',
+      reason: 'enoent',
+    });
+
+    const result = await getAnatomyData();
+
+    expect(result.anatomy).toBeNull();
+    expect(result.view_meta.schema_valid).toBe(false);
+    expect(result.view_meta.missing_reason).toContain('invalid_structure');
+    expect(console.warn).toHaveBeenCalled();
+  });
 });

--- a/tests/controllers/anatomy.test.ts
+++ b/tests/controllers/anatomy.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getAnatomyData } from '../../src/controllers/anatomy.js';
+import { resetEnvConfig } from '../../src/config.js';
+import { loadWithFallback } from '../../src/utils/loader.js';
+
+vi.mock('../../src/utils/loader.js', () => ({
+  loadWithFallback: vi.fn(),
+}));
+
+describe('getAnatomyData controller', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    resetEnvConfig();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should return anatomy data from fixture fallback', async () => {
+    vi.mocked(loadWithFallback).mockResolvedValue({
+      data: {
+        schema: 'anatomy.snapshot.v1',
+        generated_at: '2026-03-28T00:00:00Z',
+        source: 'fixture',
+        nodes: [{ id: 'leitstand', label: 'Leitstand', role: 'UI', achse: 'interface', description: 'test' }],
+        edges: [],
+        achsen: { interface: { label: 'Interface', color: '#3B82F6', description: 'UI' } },
+      },
+      source: 'fixture',
+      reason: 'enoent',
+    });
+
+    const result = await getAnatomyData();
+
+    expect(result.anatomy).not.toBeNull();
+    expect(result.anatomy!.nodes).toHaveLength(1);
+    expect(result.anatomy!.nodes[0].id).toBe('leitstand');
+    expect(result.view_meta.source_kind).toBe('fixture');
+    expect(result.view_meta.schema_valid).toBe(true);
+  });
+
+  it('should mark schema_valid=false on schema mismatch without throwing', async () => {
+    vi.mocked(loadWithFallback).mockResolvedValue({
+      data: {
+        schema: 'anatomy.snapshot.v2',
+        generated_at: '2026-03-28T00:00:00Z',
+        source: 'artifact',
+        nodes: [{ id: 'x', label: 'X', role: 'x', achse: 'x', description: 'x' }],
+        edges: [],
+        achsen: {},
+      },
+      source: 'artifact',
+      reason: 'ok',
+    });
+
+    const result = await getAnatomyData();
+
+    expect(result.anatomy).not.toBeNull();
+    expect(result.view_meta.schema_valid).toBe(false);
+    // Controller should warn, not throw
+    expect(console.warn).toHaveBeenCalled();
+    expect(vi.mocked(console.warn).mock.calls.some((args) =>
+      String(args[0]).includes('[Anatomy] Schema mismatch')
+    )).toBe(true);
+  });
+
+  it('should return null anatomy when data is missing', async () => {
+    vi.mocked(loadWithFallback).mockResolvedValue({
+      data: null,
+      source: 'missing',
+      reason: 'enoent',
+    });
+
+    const result = await getAnatomyData();
+
+    expect(result.anatomy).toBeNull();
+    expect(result.view_meta.source_kind).toBe('missing');
+    expect(result.view_meta.schema_valid).toBe(false);
+  });
+
+  it('should call loadWithFallback with correct paths and name', async () => {
+    vi.mocked(loadWithFallback).mockResolvedValue({
+      data: null,
+      source: 'missing',
+      reason: 'enoent',
+    });
+
+    await getAnatomyData();
+
+    expect(loadWithFallback).toHaveBeenCalledTimes(1);
+    const callArgs = vi.mocked(loadWithFallback).mock.calls[0];
+    expect(callArgs[0]).toContain('anatomy.snapshot.json');
+    expect(callArgs[1]).toContain('anatomy.snapshot.json');
+    expect(callArgs[2]).toMatchObject({ name: 'Anatomy' });
+  });
+});

--- a/tests/controllers/timeline-streaming.test.ts
+++ b/tests/controllers/timeline-streaming.test.ts
@@ -8,7 +8,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtemp, writeFile, rm } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { loadEventsFromDir } from '../../src/controllers/timeline.js';
+import { __loadEventsFromDir } from '../../src/controllers/timeline.js';
 
 const SINCE = '2025-01-01T00:00:00.000Z';
 const UNTIL = '2027-01-01T00:00:00.000Z';
@@ -34,7 +34,7 @@ describe('loadEventsFromDir (streaming JSONL path)', () => {
     ].join('\n');
     await writeFile(join(testDir, 'events.jsonl'), lines);
 
-    const result = await loadEventsFromDir(testDir, SINCE, UNTIL, 100);
+    const result = await __loadEventsFromDir(testDir, SINCE, UNTIL, 100);
 
     expect(result).toHaveLength(1);
     expect(result[0].kind).toBe('in.window');
@@ -48,7 +48,7 @@ describe('loadEventsFromDir (streaming JSONL path)', () => {
     ].join('\n');
     await writeFile(join(testDir, 'events.jsonl'), lines);
 
-    const result = await loadEventsFromDir(testDir, SINCE, UNTIL, 100);
+    const result = await __loadEventsFromDir(testDir, SINCE, UNTIL, 100);
 
     expect(result).toHaveLength(2);
     expect(result.map((e) => e.kind).sort()).toEqual(['after.bad', 'before.bad'].sort());
@@ -61,7 +61,7 @@ describe('loadEventsFromDir (streaming JSONL path)', () => {
     ].join('\n');
     await writeFile(join(testDir, 'events.jsonl'), lines);
 
-    const result = await loadEventsFromDir(testDir, SINCE, UNTIL, 100);
+    const result = await __loadEventsFromDir(testDir, SINCE, UNTIL, 100);
 
     expect(result).toHaveLength(1);
     expect(result[0].kind).toBe('good.ts');
@@ -74,7 +74,7 @@ describe('loadEventsFromDir (streaming JSONL path)', () => {
     ].join('\n');
     await writeFile(join(testDir, 'events.jsonl'), lines);
 
-    const result = await loadEventsFromDir(testDir, SINCE, UNTIL, 100);
+    const result = await __loadEventsFromDir(testDir, SINCE, UNTIL, 100);
 
     expect(result).toHaveLength(1);
     expect(result[0].kind).toBe('has.kind');
@@ -90,7 +90,7 @@ describe('loadEventsFromDir (streaming JSONL path)', () => {
     ).join('\n');
     await writeFile(join(testDir, 'events.jsonl'), lines);
 
-    const result = await loadEventsFromDir(testDir, SINCE, UNTIL, 3);
+    const result = await __loadEventsFromDir(testDir, SINCE, UNTIL, 3);
 
     expect(result).toHaveLength(3);
   });
@@ -102,7 +102,7 @@ describe('loadEventsFromDir (streaming JSONL path)', () => {
     ].join('\n');
     await writeFile(join(testDir, 'events.jsonl'), lines);
 
-    const result = await loadEventsFromDir(testDir, SINCE, UNTIL, 100);
+    const result = await __loadEventsFromDir(testDir, SINCE, UNTIL, 100);
 
     expect(result).toHaveLength(2);
     expect(result[0].kind).toBe('newer');
@@ -119,7 +119,7 @@ describe('loadEventsFromDir (streaming JSONL path)', () => {
       JSON.stringify({ timestamp: IN_WINDOW_TS2, kind: 'file2.event', repo: 'test' })
     );
 
-    const result = await loadEventsFromDir(testDir, SINCE, UNTIL, 100);
+    const result = await __loadEventsFromDir(testDir, SINCE, UNTIL, 100);
 
     expect(result).toHaveLength(2);
     expect(result[0].kind).toBe('file2.event'); // newer first
@@ -136,14 +136,14 @@ describe('loadEventsFromDir (streaming JSONL path)', () => {
       JSON.stringify({ timestamp: IN_WINDOW_TS2, kind: 'jsonl.event', repo: 'test' })
     );
 
-    const result = await loadEventsFromDir(testDir, SINCE, UNTIL, 100);
+    const result = await __loadEventsFromDir(testDir, SINCE, UNTIL, 100);
 
     expect(result).toHaveLength(1);
     expect(result[0].kind).toBe('jsonl.event');
   });
 
   it('should return an empty array for an empty directory', async () => {
-    const result = await loadEventsFromDir(testDir, SINCE, UNTIL, 100);
+    const result = await __loadEventsFromDir(testDir, SINCE, UNTIL, 100);
     expect(result).toHaveLength(0);
   });
 
@@ -157,7 +157,7 @@ describe('loadEventsFromDir (streaming JSONL path)', () => {
     ].join('\n');
     await writeFile(join(testDir, 'events.jsonl'), lines);
 
-    const result = await loadEventsFromDir(testDir, SINCE, UNTIL, 100);
+    const result = await __loadEventsFromDir(testDir, SINCE, UNTIL, 100);
 
     expect(result.find((e) => e.kind === 'at.boundary')).toBeUndefined();
     expect(result.find((e) => e.kind === 'just.before')).toBeDefined();

--- a/tests/controllers/timeline-streaming.test.ts
+++ b/tests/controllers/timeline-streaming.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Unit tests for loadEventsFromDir — the readline streaming path.
+ *
+ * These tests use real temporary directories to exercise the actual
+ * createReadStream + readline interface, independent of any module mocks.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, writeFile, rm } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { loadEventsFromDir } from '../../src/controllers/timeline.js';
+
+const SINCE = '2025-01-01T00:00:00.000Z';
+const UNTIL = '2027-01-01T00:00:00.000Z';
+const IN_WINDOW_TS = '2026-06-01T10:00:00.000Z';
+const IN_WINDOW_TS2 = '2026-06-01T12:00:00.000Z';
+const TOO_OLD_TS = '2024-01-01T10:00:00.000Z';
+
+describe('loadEventsFromDir (streaming JSONL path)', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'leitstand-timeline-stream-'));
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it('should filter events by time window', async () => {
+    const lines = [
+      JSON.stringify({ timestamp: IN_WINDOW_TS, kind: 'in.window', repo: 'test' }),
+      JSON.stringify({ timestamp: TOO_OLD_TS, kind: 'too.old', repo: 'test' }),
+    ].join('\n');
+    await writeFile(join(testDir, 'events.jsonl'), lines);
+
+    const result = await loadEventsFromDir(testDir, SINCE, UNTIL, 100);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].kind).toBe('in.window');
+  });
+
+  it('should skip lines with invalid JSON without throwing', async () => {
+    const lines = [
+      JSON.stringify({ timestamp: IN_WINDOW_TS, kind: 'before.bad', repo: 'test' }),
+      'NOT_VALID_JSON',
+      JSON.stringify({ timestamp: IN_WINDOW_TS2, kind: 'after.bad', repo: 'test' }),
+    ].join('\n');
+    await writeFile(join(testDir, 'events.jsonl'), lines);
+
+    const result = await loadEventsFromDir(testDir, SINCE, UNTIL, 100);
+
+    expect(result).toHaveLength(2);
+    expect(result.map((e) => e.kind).sort()).toEqual(['after.bad', 'before.bad'].sort());
+  });
+
+  it('should skip entries with invalid timestamps', async () => {
+    const lines = [
+      JSON.stringify({ timestamp: 'NOT-A-DATE', kind: 'bad.ts', repo: 'test' }),
+      JSON.stringify({ timestamp: IN_WINDOW_TS, kind: 'good.ts', repo: 'test' }),
+    ].join('\n');
+    await writeFile(join(testDir, 'events.jsonl'), lines);
+
+    const result = await loadEventsFromDir(testDir, SINCE, UNTIL, 100);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].kind).toBe('good.ts');
+  });
+
+  it('should skip entries missing required kind field', async () => {
+    const lines = [
+      JSON.stringify({ timestamp: IN_WINDOW_TS, repo: 'test' }), // no kind
+      JSON.stringify({ timestamp: IN_WINDOW_TS2, kind: 'has.kind', repo: 'test' }),
+    ].join('\n');
+    await writeFile(join(testDir, 'events.jsonl'), lines);
+
+    const result = await loadEventsFromDir(testDir, SINCE, UNTIL, 100);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].kind).toBe('has.kind');
+  });
+
+  it('should respect maxEvents limit', async () => {
+    const lines = Array.from({ length: 10 }, (_, i) =>
+      JSON.stringify({
+        timestamp: `2026-06-01T${String(i + 1).padStart(2, '0')}:00:00.000Z`,
+        kind: `event.${i}`,
+        repo: 'test',
+      })
+    ).join('\n');
+    await writeFile(join(testDir, 'events.jsonl'), lines);
+
+    const result = await loadEventsFromDir(testDir, SINCE, UNTIL, 3);
+
+    expect(result).toHaveLength(3);
+  });
+
+  it('should return events newest-first from a single file', async () => {
+    const lines = [
+      JSON.stringify({ timestamp: IN_WINDOW_TS, kind: 'older', repo: 'test' }),
+      JSON.stringify({ timestamp: IN_WINDOW_TS2, kind: 'newer', repo: 'test' }),
+    ].join('\n');
+    await writeFile(join(testDir, 'events.jsonl'), lines);
+
+    const result = await loadEventsFromDir(testDir, SINCE, UNTIL, 100);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].kind).toBe('newer');
+    expect(result[1].kind).toBe('older');
+  });
+
+  it('should merge and sort events from multiple JSONL files newest-first', async () => {
+    await writeFile(
+      join(testDir, 'file1.jsonl'),
+      JSON.stringify({ timestamp: IN_WINDOW_TS, kind: 'file1.event', repo: 'test' })
+    );
+    await writeFile(
+      join(testDir, 'file2.jsonl'),
+      JSON.stringify({ timestamp: IN_WINDOW_TS2, kind: 'file2.event', repo: 'test' })
+    );
+
+    const result = await loadEventsFromDir(testDir, SINCE, UNTIL, 100);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].kind).toBe('file2.event'); // newer first
+    expect(result[1].kind).toBe('file1.event');
+  });
+
+  it('should ignore non-.jsonl files', async () => {
+    await writeFile(
+      join(testDir, 'events.json'),
+      JSON.stringify([{ timestamp: IN_WINDOW_TS, kind: 'json.event', repo: 'test' }])
+    );
+    await writeFile(
+      join(testDir, 'events.jsonl'),
+      JSON.stringify({ timestamp: IN_WINDOW_TS2, kind: 'jsonl.event', repo: 'test' })
+    );
+
+    const result = await loadEventsFromDir(testDir, SINCE, UNTIL, 100);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].kind).toBe('jsonl.event');
+  });
+
+  it('should return an empty array for an empty directory', async () => {
+    const result = await loadEventsFromDir(testDir, SINCE, UNTIL, 100);
+    expect(result).toHaveLength(0);
+  });
+
+  it('should exclude events at exactly the upper boundary (half-open window)', async () => {
+    const atBoundary = UNTIL; // === untilIso → must be excluded
+    const justBefore = new Date(new Date(UNTIL).getTime() - 1).toISOString();
+
+    const lines = [
+      JSON.stringify({ timestamp: atBoundary, kind: 'at.boundary', repo: 'test' }),
+      JSON.stringify({ timestamp: justBefore, kind: 'just.before', repo: 'test' }),
+    ].join('\n');
+    await writeFile(join(testDir, 'events.jsonl'), lines);
+
+    const result = await loadEventsFromDir(testDir, SINCE, UNTIL, 100);
+
+    expect(result.find((e) => e.kind === 'at.boundary')).toBeUndefined();
+    expect(result.find((e) => e.kind === 'just.before')).toBeDefined();
+  });
+});

--- a/tests/controllers/timeline.test.ts
+++ b/tests/controllers/timeline.test.ts
@@ -181,4 +181,42 @@ describe('getTimelineData controller', () => {
       vi.useRealTimers();
     }
   });
+
+  it('should return source_kind chronik with empty events when chronik dir exists but window is empty', async () => {
+    // readdir succeeds but returns no .jsonl files (empty chronik dir)
+    vi.mocked(readdir).mockResolvedValueOnce([] as Awaited<ReturnType<typeof readdir>>);
+
+    const result = await getTimelineData(48);
+
+    expect(result.view_meta.source_kind).toBe('chronik');
+    expect(result.events).toHaveLength(0);
+    expect(result.view_meta.missing_reason).toBe('ok');
+  });
+
+  it('should skip invalid timestamps in JSON fixture array without throwing', async () => {
+    const now = new Date();
+    const validTs = new Date(now.getTime() - 1 * 60 * 60 * 1000).toISOString();
+
+    const fixtureEvents = [
+      { timestamp: 'not-a-date', kind: 'bad.event', repo: 'x' },
+      { timestamp: validTs, kind: 'good.event', repo: 'y' },
+    ];
+
+    vi.mocked(readdir).mockRejectedValue(
+      Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    );
+
+    vi.mocked(readFile).mockImplementation(async (path) => {
+      if (typeof path === 'string' && path.includes('events.json')) {
+        return JSON.stringify(fixtureEvents) as unknown as Buffer;
+      }
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+
+    const result = await getTimelineData(48);
+
+    // The bad timestamp is skipped; only the valid one is returned
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].kind).toBe('good.event');
+  });
 });

--- a/tests/controllers/timeline.test.ts
+++ b/tests/controllers/timeline.test.ts
@@ -190,7 +190,7 @@ describe('getTimelineData controller', () => {
 
     expect(result.view_meta.source_kind).toBe('chronik');
     expect(result.events).toHaveLength(0);
-    expect(result.view_meta.missing_reason).toBe('ok');
+    expect(result.view_meta.missing_reason).toBe('empty_window');
   });
 
   it('should skip invalid timestamps in JSON fixture array without throwing', async () => {

--- a/tests/controllers/timeline.test.ts
+++ b/tests/controllers/timeline.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getTimelineData } from '../../src/controllers/timeline.js';
+import { resetEnvConfig } from '../../src/config.js';
+import { readdir, readFile } from 'fs/promises';
+
+vi.mock('fs/promises', () => ({
+  readdir: vi.fn(),
+  readFile: vi.fn(),
+}));
+
+describe('getTimelineData controller', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    resetEnvConfig();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /**
+   * Simulate: chronik dir ENOENT, chronik fixture ENOENT,
+   * but events.json fixture exists with known timestamps.
+   */
+  it('should filter JSON fixture events by time window (hoursBack)', async () => {
+    const now = new Date();
+    const oneHourAgo = new Date(now.getTime() - 1 * 60 * 60 * 1000).toISOString();
+    const fiveHoursAgo = new Date(now.getTime() - 5 * 60 * 60 * 1000).toISOString();
+    const threeDaysAgo = new Date(now.getTime() - 72 * 60 * 60 * 1000).toISOString();
+
+    const fixtureEvents = [
+      { timestamp: oneHourAgo, kind: 'ci.pass', repo: 'a' },
+      { timestamp: fiveHoursAgo, kind: 'ci.fail', repo: 'b' },
+      { timestamp: threeDaysAgo, kind: 'old.event', repo: 'c' },
+    ];
+
+    // Both readdir calls fail (no chronik directories)
+    vi.mocked(readdir).mockRejectedValue(
+      Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    );
+
+    // readFile succeeds for the events.json fixture path
+    vi.mocked(readFile).mockImplementation(async (path) => {
+      if (typeof path === 'string' && path.includes('events.json')) {
+        return JSON.stringify(fixtureEvents) as unknown as Buffer;
+      }
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+
+    // hoursBack=6 → should include oneHourAgo and fiveHoursAgo, but not threeDaysAgo
+    const result = await getTimelineData(6);
+
+    expect(result.view_meta.source_kind).toBe('fixture');
+    expect(result.events).toHaveLength(2);
+    // Should be newest first
+    expect(result.events[0].kind).toBe('ci.pass');
+    expect(result.events[1].kind).toBe('ci.fail');
+  });
+
+  it('should return no events when hoursBack excludes all fixture events', async () => {
+    const threeDaysAgo = new Date(Date.now() - 72 * 60 * 60 * 1000).toISOString();
+
+    const fixtureEvents = [
+      { timestamp: threeDaysAgo, kind: 'old.event', repo: 'x' },
+    ];
+
+    vi.mocked(readdir).mockRejectedValue(
+      Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    );
+
+    vi.mocked(readFile).mockImplementation(async (path) => {
+      if (typeof path === 'string' && path.includes('events.json')) {
+        return JSON.stringify(fixtureEvents) as unknown as Buffer;
+      }
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+
+    // hoursBack=1 → threeDaysAgo is outside window
+    const result = await getTimelineData(1);
+
+    // Should have zero events (filtered out), returned as fixture with empty array
+    // The controller returns empty fixture results but continues to the 'missing' path
+    // since the empty array is not > 0 on the JSONL path but the JSON fixture path
+    // returns regardless. Let's check:
+    expect(result.events).toHaveLength(0);
+  });
+
+  it('should respect maxEvents limit after filtering', async () => {
+    const now = Date.now();
+    const fixtureEvents = Array.from({ length: 10 }, (_, i) => ({
+      timestamp: new Date(now - i * 60 * 1000).toISOString(),
+      kind: 'event.' + i,
+      repo: 'test',
+    }));
+
+    vi.mocked(readdir).mockRejectedValue(
+      Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    );
+
+    vi.mocked(readFile).mockImplementation(async (path) => {
+      if (typeof path === 'string' && path.includes('events.json')) {
+        return JSON.stringify(fixtureEvents) as unknown as Buffer;
+      }
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+
+    const result = await getTimelineData(48, 3);
+
+    expect(result.events.length).toBeLessThanOrEqual(3);
+    expect(result.view_meta.total_loaded).toBe(3);
+    // Newest first
+    expect(result.events[0].kind).toBe('event.0');
+  });
+
+  it('should sort events newest-first', async () => {
+    const now = Date.now();
+    const oldest = new Date(now - 3 * 60 * 60 * 1000).toISOString();
+    const middle = new Date(now - 2 * 60 * 60 * 1000).toISOString();
+    const newest = new Date(now - 1 * 60 * 60 * 1000).toISOString();
+
+    // Intentionally unordered
+    const fixtureEvents = [
+      { timestamp: middle, kind: 'middle', repo: 'a' },
+      { timestamp: oldest, kind: 'oldest', repo: 'a' },
+      { timestamp: newest, kind: 'newest', repo: 'a' },
+    ];
+
+    vi.mocked(readdir).mockRejectedValue(
+      Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    );
+
+    vi.mocked(readFile).mockImplementation(async (path) => {
+      if (typeof path === 'string' && path.includes('events.json')) {
+        return JSON.stringify(fixtureEvents) as unknown as Buffer;
+      }
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+
+    const result = await getTimelineData(48);
+
+    expect(result.events[0].kind).toBe('newest');
+    expect(result.events[1].kind).toBe('middle');
+    expect(result.events[2].kind).toBe('oldest');
+  });
+});

--- a/tests/controllers/timeline.test.ts
+++ b/tests/controllers/timeline.test.ts
@@ -80,10 +80,8 @@ describe('getTimelineData controller', () => {
     // hoursBack=1 → threeDaysAgo is outside window
     const result = await getTimelineData(1);
 
-    // Should have zero events (filtered out), returned as fixture with empty array
-    // The controller returns empty fixture results but continues to the 'missing' path
-    // since the empty array is not > 0 on the JSONL path but the JSON fixture path
-    // returns regardless. Let's check:
+    // JSON fixture path always returns (even with 0 filtered events),
+    // so source_kind is 'fixture' with an empty events array.
     expect(result.events).toHaveLength(0);
   });
 

--- a/tests/controllers/timeline.test.ts
+++ b/tests/controllers/timeline.test.ts
@@ -190,7 +190,8 @@ describe('getTimelineData controller', () => {
 
     expect(result.view_meta.source_kind).toBe('chronik');
     expect(result.events).toHaveLength(0);
-    expect(result.view_meta.missing_reason).toBe('empty_window');
+    expect(result.view_meta.window_state).toBe('empty_window');
+    expect(result.view_meta.missing_reason).toBe('ok');
   });
 
   it('should skip invalid timestamps in JSON fixture array without throwing', async () => {

--- a/tests/controllers/timeline.test.ts
+++ b/tests/controllers/timeline.test.ts
@@ -87,8 +87,10 @@ describe('getTimelineData controller', () => {
 
   it('should respect maxEvents limit after filtering', async () => {
     const now = Date.now();
+    // Offset by (i + 1) minutes so the newest event (event.0) is 1 min in the
+    // past and never touches the exclusive upper boundary (untilIso = new Date()).
     const fixtureEvents = Array.from({ length: 10 }, (_, i) => ({
-      timestamp: new Date(now - i * 60 * 1000).toISOString(),
+      timestamp: new Date(now - (i + 1) * 60 * 1000).toISOString(),
       kind: 'event.' + i,
       repo: 'test',
     }));
@@ -141,5 +143,42 @@ describe('getTimelineData controller', () => {
     expect(result.events[0].kind).toBe('newest');
     expect(result.events[1].kind).toBe('middle');
     expect(result.events[2].kind).toBe('oldest');
+  });
+
+  it('should exclude events at exactly the upper boundary (untilIso)', async () => {
+    // Fix system time so we know the exact value of untilIso inside the controller.
+    const fixedNow = new Date('2026-01-01T12:00:00.000Z');
+    vi.useFakeTimers();
+    vi.setSystemTime(fixedNow);
+
+    try {
+      const atBoundary = fixedNow.toISOString(); // === untilIso
+      const justBefore = new Date(fixedNow.getTime() - 1).toISOString(); // 1 ms before
+
+      const fixtureEvents = [
+        { timestamp: atBoundary, kind: 'at.boundary', repo: 'test' },
+        { timestamp: justBefore, kind: 'just.before', repo: 'test' },
+      ];
+
+      vi.mocked(readdir).mockRejectedValue(
+        Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+      );
+
+      vi.mocked(readFile).mockImplementation(async (path) => {
+        if (typeof path === 'string' && path.includes('events.json')) {
+          return JSON.stringify(fixtureEvents) as unknown as Buffer;
+        }
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      });
+
+      const result = await getTimelineData(48);
+
+      // Window is [since, until) — the upper boundary is exclusive.
+      expect(result.events.find((e) => e.kind === 'at.boundary')).toBeUndefined();
+      // 1 ms before the boundary must be included.
+      expect(result.events.find((e) => e.kind === 'just.before')).toBeDefined();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });


### PR DESCRIPTION
- [x] Phase 1: Anatomy – Strukturelle Übersicht
- [x] Phase 3: Timeline – Temporale Ereignisse
- [x] Navigation in allen Views aktualisiert
- [x] Revert timeline upper bound back to `ts < untilIso` (half-open `[since, until)` semantics)
- [x] Fix `should respect maxEvents limit after filtering` test: shift events by `(i+1)` minutes
- [x] Add boundary test `should exclude events at exactly the upper boundary (untilIso)`
- [x] Narrow `AnatomyViewData.view_meta.source_kind` from `string` to `'artifact' | 'fixture' | 'missing'`
- [x] Fix misleading JSDoc comment: clarify `loadAnatomySnapshot()` is not the loader in use here; `loadWithFallback` is used for fallback capability
- [x] Fix timeline fallback: only fall back to fixture on ENOENT; empty-but-accessible chronik returns `source_kind: 'chronik'`
- [x] Guard invalid timestamps in JSON fixture array filter with `Number.isNaN` check before `.toISOString()` to prevent `RangeError`
- [x] Clamp `hoursBack` query parameter to `(0, 168]`; reject NaN/negative/non-finite values (default 48 h)
- [x] Rename `_req` → `req` in `/timeline` route handler
- [x] Add `rafId`/`startSimulation()` guard in `anatomy.ejs` to prevent multiple concurrent `requestAnimationFrame` loops on drag/resize reheat
- [x] Guard `instanceof Element` before `.closest()` in `timeline.ejs` event delegation click handler
- [x] Treat missing `schema` field as `schemaValid: true` in `validateAnatomySnapshot()`, consistent with `loadAnatomySnapshot()` defaulting to `ANATOMY_SCHEMA_V1`
- [x] Switch `loadEventsFromDir` from `readFile` bulk reads to readline streaming with batch-8 concurrency (matching `src/events.ts` pattern) (155/155 tests pass)

<!-- START COPILOT CODING AGENT TIPS -->
---

📱 Kick off Copilot coding agent tasks wherever you are with [GitHub Mobile](https://gh.io/cca-mobile-docs), available on iOS and Android.