### PR TITLE
feat(insights): implement Phase 4 Zwei-Schichten-Sicht – Beobachtungsebene, Evidenzpfad, Konfidenz, Tagesverdichtung

### DIFF
--- a/docs/blueprints/leitstand_visualization.md
+++ b/docs/blueprints/leitstand_visualization.md
@@ -58,9 +58,9 @@ Statuslegende: `[ ] offen`, `[~] in Arbeit`, `[x] erledigt`
 
 - [x] Zwei-Schichten-Sicht implementieren: Beobachtungsebene (Raw) klar getrennt von Interpretation (Insights).
 - [x] Unsicherheits- und Confidence-Darstellung fur Insight-Elemente einbauen.
-- [x] Insight-Evidenzpfad anzeigen (welche Events/Metriken stutzen diese Aussage?).
-- [x] Tagesverdichtung (`insights.daily`) plus Delta zum Vortag visualisieren.
-- [x] Akzeptanztest: Jede Insight-Kachel ist bis auf Rohdatenebene zuruckverfolgbar.
+- [x] Sichtbaren Herkunftspfad anzeigen (Observatorium -> Analyse-Quelle -> insights.daily -> UI).
+- [~] Tagesverdichtung (`insights.daily`) plus Delta zum Vortag visualisieren (UI-Label vorhanden; belastbarer Vortagsvergleich als Datenbindung noch offen).
+- [~] Akzeptanztest: Jede Insight-Kachel ist bis auf Rohdatenebene zuruckverfolgbar (globaler Herkunftspfad umgesetzt, per-Insight-Raw-Refs noch offen).
 
 ### 6) Phase 5 umsetzen: Reflexion (Meta-Analyse)
 
@@ -93,14 +93,15 @@ Statuslegende: `[ ] offen`, `[~] in Arbeit`, `[x] erledigt`
 - [ ] Sprint C: Roadmap 5-6 (Erkenntnis + Reflexion)
 - [ ] Sprint D: Roadmap 7-8 (UX-Hartung + Qualitat + Rollout)
 
-### Implementierungsstand (2026-03-29)
+### Implementierungsstand (2026-04-07)
 
 - [x] Insights-Ansicht zeigt Zwei-Schichten-Sicht: Beobachtungsebene (Digest-Datum, Analyse-Quelle, Observatory-Referenz, Link zur Zeitachse) klar getrennt von der Interpretationsebene (Topics, Fragen, Deltas).
 - [x] Konfidenzbalken in der Beobachtungsebene berechnet aus globalem Unsicherheitswert (`1 - uncertainty`).
-- [x] Evidenzpfad sichtbar: Kette Observatorium → Analyse-Quelle → insights.daily → Erkenntnisse-Ansicht mit klickbarem Observatory-Link.
-- [x] Deltas-Sektion explizit als Tagesverdichtung mit Datum gekennzeichnet ("Veränderungen zum Vortag · Stand: …").
+- [x] Sichtbarer Herkunftspfad: Kette Observatorium -> Analyse-Quelle -> insights.daily -> Erkenntnisse-Ansicht mit klickbarem Observatory-Link.
+- [~] Deltas-Sektion als Tagesverdichtung mit Datum gekennzeichnet ("Veränderungen zum Vortag · Stand: …"); ein belastbarer Vergleich auf konkretes Vortags-Artefakt ist noch nicht separat ausgewiesen.
 - [x] Unsicherheits- und Konfidenzwert in Evidenzpfad-Karte als globale Aussage ausgewiesen.
 - [x] Tests fur Zwei-Schichten-Rendering, Evidenzpfad, Konfidenz und Tagesverdichtung in `tests/server.test.ts` erganzt.
+- [ ] Per-Insight-Rohdatenreferenzen (`data_refs`/Drilldown-Ziele) fur harte Ende-zu-Ende-Ruckverfolgbarkeit sind noch nicht umgesetzt.
 
 - [x] Timeline-Zeitfenster im UI steuerbar (`hours`: 6/24/48/72/168).
 - [x] Event-Limit im UI steuerbar (`max`: 100/200/500/1000).

--- a/docs/blueprints/leitstand_visualization.md
+++ b/docs/blueprints/leitstand_visualization.md
@@ -56,11 +56,11 @@ Statuslegende: `[ ] offen`, `[~] in Arbeit`, `[x] erledigt`
 
 ### 5) Phase 4 umsetzen: Erkenntnisschichten (Raw vs. Insight)
 
-- [ ] Zwei-Schichten-Sicht implementieren: Beobachtungsebene (Raw) klar getrennt von Interpretation (Insights).
-- [ ] Unsicherheits- und Confidence-Darstellung fur Insight-Elemente einbauen.
-- [ ] Insight-Evidenzpfad anzeigen (welche Events/Metriken stutzen diese Aussage?).
-- [ ] Tagesverdichtung (`insights.daily`) plus Delta zum Vortag visualisieren.
-- [ ] Akzeptanztest: Jede Insight-Kachel ist bis auf Rohdatenebene zuruckverfolgbar.
+- [x] Zwei-Schichten-Sicht implementieren: Beobachtungsebene (Raw) klar getrennt von Interpretation (Insights).
+- [x] Unsicherheits- und Confidence-Darstellung fur Insight-Elemente einbauen.
+- [x] Insight-Evidenzpfad anzeigen (welche Events/Metriken stutzen diese Aussage?).
+- [x] Tagesverdichtung (`insights.daily`) plus Delta zum Vortag visualisieren.
+- [x] Akzeptanztest: Jede Insight-Kachel ist bis auf Rohdatenebene zuruckverfolgbar.
 
 ### 6) Phase 5 umsetzen: Reflexion (Meta-Analyse)
 
@@ -94,6 +94,13 @@ Statuslegende: `[ ] offen`, `[~] in Arbeit`, `[x] erledigt`
 - [ ] Sprint D: Roadmap 7-8 (UX-Hartung + Qualitat + Rollout)
 
 ### Implementierungsstand (2026-03-29)
+
+- [x] Insights-Ansicht zeigt Zwei-Schichten-Sicht: Beobachtungsebene (Digest-Datum, Analyse-Quelle, Observatory-Referenz, Link zur Zeitachse) klar getrennt von der Interpretationsebene (Topics, Fragen, Deltas).
+- [x] Konfidenzbalken in der Beobachtungsebene berechnet aus globalem Unsicherheitswert (`1 - uncertainty`).
+- [x] Evidenzpfad sichtbar: Kette Observatorium → Analyse-Quelle → insights.daily → Erkenntnisse-Ansicht mit klickbarem Observatory-Link.
+- [x] Deltas-Sektion explizit als Tagesverdichtung mit Datum gekennzeichnet ("Veränderungen zum Vortag · Stand: …").
+- [x] Unsicherheits- und Konfidenzwert in Evidenzpfad-Karte als globale Aussage ausgewiesen.
+- [x] Tests fur Zwei-Schichten-Rendering, Evidenzpfad, Konfidenz und Tagesverdichtung in `tests/server.test.ts` erganzt.
 
 - [x] Timeline-Zeitfenster im UI steuerbar (`hours`: 6/24/48/72/168).
 - [x] Event-Limit im UI steuerbar (`max`: 100/200/500/1000).

--- a/docs/blueprints/leitstand_visualization.md
+++ b/docs/blueprints/leitstand_visualization.md
@@ -60,7 +60,7 @@ Statuslegende: `[ ] offen`, `[~] in Arbeit`, `[x] erledigt`
 - [x] Unsicherheits- und Confidence-Darstellung fur Insight-Elemente einbauen.
 - [x] Sichtbaren Herkunftspfad anzeigen (Observatorium -> Analyse-Quelle -> insights.daily -> UI).
 - [~] Tagesverdichtung (`insights.daily`) plus Delta zum Vortag visualisieren (UI-Label vorhanden; belastbarer Vortagsvergleich als Datenbindung noch offen).
-- [~] Akzeptanztest: Jede Insight-Kachel ist bis auf Rohdatenebene zuruckverfolgbar (globaler Herkunftspfad umgesetzt, per-Insight-Raw-Refs noch offen).
+- [~] Akzeptanztest: Jede Insight-Kachel ist bis auf Rohdatenebene zuruckverfolgbar (UI/Payload unterstutzen per-Insight-`data_refs`; flachendeckende Producer-Befullung noch offen).
 
 ### 6) Phase 5 umsetzen: Reflexion (Meta-Analyse)
 
@@ -101,7 +101,8 @@ Statuslegende: `[ ] offen`, `[~] in Arbeit`, `[x] erledigt`
 - [~] Deltas-Sektion als Tagesverdichtung mit Datum gekennzeichnet ("Veränderungen zum Vortag · Stand: …"); ein belastbarer Vergleich auf konkretes Vortags-Artefakt ist noch nicht separat ausgewiesen.
 - [x] Unsicherheits- und Konfidenzwert in Evidenzpfad-Karte als globale Aussage ausgewiesen.
 - [x] Tests fur Zwei-Schichten-Rendering, Evidenzpfad, Konfidenz und Tagesverdichtung in `tests/server.test.ts` erganzt.
-- [ ] Per-Insight-Rohdatenreferenzen (`data_refs`/Drilldown-Ziele) fur harte Ende-zu-Ende-Ruckverfolgbarkeit sind noch nicht umgesetzt.
+- [x] Per-Insight-Rohdatenreferenzen (`data_refs`/Drilldown-Ziele) werden im Insights-Payload akzeptiert und pro Topic/Frage/Delta im UI dargestellt.
+- [~] Flachendeckende Ende-zu-Ende-Ruckverfolgbarkeit hangt noch von konsistenter `data_refs`-Befullung in den Producer-Artefakten ab.
 
 - [x] Timeline-Zeitfenster im UI steuerbar (`hours`: 6/24/48/72/168).
 - [x] Event-Limit im UI steuerbar (`max`: 100/200/500/1000).

--- a/src/controllers/anatomy.ts
+++ b/src/controllers/anatomy.ts
@@ -193,7 +193,7 @@ function buildHealthOverlay(
   const healthFreshness: 'fresh' | 'stale' | 'unknown' =
     freshness.freshness_state === 'unknown'
       ? 'unknown'
-      : (freshness.data_age_minutes || 0) > HEALTH_STALE_AFTER_HOURS * 60
+      : (freshness.data_age_minutes ?? 0) > HEALTH_STALE_AFTER_HOURS * 60
         ? 'stale'
         : 'fresh';
 

--- a/src/fixtures/insights.daily.json
+++ b/src/fixtures/insights.daily.json
@@ -14,6 +14,28 @@
     "UI trennt Raw Observatory und Published Daily klarer."
   ],
   "source": "semantAH.daily",
+  "data_refs": {
+    "topics": {
+      "0": {
+        "refs": ["event:chronik:evt-2025-12-28-17", "obs:obs-example-001:topic/observatory"],
+        "drilldown_url": "/timeline?focus=evt-2025-12-28-17"
+      },
+      "1": {
+        "refs": ["event:chronik:evt-2025-12-28-22"]
+      }
+    },
+    "questions": {
+      "0": {
+        "refs": ["metric:fleet.health:wgx.warn_rate"],
+        "drilldown_url": "/anatomy"
+      }
+    },
+    "deltas": {
+      "0": {
+        "refs": ["event:insights.daily.generated", "obs:obs-example-001:source"]
+      }
+    }
+  },
   "metadata": {
     "observatory_ref": "obs-example-001",
     "uncertainty": 0.12

--- a/src/insights.ts
+++ b/src/insights.ts
@@ -149,6 +149,48 @@ function sanitizeDataRefs(rawDataRefs: unknown): InsightDataRefs | undefined {
   };
 }
 
+function pruneDataRefSectionToLength(
+  section: Record<string, InsightDataRefEntry> | undefined,
+  length: number,
+): Record<string, InsightDataRefEntry> | undefined {
+  if (!section || length <= 0) {
+    return undefined;
+  }
+
+  const pruned: Record<string, InsightDataRefEntry> = {};
+  for (const [key, value] of Object.entries(section)) {
+    const index = Number(key);
+    if (Number.isInteger(index) && index >= 0 && index < length) {
+      pruned[key] = value;
+    }
+  }
+
+  return Object.keys(pruned).length > 0 ? pruned : undefined;
+}
+
+function pruneDataRefsToContentLengths(
+  dataRefs: InsightDataRefs | undefined,
+  counts: { topics: number; questions: number; deltas: number },
+): InsightDataRefs | undefined {
+  if (!dataRefs) {
+    return undefined;
+  }
+
+  const topics = pruneDataRefSectionToLength(dataRefs.topics, counts.topics);
+  const questions = pruneDataRefSectionToLength(dataRefs.questions, counts.questions);
+  const deltas = pruneDataRefSectionToLength(dataRefs.deltas, counts.deltas);
+
+  if (!topics && !questions && !deltas) {
+    return undefined;
+  }
+
+  return {
+    topics,
+    questions,
+    deltas,
+  };
+}
+
 export function sanitizeDailyInsights(rawData: unknown, options?: { requireTs?: boolean }): DailyInsights | null {
   if (!isRecord(rawData)) {
     return null;
@@ -180,13 +222,19 @@ export function sanitizeDailyInsights(rawData: unknown, options?: { requireTs?: 
     return null;
   }
 
+  const dataRefs = pruneDataRefsToContentLengths(sanitizeDataRefs(data.data_refs), {
+    topics: topics.length,
+    questions: questions.length,
+    deltas: deltas.length,
+  });
+
   return {
     ts: normalizedTs,
     topics,
     questions,
     deltas,
     source: typeof data.source === 'string' ? data.source : undefined,
-    data_refs: sanitizeDataRefs(data.data_refs),
+    data_refs: dataRefs,
     metadata: sanitizeMetadata(data.metadata),
   };
 }

--- a/src/insights.ts
+++ b/src/insights.ts
@@ -5,6 +5,17 @@ import { readJsonFile } from './utils/fs.js';
  */
 export type Topic = [string, number];
 
+export interface InsightDataRefEntry {
+  refs: string[];
+  drilldown_url?: string;
+}
+
+export interface InsightDataRefs {
+  topics?: Record<string, InsightDataRefEntry>;
+  questions?: Record<string, InsightDataRefEntry>;
+  deltas?: Record<string, InsightDataRefEntry>;
+}
+
 /**
  * Daily insights from semantAH
  */
@@ -19,6 +30,8 @@ export interface DailyInsights {
   deltas: string[];
   /** Optional source identifier */
   source?: string;
+  /** Optional per-insight data references for traceability */
+  data_refs?: InsightDataRefs;
   /** Optional metadata */
   metadata?: {
     generated_at?: string;
@@ -34,6 +47,7 @@ interface RawInsights {
   questions?: unknown;
   deltas?: unknown;
   source?: unknown;
+  data_refs?: unknown;
   metadata?: unknown;
 }
 
@@ -65,6 +79,73 @@ function sanitizeMetadata(rawMetadata: unknown): DailyInsights['metadata'] | und
   }
 
   return Object.keys(metadata).length > 0 ? (metadata as DailyInsights['metadata']) : undefined;
+}
+
+function isSafeDrilldownUrl(value: string): boolean {
+  return /^(https?:\/\/|\/)/.test(value);
+}
+
+function sanitizeDataRefEntry(rawEntry: unknown): InsightDataRefEntry | undefined {
+  if (!isRecord(rawEntry)) {
+    return undefined;
+  }
+
+  const refs = Array.isArray(rawEntry.refs)
+    ? rawEntry.refs
+      .filter((ref: unknown): ref is string => typeof ref === 'string')
+      .map((ref) => ref.trim())
+      .filter((ref) => ref.length > 0)
+    : [];
+
+  if (refs.length === 0) {
+    return undefined;
+  }
+
+  const drilldown = typeof rawEntry.drilldown_url === 'string' ? rawEntry.drilldown_url.trim() : '';
+
+  return {
+    refs,
+    drilldown_url: drilldown && isSafeDrilldownUrl(drilldown) ? drilldown : undefined,
+  };
+}
+
+function sanitizeDataRefSection(rawSection: unknown): Record<string, InsightDataRefEntry> | undefined {
+  if (!isRecord(rawSection)) {
+    return undefined;
+  }
+
+  const section: Record<string, InsightDataRefEntry> = {};
+  for (const [key, value] of Object.entries(rawSection)) {
+    if (!/^\d+$/.test(key)) {
+      continue;
+    }
+    const entry = sanitizeDataRefEntry(value);
+    if (entry) {
+      section[key] = entry;
+    }
+  }
+
+  return Object.keys(section).length > 0 ? section : undefined;
+}
+
+function sanitizeDataRefs(rawDataRefs: unknown): InsightDataRefs | undefined {
+  if (!isRecord(rawDataRefs)) {
+    return undefined;
+  }
+
+  const topics = sanitizeDataRefSection(rawDataRefs.topics);
+  const questions = sanitizeDataRefSection(rawDataRefs.questions);
+  const deltas = sanitizeDataRefSection(rawDataRefs.deltas);
+
+  if (!topics && !questions && !deltas) {
+    return undefined;
+  }
+
+  return {
+    topics,
+    questions,
+    deltas,
+  };
 }
 
 export function sanitizeDailyInsights(rawData: unknown, options?: { requireTs?: boolean }): DailyInsights | null {
@@ -104,6 +185,7 @@ export function sanitizeDailyInsights(rawData: unknown, options?: { requireTs?: 
     questions,
     deltas,
     source: typeof data.source === 'string' ? data.source : undefined,
+    data_refs: sanitizeDataRefs(data.data_refs),
     metadata: sanitizeMetadata(data.metadata),
   };
 }

--- a/src/insights.ts
+++ b/src/insights.ts
@@ -82,7 +82,8 @@ function sanitizeMetadata(rawMetadata: unknown): DailyInsights['metadata'] | und
 }
 
 function isSafeDrilldownUrl(value: string): boolean {
-  return /^(https?:\/\/|\/)/.test(value);
+  // Allow only internal absolute paths (single leading slash).
+  return /^\/(?!\/)/.test(value);
 }
 
 function sanitizeDataRefEntry(rawEntry: unknown): InsightDataRefEntry | undefined {

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -115,13 +115,13 @@ export async function loadMetricsSnapshot(filePath: string): Promise<MetricsSnap
     const data = await readJsonFile<RawMetrics>(filePath);
     
     // Extract basic metrics with fallback defaults
-    const repoCount = data.repoCount || data.repos?.length || 0;
+    const repoCount = data.repoCount ?? data.repos?.length ?? 0;
 
     // We will recalculate status if repos array is present
-    let status = data.status || {
-      ok: data.ok || 0,
-      warn: data.warn || 0,
-      fail: data.fail || 0,
+    let status = data.status ?? {
+      ok: data.ok ?? 0,
+      warn: data.warn ?? 0,
+      fail: data.fail ?? 0,
     };
 
     let processedRepos: RepoData[] | undefined = undefined;

--- a/src/server.ts
+++ b/src/server.ts
@@ -259,7 +259,7 @@ app.post('/events', async (req, res) => {
            meta.plexer_report = {
              fetched_at: new Date().toISOString(),
              source_kind: 'event',
-             bytes: Buffer.byteLength(JSON.stringify(payload))
+             bytes: Buffer.byteLength(serializedPayload)
            };
            return meta;
        });

--- a/src/views/insights.ejs
+++ b/src/views/insights.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="de">
 <head>
   <title>Erkenntnisse – Leitstand</title>
   <meta charset="utf-8">
@@ -84,18 +84,6 @@
     .page-header .subtitle {
       color: var(--text-secondary);
       font-size: 0.88em;
-    }
-
-    .interpretation-badge {
-      display: inline-block;
-      margin-top: 10px;
-      padding: 4px 10px;
-      background: rgba(59, 130, 246, 0.08);
-      border: 1px solid rgba(59, 130, 246, 0.2);
-      border-radius: 20px;
-      font-size: 0.72em;
-      color: var(--accent);
-      letter-spacing: 0.02em;
     }
 
     .section {
@@ -237,6 +225,213 @@
     #source-badge .warn {
       color: var(--warn);
     }
+
+    /* ── Zwei-Schichten-Sicht ──────────────────────────── */
+
+    .layer-card {
+      border-radius: 14px;
+      padding: 18px 22px;
+      margin-bottom: 20px;
+    }
+
+    .layer-card.layer-raw {
+      background: rgba(15, 23, 42, 0.7);
+      border: 1px solid rgba(255, 255, 255, 0.07);
+    }
+
+    .layer-header {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin-bottom: 14px;
+    }
+
+    .layer-label {
+      font-size: 0.68em;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+    }
+
+    .layer-label.raw { color: #6b7280; }
+    .layer-label.interp { color: var(--accent); }
+
+    .layer-pill {
+      font-size: 0.62em;
+      padding: 2px 8px;
+      border-radius: 20px;
+      font-weight: 500;
+    }
+
+    .layer-pill.raw {
+      background: rgba(107, 114, 128, 0.12);
+      border: 1px solid rgba(107, 114, 128, 0.25);
+      color: #9ca3af;
+    }
+
+    .layer-pill.interp {
+      background: rgba(59, 130, 246, 0.08);
+      border: 1px solid rgba(59, 130, 246, 0.2);
+      color: var(--accent);
+    }
+
+    .raw-meta-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+      gap: 10px;
+    }
+
+    .raw-meta-item {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+
+    .raw-meta-label {
+      font-size: 0.65em;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--text-muted);
+    }
+
+    .raw-meta-value {
+      font-size: 0.8em;
+      color: var(--text-secondary);
+    }
+
+    .raw-meta-value a {
+      color: var(--accent);
+      text-decoration: none;
+    }
+
+    .raw-meta-value a:hover { text-decoration: underline; }
+
+    /* Confidence bar */
+    .confidence-row {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin-top: 12px;
+    }
+
+    .confidence-label {
+      font-size: 0.68em;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--text-muted);
+      white-space: nowrap;
+    }
+
+    .confidence-track {
+      flex: 1;
+      height: 5px;
+      background: rgba(255,255,255,0.05);
+      border: 1px solid var(--border-glass);
+      border-radius: 4px;
+      overflow: hidden;
+    }
+
+    .confidence-fill {
+      height: 100%;
+      border-radius: 4px;
+      transition: width 0.4s ease;
+    }
+
+    .confidence-fill.high { background: #22c55e; }
+    .confidence-fill.mid  { background: #f59e0b; }
+    .confidence-fill.low  { background: #ef4444; }
+
+    .confidence-value {
+      font-size: 0.72em;
+      color: var(--text-muted);
+      min-width: 48px;
+      text-align: right;
+    }
+
+    /* Interpretation layer divider */
+    .layer-divider {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 20px;
+    }
+
+    .layer-divider::before,
+    .layer-divider::after {
+      content: '';
+      flex: 1;
+      height: 1px;
+      background: rgba(59, 130, 246, 0.15);
+    }
+
+    .layer-divider span {
+      font-size: 0.65em;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.14em;
+      color: rgba(59, 130, 246, 0.5);
+      white-space: nowrap;
+    }
+
+    /* Delta section */
+    .delta-date-note {
+      font-size: 0.72em;
+      color: var(--text-muted);
+      margin-bottom: 14px;
+    }
+
+    /* Evidence path */
+    .evidenz-card {
+      background: rgba(15, 23, 42, 0.5);
+      border: 1px solid rgba(255, 255, 255, 0.05);
+      border-radius: 12px;
+      padding: 16px 20px;
+      margin-top: 24px;
+    }
+
+    .evidenz-title {
+      font-size: 0.68em;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--text-muted);
+      margin-bottom: 12px;
+    }
+
+    .evidenz-chain {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 6px;
+      font-size: 0.78em;
+    }
+
+    .evidenz-node {
+      padding: 4px 10px;
+      border-radius: 6px;
+      background: var(--bg-glass);
+      border: 1px solid var(--border-glass);
+      color: var(--text-secondary);
+    }
+
+    .evidenz-node.origin {
+      border-color: rgba(59, 130, 246, 0.25);
+      color: var(--accent);
+    }
+
+    .evidenz-arrow {
+      color: var(--text-muted);
+      font-size: 0.9em;
+    }
+
+    .evidenz-node a {
+      color: inherit;
+      text-decoration: none;
+    }
+
+    .evidenz-node a:hover { text-decoration: underline; }
   </style>
 </head>
 <body>
@@ -254,7 +449,6 @@
     <div class="page-header">
       <h1>Erkenntnisse</h1>
       <div class="subtitle">Semantische Tagesanalyse – Topics, offene Fragen und erkannte Deltas</div>
-      <span class="interpretation-badge">Semantische Interpretation – kein Rohdaten-Ersatz</span>
     </div>
 
     <% if (!insights) { %>
@@ -271,9 +465,67 @@
         <% } %>
       </div>
     <% } else { %>
+
+      <%
+        // Confidence = 1 - uncertainty (global). Null when no uncertainty provided.
+        const confidenceVal = (view_meta.uncertainty !== null) ? Math.max(0, 1 - view_meta.uncertainty) : null;
+        const confidencePct = confidenceVal !== null ? Math.round(confidenceVal * 100) : null;
+        const confidenceClass = confidencePct === null ? '' : confidencePct >= 75 ? 'high' : confidencePct >= 45 ? 'mid' : 'low';
+      %>
+
+      <!-- ── Beobachtungsebene ───────────────────────────────── -->
+      <div class="layer-card layer-raw">
+        <div class="layer-header">
+          <span class="layer-label raw">Beobachtungsebene</span>
+          <span class="layer-pill raw">Rohdaten-Referenz</span>
+        </div>
+        <div class="raw-meta-grid">
+          <% if (insights.ts) { %>
+          <div class="raw-meta-item">
+            <span class="raw-meta-label">Digest-Datum</span>
+            <span class="raw-meta-value"><%= insights.ts %></span>
+          </div>
+          <% } %>
+          <% if (insights.source) { %>
+          <div class="raw-meta-item">
+            <span class="raw-meta-label">Analyse-Quelle</span>
+            <span class="raw-meta-value"><%= insights.source %></span>
+          </div>
+          <% } %>
+          <div class="raw-meta-item">
+            <span class="raw-meta-label">Rohe Ereignisse</span>
+            <span class="raw-meta-value"><a href="/timeline">→ Zeitachse öffnen</a></span>
+          </div>
+          <% if (view_meta.observatory_ref) { %>
+          <div class="raw-meta-item">
+            <span class="raw-meta-label">Observatorium-Basis</span>
+            <span class="raw-meta-value"><a href="/observatory"><%= view_meta.observatory_ref %></a></span>
+          </div>
+          <% } %>
+        </div>
+        <% if (confidencePct !== null) { %>
+        <div class="confidence-row">
+          <span class="confidence-label">Konfidenz</span>
+          <div class="confidence-track">
+            <div class="confidence-fill <%= confidenceClass %>" style="width: <%= confidencePct %>%;"></div>
+          </div>
+          <span class="confidence-value"><%= confidencePct %>%</span>
+        </div>
+        <% } %>
+      </div>
+      <!-- ── Ende Beobachtungsebene ─────────────────────────── -->
+
+      <!-- Schichtentrennlinie -->
+      <div class="layer-divider">
+        <span>Interpretationsebene</span>
+      </div>
+
       <% if (insights.topics.length > 0) { %>
       <div class="section">
-        <div class="section-title">Topics</div>
+        <div class="layer-header" style="margin-bottom:14px;">
+          <span class="layer-label interp">Topics</span>
+          <span class="layer-pill interp">Semantische Gewichtung</span>
+        </div>
         <div class="topic-list">
           <% for (const [name, score] of insights.topics) { %>
           <% const scorePercent = Math.round(Math.min(Math.max(Number(score), 0), 1) * 100); %>
@@ -292,7 +544,10 @@
 
       <% if (insights.questions.length > 0) { %>
       <div class="section">
-        <div class="section-title">Offene Fragen</div>
+        <div class="layer-header" style="margin-bottom:14px;">
+          <span class="layer-label interp">Offene Fragen</span>
+          <span class="layer-pill interp">Erkannte Unklarheiten</span>
+        </div>
         <ul class="item-list questions-list">
           <% for (const question of insights.questions) { %>
           <li><%= question %></li>
@@ -303,7 +558,13 @@
 
       <% if (insights.deltas.length > 0) { %>
       <div class="section">
-        <div class="section-title">Deltas</div>
+        <div class="layer-header" style="margin-bottom:4px;">
+          <span class="layer-label interp">Deltas</span>
+          <span class="layer-pill interp">Tagesverdichtung</span>
+        </div>
+        <% if (insights.ts) { %>
+        <div class="delta-date-note">Veränderungen zum Vortag · Stand: <%= insights.ts %></div>
+        <% } %>
         <ul class="item-list deltas-list">
           <% for (const delta of insights.deltas) { %>
           <li><%= delta %></li>
@@ -319,6 +580,34 @@
         <p>Die Analyse enthält noch keine Topics, Fragen oder Deltas.</p>
       </div>
       <% } %>
+
+      <!-- ── Evidenzpfad ─────────────────────────────────────── -->
+      <div class="evidenz-card">
+        <div class="evidenz-title">Evidenzpfad</div>
+        <div class="evidenz-chain">
+          <% if (view_meta.observatory_ref) { %>
+          <span class="evidenz-node origin">
+            <a href="/observatory">Observatorium (<%= view_meta.observatory_ref %>)</a>
+          </span>
+          <span class="evidenz-arrow">→</span>
+          <% } %>
+          <% if (insights.source) { %>
+          <span class="evidenz-node"><%= insights.source %></span>
+          <span class="evidenz-arrow">→</span>
+          <% } %>
+          <span class="evidenz-node">insights.daily</span>
+          <span class="evidenz-arrow">→</span>
+          <span class="evidenz-node origin">Erkenntnisse (diese Ansicht)</span>
+        </div>
+        <% if (confidencePct !== null) { %>
+        <div style="margin-top:10px; font-size:0.72em; color:var(--text-muted);">
+          Globale Unsicherheit: <%= (view_meta.uncertainty * 100).toFixed(0) %>% · Konfidenz: <%= confidencePct %>%
+          <% if (view_meta.freshness_degraded) { %> · <span style="color:var(--warn);">Degradierter Zeitstempel-Fallback</span><% } %>
+        </div>
+        <% } %>
+      </div>
+      <!-- ── Ende Evidenzpfad ────────────────────────────────── -->
+
     <% } %>
   </div>
 
@@ -346,12 +635,6 @@
     <% } %>
     <% if (view_meta.freshness_degraded) { %>
       · <span class="warn">degradierter Fallback</span>
-    <% } %>
-    <% if (view_meta.uncertainty !== null) { %>
-      · Unsicherheit: <%= (view_meta.uncertainty * 100).toFixed(0) %>%
-    <% } %>
-    <% if (view_meta.observatory_ref) { %>
-      · Ref: <%= view_meta.observatory_ref %>
     <% } %>
   </div>
 </body>

--- a/src/views/insights.ejs
+++ b/src/views/insights.ejs
@@ -175,6 +175,45 @@
       font-size: 0.9em;
     }
 
+    .item-text {
+      display: block;
+      color: var(--text-secondary);
+    }
+
+    .data-refs {
+      margin-top: 6px;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      flex-wrap: wrap;
+      font-size: 0.68em;
+      line-height: 1.2;
+    }
+
+    .data-refs-label {
+      text-transform: uppercase;
+      letter-spacing: 0.07em;
+      color: var(--text-muted);
+      font-weight: 600;
+    }
+
+    .data-ref-chip {
+      padding: 2px 7px;
+      border-radius: 999px;
+      border: 1px solid var(--border-glass);
+      background: var(--bg-glass);
+      color: var(--text-secondary);
+    }
+
+    .data-ref-link {
+      margin-left: 2px;
+      color: var(--accent);
+      text-decoration: none;
+      border-bottom: 1px solid rgba(59, 130, 246, 0.35);
+    }
+
+    .data-ref-link:hover { text-decoration: underline; }
+
     .questions-list li::before { content: '?'; }
     .deltas-list li::before { content: '△'; }
 
@@ -471,6 +510,9 @@
         const confidenceVal = (view_meta.uncertainty !== null) ? Math.max(0, 1 - view_meta.uncertainty) : null;
         const confidencePct = confidenceVal !== null ? Math.round(confidenceVal * 100) : null;
         const confidenceClass = confidencePct === null ? '' : confidencePct >= 75 ? 'high' : confidencePct >= 45 ? 'mid' : 'low';
+        const topicDataRefs = insights.data_refs?.topics ?? {};
+        const questionDataRefs = insights.data_refs?.questions ?? {};
+        const deltaDataRefs = insights.data_refs?.deltas ?? {};
       %>
 
       <!-- ── Beobachtungsebene ───────────────────────────────── -->
@@ -527,9 +569,11 @@
           <span class="layer-pill interp">Semantische Gewichtung</span>
         </div>
         <div class="topic-list">
-          <% for (const [name, score] of insights.topics) { %>
+          <% for (let idx = 0; idx < insights.topics.length; idx++) { %>
+          <% const [name, score] = insights.topics[idx]; %>
           <% const scorePercent = Math.round(Math.min(Math.max(Number(score), 0), 1) * 100); %>
           <% const scoreWidth = `${scorePercent}%`; %>
+          <% const topicRefEntry = topicDataRefs[String(idx)]; %>
           <div class="topic-row">
             <span class="topic-name" title="<%= name %>"><%= name %></span>
             <div class="topic-bar-track">
@@ -537,6 +581,17 @@
             </div>
             <span class="topic-score"><%= scorePercent %>%</span>
           </div>
+          <% if (topicRefEntry) { %>
+          <div class="data-refs" style="margin-left:172px; margin-bottom:6px;">
+            <span class="data-refs-label">data_refs</span>
+            <% for (const ref of topicRefEntry.refs) { %>
+            <span class="data-ref-chip"><%= ref %></span>
+            <% } %>
+            <% if (topicRefEntry.drilldown_url) { %>
+            <a class="data-ref-link" href="<%= topicRefEntry.drilldown_url %>">Drilldown</a>
+            <% } %>
+          </div>
+          <% } %>
           <% } %>
         </div>
       </div>
@@ -549,8 +604,23 @@
           <span class="layer-pill interp">Erkannte Unklarheiten</span>
         </div>
         <ul class="item-list questions-list">
-          <% for (const question of insights.questions) { %>
-          <li><%= question %></li>
+          <% for (let idx = 0; idx < insights.questions.length; idx++) { %>
+          <% const question = insights.questions[idx]; %>
+          <% const questionRefEntry = questionDataRefs[String(idx)]; %>
+          <li>
+            <span class="item-text"><%= question %></span>
+            <% if (questionRefEntry) { %>
+            <div class="data-refs">
+              <span class="data-refs-label">data_refs</span>
+              <% for (const ref of questionRefEntry.refs) { %>
+              <span class="data-ref-chip"><%= ref %></span>
+              <% } %>
+              <% if (questionRefEntry.drilldown_url) { %>
+              <a class="data-ref-link" href="<%= questionRefEntry.drilldown_url %>">Drilldown</a>
+              <% } %>
+            </div>
+            <% } %>
+          </li>
           <% } %>
         </ul>
       </div>
@@ -566,8 +636,23 @@
         <div class="delta-date-note">Veränderungen zum Vortag · Stand: <%= insights.ts %></div>
         <% } %>
         <ul class="item-list deltas-list">
-          <% for (const delta of insights.deltas) { %>
-          <li><%= delta %></li>
+          <% for (let idx = 0; idx < insights.deltas.length; idx++) { %>
+          <% const delta = insights.deltas[idx]; %>
+          <% const deltaRefEntry = deltaDataRefs[String(idx)]; %>
+          <li>
+            <span class="item-text"><%= delta %></span>
+            <% if (deltaRefEntry) { %>
+            <div class="data-refs">
+              <span class="data-refs-label">data_refs</span>
+              <% for (const ref of deltaRefEntry.refs) { %>
+              <span class="data-ref-chip"><%= ref %></span>
+              <% } %>
+              <% if (deltaRefEntry.drilldown_url) { %>
+              <a class="data-ref-link" href="<%= deltaRefEntry.drilldown_url %>">Drilldown</a>
+              <% } %>
+            </div>
+            <% } %>
+          </li>
           <% } %>
         </ul>
       </div>

--- a/tests/insights.test.ts
+++ b/tests/insights.test.ts
@@ -76,6 +76,15 @@ describe('insights', () => {
       topics: [['TypeScript', 0.7], ['Broken'], ['NaN', Number.NaN]],
       questions: ['How to test?', 42],
       deltas: ['Added new feature', { text: 'broken' }],
+      data_refs: {
+        topics: {
+          '0': { refs: ['event:123', 'obs:alpha'], drilldown_url: '/timeline?focus=123' },
+          bad: { refs: ['ignored'] },
+        },
+        questions: {
+          '0': { refs: ['metric:cpu'], drilldown_url: 'javascript:alert(1)' },
+        },
+      },
       metadata: {
         generated_at: '2025-12-05T10:00:00.000Z',
         uncertainty: 1.4,
@@ -87,7 +96,35 @@ describe('insights', () => {
     expect(insights?.topics).toEqual([['TypeScript', 0.7]]);
     expect(insights?.questions).toEqual(['How to test?']);
     expect(insights?.deltas).toEqual(['Added new feature']);
+    expect(insights?.data_refs?.topics).toEqual({
+      '0': { refs: ['event:123', 'obs:alpha'], drilldown_url: '/timeline?focus=123' },
+    });
+    expect(insights?.data_refs?.questions).toEqual({
+      '0': { refs: ['metric:cpu'], drilldown_url: undefined },
+    });
     expect(insights?.metadata?.uncertainty).toBeUndefined();
     expect(insights?.metadata?.observatory_ref).toBe('obs-123');
+  });
+
+  it('should ignore invalid data_refs sections and entries', () => {
+    const insights = sanitizeDailyInsights({
+      ts: '2025-12-05',
+      topics: [['Topic', 0.5]],
+      questions: ['Q1'],
+      deltas: ['D1'],
+      data_refs: {
+        topics: {
+          '0': { refs: [] },
+          '1': { refs: ['ok'] },
+        },
+        deltas: 'invalid',
+      },
+    });
+
+    expect(insights).not.toBeNull();
+    expect(insights?.data_refs?.topics).toEqual({
+      '1': { refs: ['ok'], drilldown_url: undefined },
+    });
+    expect(insights?.data_refs?.deltas).toBeUndefined();
   });
 });

--- a/tests/insights.test.ts
+++ b/tests/insights.test.ts
@@ -83,6 +83,7 @@ describe('insights', () => {
         },
         questions: {
           '0': { refs: ['metric:cpu'], drilldown_url: 'javascript:alert(1)' },
+          '1': { refs: ['metric:ram'], drilldown_url: '//evil.example/phish' },
         },
       },
       metadata: {
@@ -101,9 +102,33 @@ describe('insights', () => {
     });
     expect(insights?.data_refs?.questions).toEqual({
       '0': { refs: ['metric:cpu'], drilldown_url: undefined },
+      '1': { refs: ['metric:ram'], drilldown_url: undefined },
     });
     expect(insights?.metadata?.uncertainty).toBeUndefined();
     expect(insights?.metadata?.observatory_ref).toBe('obs-123');
+  });
+
+  it('should only allow internal absolute-path drilldown URLs', () => {
+    const insights = sanitizeDailyInsights({
+      ts: '2025-12-05',
+      topics: [['Topic', 0.5]],
+      questions: ['Q1'],
+      deltas: ['D1'],
+      data_refs: {
+        topics: {
+          '0': { refs: ['topic:ok'], drilldown_url: '/timeline?focus=123' },
+          '1': { refs: ['topic:blocked'], drilldown_url: 'https://evil.example' },
+          '2': { refs: ['topic:protocol-relative'], drilldown_url: '//evil.example/path' },
+        },
+      },
+    });
+
+    expect(insights).not.toBeNull();
+    expect(insights?.data_refs?.topics).toEqual({
+      '0': { refs: ['topic:ok'], drilldown_url: '/timeline?focus=123' },
+      '1': { refs: ['topic:blocked'], drilldown_url: undefined },
+      '2': { refs: ['topic:protocol-relative'], drilldown_url: undefined },
+    });
   });
 
   it('should ignore invalid data_refs sections and entries', () => {

--- a/tests/insights.test.ts
+++ b/tests/insights.test.ts
@@ -102,7 +102,6 @@ describe('insights', () => {
     });
     expect(insights?.data_refs?.questions).toEqual({
       '0': { refs: ['metric:cpu'], drilldown_url: undefined },
-      '1': { refs: ['metric:ram'], drilldown_url: undefined },
     });
     expect(insights?.metadata?.uncertainty).toBeUndefined();
     expect(insights?.metadata?.observatory_ref).toBe('obs-123');
@@ -111,7 +110,7 @@ describe('insights', () => {
   it('should only allow internal absolute-path drilldown URLs', () => {
     const insights = sanitizeDailyInsights({
       ts: '2025-12-05',
-      topics: [['Topic', 0.5]],
+      topics: [['Topic', 0.5], ['Topic 2', 0.4], ['Topic 3', 0.3]],
       questions: ['Q1'],
       deltas: ['D1'],
       data_refs: {
@@ -131,6 +130,46 @@ describe('insights', () => {
     });
   });
 
+  it('should prune data_refs that point to removed sanitized items', () => {
+    const insights = sanitizeDailyInsights({
+      ts: '2025-12-05',
+      topics: [['T1', 0.5], ['Broken'], ['T3', Number.NaN]],
+      questions: ['Q1', 123],
+      deltas: ['D1', { text: 'broken' }],
+      data_refs: {
+        topics: {
+          '0': { refs: ['topic:0'] },
+          '1': { refs: ['topic:1'] },
+          '2': { refs: ['topic:2'] },
+        },
+        questions: {
+          '0': { refs: ['question:0'] },
+          '1': { refs: ['question:1'] },
+        },
+        deltas: {
+          '0': { refs: ['delta:0'] },
+          '1': { refs: ['delta:1'] },
+        },
+      },
+    });
+
+    expect(insights).not.toBeNull();
+    expect(insights?.topics).toEqual([['T1', 0.5]]);
+    expect(insights?.questions).toEqual(['Q1']);
+    expect(insights?.deltas).toEqual(['D1']);
+    expect(insights?.data_refs).toEqual({
+      topics: {
+        '0': { refs: ['topic:0'], drilldown_url: undefined },
+      },
+      questions: {
+        '0': { refs: ['question:0'], drilldown_url: undefined },
+      },
+      deltas: {
+        '0': { refs: ['delta:0'], drilldown_url: undefined },
+      },
+    });
+  });
+
   it('should ignore invalid data_refs sections and entries', () => {
     const insights = sanitizeDailyInsights({
       ts: '2025-12-05',
@@ -147,9 +186,6 @@ describe('insights', () => {
     });
 
     expect(insights).not.toBeNull();
-    expect(insights?.data_refs?.topics).toEqual({
-      '1': { refs: ['ok'], drilldown_url: undefined },
-    });
-    expect(insights?.data_refs?.deltas).toBeUndefined();
+    expect(insights?.data_refs).toBeUndefined();
   });
 });

--- a/tests/meta_concurrency.test.ts
+++ b/tests/meta_concurrency.test.ts
@@ -57,6 +57,10 @@ describe('POST /events concurrency', () => {
         const meta = JSON.parse(await fs.readFile(metaPath, 'utf8'));
 
         expect(meta.plexer_report.bytes).toBe(Buffer.byteLength(fileContent));
+        // Pin the storage format invariant: the handler deliberately writes pretty-printed JSON.
+        // If someone switches to compact serialization and also updates the bytes accordingly,
+        // the line above would still pass — this assertion catches that format regression.
+        expect(fileContent).toBe(JSON.stringify(payload, null, 2));
     });
 
     it('should correctly handle concurrent plexer reports and maintain valid _meta.json', async () => {

--- a/tests/meta_concurrency.test.ts
+++ b/tests/meta_concurrency.test.ts
@@ -35,6 +35,30 @@ describe('POST /events concurrency', () => {
         resetValidators();
     });
 
+    it('plexer_report.bytes in _meta.json equals Buffer.byteLength of the actual artifact file', async () => {
+        // Regression: bytes was previously computed from compact JSON.stringify(payload) while
+        // the artifact is written with JSON.stringify(payload, null, 2). This test ensures both
+        // match — i.e. the metadata describes what is actually on disk.
+        const payload = {
+            counts: { pending: 3, failed: 1 },
+            last_error: 'timeout',
+            last_retry_at: new Date().toISOString(),
+        };
+
+        const res = await request(app)
+            .post('/events')
+            .send({ type: 'plexer.delivery.report.v1', payload });
+
+        expect(res.status).toBe(200);
+
+        await __wait_for_meta_queue();
+
+        const fileContent = await fs.readFile(artifactPath, 'utf8');
+        const meta = JSON.parse(await fs.readFile(metaPath, 'utf8'));
+
+        expect(meta.plexer_report.bytes).toBe(Buffer.byteLength(fileContent));
+    });
+
     it('should correctly handle concurrent plexer reports and maintain valid _meta.json', async () => {
         const iterations = 10;
         const promises = [];

--- a/tests/metrics.test.ts
+++ b/tests/metrics.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { writeFile, rm, mkdtemp, utimes } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { loadLatestMetrics } from '../src/metrics.js';
+import { loadLatestMetrics, loadMetricsSnapshot } from '../src/metrics.js';
 
 describe('metrics', () => {
   let testDir: string;
@@ -180,5 +180,21 @@ describe('metrics', () => {
     expect(metrics).toBeDefined();
     expect(metrics?.repoCount).toBe(3); // Should derive from repos array
     expect(metrics?.status.ok).toBe(2);
+  });
+
+  it('preserves explicit repoCount: 0 even when repos array has entries', async () => {
+    // Regression: repoCount was computed with || so an explicit 0 would silently fall
+    // through to repos.length. With ?? the explicit 0 is kept as-is.
+    const metricsData = {
+      timestamp: '2025-12-05T12:00:00Z',
+      repoCount: 0,
+      repos: [{ name: 'repo1', status: 'ok' }],
+    };
+    const filePath = join(testDir, 'metrics-zero-repocount.json');
+    await writeFile(filePath, JSON.stringify(metricsData), 'utf-8');
+
+    const metrics = await loadMetricsSnapshot(filePath);
+
+    expect(metrics.repoCount).toBe(0);
   });
 });

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -395,9 +395,20 @@ describe('GET /insights', () => {
       insights: {
         ts: '2026-03-30',
         topics: [['leitstand', 0.8]],
-        questions: [],
+        questions: ['Welche Quelle stützt den Shift?'],
         deltas: ['Something shifted'],
         source: 'semantAH.daily',
+        data_refs: {
+          topics: {
+            '0': { refs: ['event:evt-123', 'obs:obs-999'], drilldown_url: '/timeline?focus=evt-123' },
+          },
+          questions: {
+            '0': { refs: ['metric:cpu:95'] },
+          },
+          deltas: {
+            '0': { refs: ['event:evt-200'], drilldown_url: '/timeline?focus=evt-200' },
+          },
+        },
         metadata: { observatory_ref: 'obs-999', uncertainty: 0.1 },
       },
       view_meta: {
@@ -431,6 +442,13 @@ describe('GET /insights', () => {
     expect(res.text).toContain('Evidenzpfad');
     expect(res.text).toContain('obs-999');
     expect(res.text).toContain('insights.daily');
+    // Per-insight traceability refs
+    expect(res.text).toContain('data_refs');
+    expect(res.text).toContain('event:evt-123');
+    expect(res.text).toContain('metric:cpu:95');
+    expect(res.text).toContain('event:evt-200');
+    expect(res.text).toContain('/timeline?focus=evt-123');
+    expect(res.text).toContain('/timeline?focus=evt-200');
   });
 
   it('should render delta section with Tagesverdichtung label and date', async () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -389,6 +389,119 @@ describe('GET /insights', () => {
     expect(res.text).toContain('New insights route wired');
   });
 
+  it('should render the Beobachtungsebene layer card with raw meta', async () => {
+    const insightsController = await import('../src/controllers/insights.js');
+    vi.spyOn(insightsController, 'getInsightsData').mockResolvedValueOnce({
+      insights: {
+        ts: '2026-03-30',
+        topics: [['leitstand', 0.8]],
+        questions: [],
+        deltas: ['Something shifted'],
+        source: 'semantAH.daily',
+        metadata: { observatory_ref: 'obs-999', uncertainty: 0.1 },
+      },
+      view_meta: {
+        source_kind: 'artifact',
+        missing_reason: 'ok',
+        is_strict: false,
+        data_timestamp: '2026-03-30T10:00:00.000Z',
+        data_age_minutes: 60,
+        freshness_state: 'fresh',
+        freshness_source: 'metadata.generated_at',
+        freshness_degraded: false,
+        stale_after_hours: 30,
+        uncertainty: 0.1,
+        observatory_ref: 'obs-999',
+      },
+    });
+
+    const res = await request(app).get('/insights');
+
+    expect(res.status).toBe(200);
+    // Zwei-Schichten: Beobachtungsebene card
+    expect(res.text).toContain('Beobachtungsebene');
+    expect(res.text).toContain('Rohdaten-Referenz');
+    expect(res.text).toContain('2026-03-30');
+    expect(res.text).toContain('semantAH.daily');
+    // Zwei-Schichten: Interpretationsebene divider
+    expect(res.text).toContain('Interpretationsebene');
+    // Confidence bar from uncertainty 0.1 → 90% confidence
+    expect(res.text).toContain('90%');
+    // Evidence path
+    expect(res.text).toContain('Evidenzpfad');
+    expect(res.text).toContain('obs-999');
+    expect(res.text).toContain('insights.daily');
+  });
+
+  it('should render delta section with Tagesverdichtung label and date', async () => {
+    const insightsController = await import('../src/controllers/insights.js');
+    vi.spyOn(insightsController, 'getInsightsData').mockResolvedValueOnce({
+      insights: {
+        ts: '2026-03-29',
+        topics: [],
+        questions: [],
+        deltas: ['Neue Observatory-Quelle verfügbar.'],
+        metadata: { uncertainty: 0.25 },
+      },
+      view_meta: {
+        source_kind: 'artifact',
+        missing_reason: 'ok',
+        is_strict: false,
+        data_timestamp: '2026-03-30T08:00:00.000Z',
+        data_age_minutes: 30,
+        freshness_state: 'fresh',
+        freshness_source: 'metadata.generated_at',
+        freshness_degraded: false,
+        stale_after_hours: 30,
+        uncertainty: 0.25,
+        observatory_ref: null,
+      },
+    });
+
+    const res = await request(app).get('/insights');
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Tagesverdichtung');
+    expect(res.text).toContain('Veränderungen zum Vortag');
+    expect(res.text).toContain('2026-03-29');
+    expect(res.text).toContain('Neue Observatory-Quelle verfügbar.');
+  });
+
+  it('should render evidence path without observatory node when ref is absent', async () => {
+    const insightsController = await import('../src/controllers/insights.js');
+    vi.spyOn(insightsController, 'getInsightsData').mockResolvedValueOnce({
+      insights: {
+        ts: '2026-03-28',
+        topics: [['ci', 0.5]],
+        questions: [],
+        deltas: [],
+        source: 'semantAH.daily',
+      },
+      view_meta: {
+        source_kind: 'fixture',
+        missing_reason: 'enoent',
+        is_strict: false,
+        data_timestamp: null,
+        data_age_minutes: null,
+        freshness_state: 'unknown',
+        freshness_source: 'unknown',
+        freshness_degraded: false,
+        stale_after_hours: 30,
+        uncertainty: null,
+        observatory_ref: null,
+      },
+    });
+
+    const res = await request(app).get('/insights');
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Evidenzpfad');
+    // No observatory link when ref is absent
+    expect(res.text).not.toContain('Observatorium (');
+    expect(res.text).toContain('semantAH.daily');
+    expect(res.text).toContain('insights.daily');
+  });
+
   it('should show transport-time wording when freshness falls back to mtime', async () => {
     const insightsController = await import('../src/controllers/insights.js');
     vi.spyOn(insightsController, 'getInsightsData').mockResolvedValueOnce({


### PR DESCRIPTION
- Add Beobachtungsebene card (raw layer): shows digest date, analysis source, link to timeline, observatory reference, and confidence bar derived from global uncertainty (1 – uncertainty)
- Add visual layer divider separating Beobachtungsebene from semantically labelled Interpretationsebene (Topics, Fragen, Deltas)
- Add Evidenzpfad section: traceable chain from Observatorium → source → insights.daily → current view, with clickable observatory link
- Deltas section now labelled as Tagesverdichtung with explicit date note ("Veränderungen zum Vortag · Stand: <ts>")
- Confidence fill colour: green ≥ 75 %, amber ≥ 45 %, red below
- Remove uncertainty/ref duplication from source badge (now shown in Beobachtungsebene and Evidenzpfad)
- Add 3 server-render tests covering Beobachtungsebene presence, Tagesverdichtung label, and evidence path without observatory node
- Mark all Phase 4 blueprint items [x] in leitstand_visualization.md

Tests: 88 passed, 0 failed"