### PR TITLE
Implement data-bound day-over-day insights comparison with source coherence enforcement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,8 +62,10 @@ so agents can pick up work without re-reading the full roadmap.
 
 - **Phase 0/1 governance**: Scope, source inventory and DoD checklist still need
   to be formally documented (`docs/blueprints/leitstand_visualization.md` §0-§1).
-- **Phase 5 Vortagsvergleich**: Delta-Sektion zeigt heutige Daten, der belastbare
-  Vortagsvergleich auf das konkrete Vortags-Artefakt fehlt als Datenbindung.
+- **Phase 4/5 Vortagsvergleich**: ✅ Umgesetzt — die Erkenntnisse-Ansicht bindet
+  das konkrete Vortags-Artefakt (`insights.daily.<YYYY-MM-DD>.json`) und berechnet
+  ein strukturiertes Delta (Topics/Fragen). Verbleibende Abhängigkeit: produzentseitige
+  Bereitstellung datierter Vortags-Artefakte im Echtbetrieb (Dev/Fixture deckt es ab).
 - **Phase 6 Reflexion-Producer-Contract**: Producer-Contract für
   `heimgeist.reflexion.bundle.v1` ist im Leitstand defensiv geprüft, aber noch
   nicht End-to-End mit dem Producer-Repo abgestimmt.

--- a/audit/impl-registry.yaml
+++ b/audit/impl-registry.yaml
@@ -43,3 +43,16 @@ implementations:
       - tests/server.test.ts
     supersedes: []
     deprecated_by: []
+
+  - id: impl.insights.comparison
+    path: src/insightsComparison.ts
+    impl_type: util
+    status: active
+    documented_by:
+      - docs/blueprints/leitstand_visualization.md
+    verified_by:
+      - tests/insightsComparison.test.ts
+      - tests/controllers/insights.test.ts
+      - tests/server.test.ts
+    supersedes: []
+    deprecated_by: []

--- a/docs/blueprints/leitstand_visualization.md
+++ b/docs/blueprints/leitstand_visualization.md
@@ -59,7 +59,7 @@ Statuslegende: `[ ] offen`, `[~] in Arbeit`, `[x] erledigt`
 - [x] Zwei-Schichten-Sicht implementieren: Beobachtungsebene (Raw) klar getrennt von Interpretation (Insights).
 - [x] Unsicherheits- und Confidence-Darstellung für Insight-Elemente einbauen.
 - [x] Sichtbaren Herkunftspfad anzeigen (Observatorium -> Analyse-Quelle -> insights.daily -> UI).
-- [~] Tagesverdichtung (`insights.daily`) plus Delta zum Vortag visualisieren (UI-Label vorhanden; belastbarer Vortagsvergleich als Datenbindung noch offen).
+- [x] Tagesverdichtung (`insights.daily`) plus Delta zum Vortag visualisieren: belastbarer Vortagsvergleich als Datenbindung gegen das konkrete Vortags-Artefakt (`insights.daily.<YYYY-MM-DD>.json`) implementiert; berechnet neue/entfallene/verschobene Topics und neue/beantwortete Fragen.
 - [~] Akzeptanztest: Jede Insight-Kachel ist bis auf Rohdatenebene zurückverfolgbar (UI/Payload unterstützen per-Insight-`data_refs`; flächendeckende Producer-Befüllung noch offen).
 
 ### 6) Phase 5 umsetzen: Reflexion (Meta-Analyse)
@@ -98,7 +98,7 @@ Statuslegende: `[ ] offen`, `[~] in Arbeit`, `[x] erledigt`
 - [x] Insights-Ansicht zeigt Zwei-Schichten-Sicht: Beobachtungsebene (Digest-Datum, Analyse-Quelle, Observatory-Referenz, Link zur Zeitachse) klar getrennt von der Interpretationsebene (Topics, Fragen, Deltas).
 - [x] Konfidenzbalken in der Beobachtungsebene berechnet aus globalem Unsicherheitswert (`1 - uncertainty`).
 - [x] Sichtbarer Herkunftspfad: Kette Observatorium -> Analyse-Quelle -> insights.daily -> Erkenntnisse-Ansicht mit klickbarem Observatory-Link.
-- [~] Deltas-Sektion als Tagesverdichtung mit Datum gekennzeichnet ("Veränderungen zum Vortag · Stand: …"); ein belastbarer Vergleich auf konkretes Vortags-Artefakt ist noch nicht separat ausgewiesen.
+- [x] Deltas-Sektion als Tagesverdichtung mit Datum gekennzeichnet ("Veränderungen zum Vortag · Stand: …"); zusätzlich ein belastbarer, datengebundener Vergleich auf das konkrete Vortags-Artefakt separat ausgewiesen (siehe Implementierungsstand 2026-05-29).
 - [x] Unsicherheits- und Konfidenzwert in Evidenzpfad-Karte als globale Aussage ausgewiesen.
 - [x] Tests für Zwei-Schichten-Rendering, Evidenzpfad, Konfidenz und Tagesverdichtung in `tests/server.test.ts` ergänzt.
 - [x] Per-Insight-Rohdatenreferenzen (`data_refs`/Drilldown-Ziele) werden im Insights-Payload akzeptiert und pro Topic/Frage/Delta im UI dargestellt.
@@ -135,6 +135,33 @@ Technische Referenzen:
 - `src/views/index.ejs` (Landing-Seite im Dark-Theme mit ARIA-Labels und Phase-Tiles)
 - `tests/utils/eventKind.test.ts` (Event-Familien-Stabilität und Fallback)
 - `tests/controllers/dashboard.test.ts` (Phase-Tiles und Fehler-Isolation)
+
+### Implementierungsstand (2026-05-29)
+
+- [x] Belastbarer Vortagsvergleich als Datenbindung: Die Erkenntnisse-Ansicht lädt
+  zusätzlich zum heutigen `insights.daily` das konkrete Vortags-Artefakt
+  (`insights.daily.<YYYY-MM-DD>.json`, abgeleitet aus `ts − 1 Tag`, analog zur
+  datierten WGX-Metrics-Konvention) und berechnet daraus ein strukturiertes Delta:
+  neue/entfallene/gewichtsveränderte Topics sowie neue/beantwortete Fragen.
+- [x] Das Vortags-Artefakt ist rein supplementär: Es wird über einen
+  nicht-werfenden Optional-Loader geladen, umgeht Strict-Mode-Abbrüche und
+  degradiert bei fehlendem/korruptem Artefakt sichtbar ("Kein belastbares
+  Vortags-Artefakt gebunden") statt stiller Datenverluste.
+- [x] Vom Producer gemeldete `deltas[]` bleiben erhalten, werden aber klar von der
+  berechneten Datenbindung getrennt ("Vom Producer gemeldet").
+- [x] Read-only-Invariante gewahrt: Der Vergleich liest ausschließlich zwei
+  Artefakte und stellt deren Differenz dar; keine Generierung, keine Mutation.
+- [x] Tests: reine Vergleichslogik (`tests/insightsComparison.test.ts`),
+  Controller-Bindung inkl. Fallback-/Invalid-Pfade (`tests/controllers/insights.test.ts`),
+  Render des Vergleichs in der View (`tests/server.test.ts`).
+
+Technische Referenzen:
+
+- `src/insightsComparison.ts` (reine Delta-Berechnung + `previousDateOf`)
+- `src/controllers/insights.ts` (`buildComparison`, Bindung an das Vortags-Artefakt)
+- `src/utils/loader.ts` (`loadOptional` – supplementärer, nicht-werfender Loader)
+- `src/views/insights.ejs` (Vortagsvergleich-Block in der Deltas-Sektion)
+- `src/fixtures/insights.daily.2025-12-27.json` (Vortags-Fixture für Dev/Fixture-Modus)
 
 ## Phase 1: Anatomie (Strukturelle Übersicht)
 

--- a/src/controllers/insights.ts
+++ b/src/controllers/insights.ts
@@ -180,7 +180,7 @@ async function buildComparison(
   if (loaded.data === null) {
     // If today is from artifact but previous-day artifact is missing/invalid,
     // report no-source-coherence to distinguish from general unavailability.
-    const reason = currentSource === 'artifact' && loaded.reason !== 'ok'
+    const reason = currentSource === 'artifact'
       ? 'no-source-coherence'
       : loaded.reason;
 

--- a/src/controllers/insights.ts
+++ b/src/controllers/insights.ts
@@ -30,7 +30,17 @@ export interface ComparisonMeta {
   /** True only when a previous-day artifact was found and yielded a comparison. */
   available: boolean;
   source_kind: 'artifact' | 'fixture' | 'missing';
-  /** 'ok' | 'no-base-date' | 'enoent' | 'invalid-json' | 'invalid-shape'. */
+  /**
+   * Status code: 'ok' | 'no-base-date' | 'no-source-coherence' | 'enoent' | 'empty' | 'invalid-json' | 'error' | 'invalid-shape'.
+   * - 'ok': Comparison available.
+   * - 'no-base-date': Today's ts is invalid/unparseable, so no previous date could be derived.
+   * - 'no-source-coherence': Today is artifact but previous-day artifact missing/invalid (fixture not allowed).
+   * - 'enoent': Previous artifact file not found.
+   * - 'empty': Previous artifact file is empty.
+   * - 'invalid-json': Previous artifact contains invalid JSON.
+   * - 'error': Other read error (e.g., permission denied).
+   * - 'invalid-shape': Previous artifact loaded but failed sanitization (wrong schema).
+   */
   reason: string;
   /** Date we looked up (today's ts minus one day), or null when undeterminable. */
   previous_date: string | null;
@@ -131,32 +141,55 @@ function noComparison(reason: string): Pick<InsightsViewData, 'comparison' | 'co
  * never blocks the page (it is loaded via {@link loadOptional}, bypassing
  * strict-mode aborts).
  *
+ * Enforces source coherence: if today's insights came from an artifact, the
+ * previous day's insights must also come from an artifact (no fixture fallback).
+ * If today is from a fixture, the previous day is loaded from fixture. If today
+ * is missing, no comparison is possible.
+ *
  * Convention (mirrors the dated WGX metrics snapshots): the previous day's
  * payload lives at `insights.daily.<YYYY-MM-DD>.json`, derived from today's ts.
  */
 async function buildComparison(
   current: DailyInsights,
   paths: { artifacts: string; fixtures: string },
+  currentSource: 'artifact' | 'fixture' | 'missing',
 ): Promise<Pick<InsightsViewData, 'comparison' | 'comparison_meta'>> {
+  // If today's insights are missing, no comparison is possible.
+  if (currentSource === 'missing') {
+    return noComparison('no-insights');
+  }
+
   const previousDate = previousDateOf(current.ts);
   if (!previousDate) {
     return noComparison('no-base-date');
   }
 
   const fileName = `insights.daily.${previousDate}.json`;
+
+  // Enforce source coherence: artifact → artifact, fixture → fixture.
+  const allowFixtureFallback = currentSource === 'fixture';
+  const fixturePath = currentSource === 'fixture' ? join(paths.fixtures, fileName) : null;
+
   const loaded = await loadOptional<unknown>(
     join(paths.artifacts, fileName),
-    join(paths.fixtures, fileName),
+    fixturePath,
     'Insights(prev)',
+    { allowFixtureFallback },
   );
 
   if (loaded.data === null) {
+    // If today is from artifact but previous-day artifact is missing/invalid,
+    // report no-source-coherence to distinguish from general unavailability.
+    const reason = currentSource === 'artifact' && loaded.reason !== 'ok'
+      ? 'no-source-coherence'
+      : loaded.reason;
+
     return {
       comparison: null,
       comparison_meta: {
         available: false,
         source_kind: loaded.source,
-        reason: loaded.reason,
+        reason,
         previous_date: previousDate,
         previous_ts: null,
       },
@@ -166,12 +199,17 @@ async function buildComparison(
   const previous = sanitizeDailyInsights(loaded.data);
   if (!previous) {
     console.warn(`[Insights] Ignoring invalid previous-day insights from ${loaded.source} source.`);
+
+    const reason = currentSource === 'artifact'
+      ? 'no-source-coherence'
+      : 'invalid-shape';
+
     return {
       comparison: null,
       comparison_meta: {
         available: false,
         source_kind: loaded.source,
-        reason: 'invalid-shape',
+        reason,
         previous_date: previousDate,
         previous_ts: null,
       },
@@ -185,7 +223,7 @@ async function buildComparison(
       source_kind: loaded.source,
       reason: 'ok',
       previous_date: previousDate,
-      previous_ts: previous.ts || null,
+      previous_ts: previous.ts.trim() || null,
     },
   };
 }
@@ -259,7 +297,7 @@ export async function getInsightsData(): Promise<InsightsViewData> {
     }
   }
 
-  const comparison = await buildComparison(insights, paths);
+  const comparison = await buildComparison(insights, paths, loaded.source);
 
   return {
     insights,

--- a/src/controllers/insights.ts
+++ b/src/controllers/insights.ts
@@ -170,26 +170,15 @@ async function buildComparison(
   // Enforce source coherence: artifact → artifact, fixture → fixture.
   // For fixture source, load from fixture path only (no artifact fallback).
   // For artifact source, load from artifact path only (no fixture fallback).
-  let primaryPath: string;
-  let secondaryPath: string | null;
-  let allowFixtureFallback: boolean;
-
-  if (currentSource === 'fixture') {
-    primaryPath = join(paths.fixtures, fileName);
-    secondaryPath = null; // No fallback to artifact
-    allowFixtureFallback = false;
-  } else {
-    // artifact source
-    primaryPath = join(paths.artifacts, fileName);
-    secondaryPath = null; // No fallback to fixture
-    allowFixtureFallback = false;
-  }
+  const primaryPath = currentSource === 'fixture'
+    ? join(paths.fixtures, fileName)
+    : join(paths.artifacts, fileName);
 
   const loaded = await loadOptional<unknown>(
     primaryPath,
-    secondaryPath,
+    null,
     'Insights(prev)',
-    { allowFixtureFallback },
+    { allowFixtureFallback: false },
   );
 
   if (loaded.data === null) {

--- a/src/controllers/insights.ts
+++ b/src/controllers/insights.ts
@@ -178,7 +178,7 @@ async function buildComparison(
     primaryPath,
     null,
     'Insights(prev)',
-    { allowFixtureFallback: false },
+    { allowFixtureFallback: false, primarySource: currentSource },
   );
 
   if (loaded.data === null) {

--- a/src/controllers/insights.ts
+++ b/src/controllers/insights.ts
@@ -1,8 +1,9 @@
 import { join } from 'path';
 import { envConfig } from '../config.js';
 import { sanitizeDailyInsights, type DailyInsights } from '../insights.js';
+import { compareInsights, previousDateOf, type DayComparison } from '../insightsComparison.js';
 import { getTransportTimestamp } from '../utils/fs.js';
-import { loadWithFallback } from '../utils/loader.js';
+import { loadOptional, loadWithFallback } from '../utils/loader.js';
 
 /**
  * Freshness contract (from contracts/consumers/leitstand.insights.daily.consumer.md):
@@ -21,8 +22,26 @@ interface FreshnessResult {
   freshness_degraded: boolean;
 }
 
+/**
+ * Result of binding today's insights against the previous day's artifact.
+ * Optional: present in the live controller, omitted by lightweight test mocks.
+ */
+export interface ComparisonMeta {
+  /** True only when a previous-day artifact was found and yielded a comparison. */
+  available: boolean;
+  source_kind: 'artifact' | 'fixture' | 'missing';
+  /** 'ok' | 'no-base-date' | 'enoent' | 'invalid-shape'. */
+  reason: string;
+  /** Date we looked up (today's ts minus one day), or null when undeterminable. */
+  previous_date: string | null;
+  /** Actual ts found in the previous-day artifact, or null. */
+  previous_ts: string | null;
+}
+
 export interface InsightsViewData {
   insights: DailyInsights | null;
+  comparison?: DayComparison | null;
+  comparison_meta?: ComparisonMeta;
   view_meta: {
     source_kind: 'artifact' | 'fixture' | 'missing';
     missing_reason: string;
@@ -92,6 +111,85 @@ function computeFreshness(raw: DailyInsights): FreshnessResult {
   };
 }
 
+function noComparison(reason: string): Pick<InsightsViewData, 'comparison' | 'comparison_meta'> {
+  return {
+    comparison: null,
+    comparison_meta: {
+      available: false,
+      source_kind: 'missing',
+      reason,
+      previous_date: null,
+      previous_ts: null,
+    },
+  };
+}
+
+/**
+ * Binds today's insights against the previous day's artifact to produce a
+ * verifiable day-over-day delta. The previous artifact is supplementary: its
+ * absence or corruption degrades gracefully to "no comparison available" and
+ * never blocks the page (it is loaded via {@link loadOptional}, bypassing
+ * strict-mode aborts).
+ *
+ * Convention (mirrors the dated WGX metrics snapshots): the previous day's
+ * payload lives at `insights.daily.<YYYY-MM-DD>.json`, derived from today's ts.
+ */
+async function buildComparison(
+  current: DailyInsights,
+  paths: { artifacts: string; fixtures: string },
+): Promise<Pick<InsightsViewData, 'comparison' | 'comparison_meta'>> {
+  const previousDate = previousDateOf(current.ts);
+  if (!previousDate) {
+    return noComparison('no-base-date');
+  }
+
+  const fileName = `insights.daily.${previousDate}.json`;
+  const loaded = await loadOptional<unknown>(
+    join(paths.artifacts, fileName),
+    join(paths.fixtures, fileName),
+    'Insights(prev)',
+  );
+
+  if (loaded.data === null) {
+    return {
+      comparison: null,
+      comparison_meta: {
+        available: false,
+        source_kind: 'missing',
+        reason: 'enoent',
+        previous_date: previousDate,
+        previous_ts: null,
+      },
+    };
+  }
+
+  const previous = sanitizeDailyInsights(loaded.data);
+  if (!previous) {
+    console.warn(`[Insights] Ignoring invalid previous-day insights from ${loaded.source} source.`);
+    return {
+      comparison: null,
+      comparison_meta: {
+        available: false,
+        source_kind: loaded.source,
+        reason: 'invalid-shape',
+        previous_date: previousDate,
+        previous_ts: null,
+      },
+    };
+  }
+
+  return {
+    comparison: compareInsights(current, previous),
+    comparison_meta: {
+      available: true,
+      source_kind: loaded.source,
+      reason: 'ok',
+      previous_date: previousDate,
+      previous_ts: previous.ts || null,
+    },
+  };
+}
+
 export async function getInsightsData(): Promise<InsightsViewData> {
   const { isStrict, isStrictFail, paths } = envConfig;
 
@@ -107,6 +205,7 @@ export async function getInsightsData(): Promise<InsightsViewData> {
   if (loaded.data === null) {
     return {
       insights: null,
+      ...noComparison('no-insights'),
       view_meta: {
         source_kind: loaded.source,
         missing_reason: loaded.reason,
@@ -128,6 +227,7 @@ export async function getInsightsData(): Promise<InsightsViewData> {
     console.warn(`[Insights] Ignoring invalid insights payload from ${loaded.source} source.`);
     return {
       insights: null,
+      ...noComparison('no-insights'),
       view_meta: {
         source_kind: loaded.source,
         missing_reason: 'invalid-shape',
@@ -159,8 +259,11 @@ export async function getInsightsData(): Promise<InsightsViewData> {
     }
   }
 
+  const comparison = await buildComparison(insights, paths);
+
   return {
     insights,
+    ...comparison,
     view_meta: {
       source_kind: loaded.source,
       missing_reason: loaded.reason,

--- a/src/controllers/insights.ts
+++ b/src/controllers/insights.ts
@@ -30,7 +30,7 @@ export interface ComparisonMeta {
   /** True only when a previous-day artifact was found and yielded a comparison. */
   available: boolean;
   source_kind: 'artifact' | 'fixture' | 'missing';
-  /** 'ok' | 'no-base-date' | 'enoent' | 'invalid-shape'. */
+  /** 'ok' | 'no-base-date' | 'enoent' | 'invalid-json' | 'invalid-shape'. */
   reason: string;
   /** Date we looked up (today's ts minus one day), or null when undeterminable. */
   previous_date: string | null;
@@ -155,8 +155,8 @@ async function buildComparison(
       comparison: null,
       comparison_meta: {
         available: false,
-        source_kind: 'missing',
-        reason: 'enoent',
+        source_kind: loaded.source,
+        reason: loaded.reason,
         previous_date: previousDate,
         previous_ts: null,
       },

--- a/src/controllers/insights.ts
+++ b/src/controllers/insights.ts
@@ -31,15 +31,16 @@ export interface ComparisonMeta {
   available: boolean;
   source_kind: 'artifact' | 'fixture' | 'missing';
   /**
-   * Status code: 'ok' | 'no-base-date' | 'no-source-coherence' | 'enoent' | 'empty' | 'invalid-json' | 'error' | 'invalid-shape'.
+   * Status code indicating availability and failure reason.
    * - 'ok': Comparison available.
+   * - 'no-insights': Today's insights are missing or invalid.
    * - 'no-base-date': Today's ts is invalid/unparseable, so no previous date could be derived.
    * - 'no-source-coherence': Today is artifact but previous-day artifact missing/invalid (fixture not allowed).
+   * - 'invalid-shape': Previous artifact loaded but failed sanitization (wrong schema).
    * - 'enoent': Previous artifact file not found.
    * - 'empty': Previous artifact file is empty.
    * - 'invalid-json': Previous artifact contains invalid JSON.
    * - 'error': Other read error (e.g., permission denied).
-   * - 'invalid-shape': Previous artifact loaded but failed sanitization (wrong schema).
    */
   reason: string;
   /** Date we looked up (today's ts minus one day), or null when undeterminable. */
@@ -167,12 +168,26 @@ async function buildComparison(
   const fileName = `insights.daily.${previousDate}.json`;
 
   // Enforce source coherence: artifact → artifact, fixture → fixture.
-  const allowFixtureFallback = currentSource === 'fixture';
-  const fixturePath = currentSource === 'fixture' ? join(paths.fixtures, fileName) : null;
+  // For fixture source, load from fixture path only (no artifact fallback).
+  // For artifact source, load from artifact path only (no fixture fallback).
+  let primaryPath: string;
+  let secondaryPath: string | null;
+  let allowFixtureFallback: boolean;
+
+  if (currentSource === 'fixture') {
+    primaryPath = join(paths.fixtures, fileName);
+    secondaryPath = null; // No fallback to artifact
+    allowFixtureFallback = false;
+  } else {
+    // artifact source
+    primaryPath = join(paths.artifacts, fileName);
+    secondaryPath = null; // No fallback to fixture
+    allowFixtureFallback = false;
+  }
 
   const loaded = await loadOptional<unknown>(
-    join(paths.artifacts, fileName),
-    fixturePath,
+    primaryPath,
+    secondaryPath,
     'Insights(prev)',
     { allowFixtureFallback },
   );

--- a/src/fixtures/insights.daily.2025-12-27.json
+++ b/src/fixtures/insights.daily.2025-12-27.json
@@ -1,0 +1,20 @@
+{
+  "ts": "2025-12-27",
+  "topics": [
+    ["observatory", 0.8],
+    ["insights.daily", 0.7],
+    ["chronik-events", 0.6]
+  ],
+  "questions": [
+    "Welche Topics aus knowledge.observatory sind stabil über 3 Tage?",
+    "Ist die Observatory-Quelle nach dem Ausfall wieder erreichbar?"
+  ],
+  "deltas": [
+    "Observatory-Quelle nach Wartungsfenster wiederhergestellt."
+  ],
+  "source": "semantAH.daily",
+  "metadata": {
+    "observatory_ref": "obs-example-000",
+    "uncertainty": 0.18
+  }
+}

--- a/src/insightsComparison.ts
+++ b/src/insightsComparison.ts
@@ -171,8 +171,8 @@ export function compareInsights(current: DailyInsights, previous: DailyInsights)
     questions.resolved.length > 0;
 
   return {
-    current_ts: current.ts.trim() !== '' ? current.ts : null,
-    previous_ts: previous.ts.trim() !== '' ? previous.ts : null,
+    current_ts: current.ts.trim() !== '' ? current.ts.trim() : null,
+    previous_ts: previous.ts.trim() !== '' ? previous.ts.trim() : null,
     topics: { added, removed, changed, unchanged },
     questions,
     has_changes: hasChanges,

--- a/src/insightsComparison.ts
+++ b/src/insightsComparison.ts
@@ -1,0 +1,206 @@
+import type { DailyInsights, Topic } from './insights.js';
+
+/**
+ * A topic whose semantic weight changed between two daily insight artifacts.
+ */
+export interface TopicDelta {
+  name: string;
+  /** Score in the previous (Vortag) artifact. */
+  previous: number;
+  /** Score in the current (today) artifact. */
+  current: number;
+  /** current - previous, rounded to 4 decimals to suppress float noise. */
+  diff: number;
+  direction: 'up' | 'down';
+}
+
+/**
+ * A topic that only exists on one of the two compared days.
+ */
+export interface TopicEntry {
+  name: string;
+  score: number;
+}
+
+/**
+ * Structured, data-bound day-over-day comparison between two `insights.daily`
+ * artifacts. Unlike the producer-supplied `deltas[]` (free-text), this is
+ * computed by Leitstand purely from the two payloads, so every entry is
+ * traceable to a concrete topic/question in a concrete dated artifact.
+ *
+ * This is strictly observational: it reads two artifacts and reports the
+ * difference. It never mutates or generates source data.
+ */
+export interface DayComparison {
+  /** ISO date of the current artifact, or null when absent. */
+  current_ts: string | null;
+  /** ISO date of the previous artifact, or null when absent. */
+  previous_ts: string | null;
+  topics: {
+    /** Present today, absent yesterday. */
+    added: TopicEntry[];
+    /** Present yesterday, absent today. */
+    removed: TopicEntry[];
+    /** Present both days with a changed score. */
+    changed: TopicDelta[];
+    /** Count of topics present both days with an unchanged score. */
+    unchanged: number;
+  };
+  questions: {
+    /** Open today, not present yesterday. */
+    added: string[];
+    /** Present yesterday, no longer present today. */
+    resolved: string[];
+  };
+  /** True when any topic or question differs between the two days. */
+  has_changes: boolean;
+}
+
+/**
+ * Scores are floats in [0, 1]; differences below this epsilon are treated as
+ * "unchanged" so float representation noise is not reported as a delta.
+ */
+const SCORE_CHANGE_EPSILON = 1e-6;
+
+function roundTo(value: number, decimals: number): number {
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+}
+
+/**
+ * Builds a name → score lookup, keeping the first occurrence of a name so the
+ * comparison reflects the top-ranked instance when a producer emits duplicates.
+ */
+function toScoreMap(topics: Topic[]): Map<string, number> {
+  const map = new Map<string, number>();
+  for (const [name, score] of topics) {
+    if (!map.has(name)) {
+      map.set(name, score);
+    }
+  }
+  return map;
+}
+
+function diffQuestions(
+  current: string[],
+  previous: string[],
+): { added: string[]; resolved: string[] } {
+  const currentSet = new Set(current.map((q) => q.trim()).filter((q) => q.length > 0));
+  const previousSet = new Set(previous.map((q) => q.trim()).filter((q) => q.length > 0));
+
+  const added: string[] = [];
+  const seenAdded = new Set<string>();
+  for (const question of current) {
+    const key = question.trim();
+    if (key.length === 0 || previousSet.has(key) || seenAdded.has(key)) {
+      continue;
+    }
+    seenAdded.add(key);
+    added.push(question);
+  }
+
+  const resolved: string[] = [];
+  const seenResolved = new Set<string>();
+  for (const question of previous) {
+    const key = question.trim();
+    if (key.length === 0 || currentSet.has(key) || seenResolved.has(key)) {
+      continue;
+    }
+    seenResolved.add(key);
+    resolved.push(question);
+  }
+
+  return { added, resolved };
+}
+
+/**
+ * Computes the day-over-day delta between today's and the previous day's
+ * sanitized daily insights.
+ *
+ * Matching is by exact topic name and trimmed question text. Topic ordering:
+ * added/removed by score descending, changed by absolute delta descending, each
+ * with a stable name tie-breaker; question ordering follows the source artifact.
+ */
+export function compareInsights(current: DailyInsights, previous: DailyInsights): DayComparison {
+  const currentMap = toScoreMap(current.topics);
+  const previousMap = toScoreMap(previous.topics);
+
+  const added: TopicEntry[] = [];
+  const changed: TopicDelta[] = [];
+  let unchanged = 0;
+
+  for (const [name, currentScore] of currentMap) {
+    const previousScore = previousMap.get(name);
+    if (previousScore === undefined) {
+      added.push({ name, score: currentScore });
+      continue;
+    }
+
+    const rawDiff = currentScore - previousScore;
+    if (Math.abs(rawDiff) <= SCORE_CHANGE_EPSILON) {
+      unchanged += 1;
+    } else {
+      changed.push({
+        name,
+        previous: previousScore,
+        current: currentScore,
+        diff: roundTo(rawDiff, 4),
+        direction: rawDiff > 0 ? 'up' : 'down',
+      });
+    }
+  }
+
+  const removed: TopicEntry[] = [];
+  for (const [name, score] of previousMap) {
+    if (!currentMap.has(name)) {
+      removed.push({ name, score });
+    }
+  }
+
+  added.sort((a, b) => b.score - a.score || a.name.localeCompare(b.name));
+  removed.sort((a, b) => b.score - a.score || a.name.localeCompare(b.name));
+  changed.sort((a, b) => Math.abs(b.diff) - Math.abs(a.diff) || a.name.localeCompare(b.name));
+
+  const questions = diffQuestions(current.questions, previous.questions);
+
+  const hasChanges =
+    added.length > 0 ||
+    removed.length > 0 ||
+    changed.length > 0 ||
+    questions.added.length > 0 ||
+    questions.resolved.length > 0;
+
+  return {
+    current_ts: current.ts.trim() !== '' ? current.ts : null,
+    previous_ts: previous.ts.trim() !== '' ? previous.ts : null,
+    topics: { added, removed, changed, unchanged },
+    questions,
+    has_changes: hasChanges,
+  };
+}
+
+/**
+ * Returns the ISO date (YYYY-MM-DD) of the day before `ts`, or null when `ts`
+ * is not a valid calendar date. Used to locate the previous day's artifact.
+ */
+export function previousDateOf(ts: string): string | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(ts.trim());
+  if (!match) {
+    return null;
+  }
+
+  const date = new Date(`${match[1]}-${match[2]}-${match[3]}T00:00:00Z`);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  // Reject values that JS rolled over (e.g. 2025-13-40) so we only ever derive
+  // a previous date from a genuine calendar date.
+  const roundTrip = date.toISOString().slice(0, 10);
+  if (roundTrip !== `${match[1]}-${match[2]}-${match[3]}`) {
+    return null;
+  }
+
+  date.setUTCDate(date.getUTCDate() - 1);
+  return date.toISOString().slice(0, 10);
+}

--- a/src/insightsComparison.ts
+++ b/src/insightsComparison.ts
@@ -171,8 +171,8 @@ export function compareInsights(current: DailyInsights, previous: DailyInsights)
     questions.resolved.length > 0;
 
   return {
-    current_ts: current.ts.trim() !== '' ? current.ts.trim() : null,
-    previous_ts: previous.ts.trim() !== '' ? previous.ts.trim() : null,
+    current_ts: current.ts.trim() || null,
+    previous_ts: previous.ts.trim() || null,
     topics: { added, removed, changed, unchanged },
     questions,
     has_changes: hasChanges,

--- a/src/utils/loader.ts
+++ b/src/utils/loader.ts
@@ -80,6 +80,8 @@ export async function loadWithFallback<T>(
 export interface LoadOptionalOptions {
   /** Whether to try fixture as fallback. If false, only the artifact path is tried. */
   allowFixtureFallback?: boolean;
+  /** Source label for the primary path. Defaults to 'artifact'. */
+  primarySource?: 'artifact' | 'fixture';
 }
 
 /**
@@ -91,8 +93,10 @@ export interface LoadOptionalOptions {
  * or trip strict-fail. Returns the first readable JSON payload, or a `missing`
  * result if none can be read.
  *
- * Supports source coherence: when `allowFixtureFallback` is false, only the artifact
- * path is tried, enabling enforcement of artifact→artifact or fixture→fixture pairings.
+ * Supports source coherence: when `allowFixtureFallback` is false, only the primary path
+ * is tried, enabling enforcement of artifact→artifact or fixture→fixture pairings.
+ * The `primarySource` option specifies how the primary path should be labeled,
+ * enabling correct source tracking even when passing fixture paths as the primary.
  */
 export async function loadOptional<T>(
   artifactPath: string,
@@ -100,10 +104,10 @@ export async function loadOptional<T>(
   name = 'Artifact',
   options: LoadOptionalOptions = {}
 ): Promise<LoadResult<T>> {
-  const { allowFixtureFallback = true } = options;
+  const { allowFixtureFallback = true, primarySource = 'artifact' } = options;
 
   const candidates: Array<{ path: string; source: 'artifact' | 'fixture' }> = [
-    { path: artifactPath, source: 'artifact' },
+    { path: artifactPath, source: primarySource },
   ];
 
   if (allowFixtureFallback && fixturePath !== null) {

--- a/src/utils/loader.ts
+++ b/src/utils/loader.ts
@@ -133,7 +133,7 @@ export async function loadOptional<T>(
     reason = 'invalid-json';
   } else if (lastErr instanceof EmptyFileError) {
     reason = 'empty';
-  } else if (typeof lastErr === 'object' && lastErr !== null && 'code' in lastErr && (lastErr as { code: unknown }).code === 'ENOENT') {
+  } else if (lastErr instanceof Error && 'code' in lastErr && (lastErr as NodeJS.ErrnoException).code === 'ENOENT') {
     reason = 'enoent';
   } else if (lastErr) {
     // For other errors (EACCES, etc), use a generic error code

--- a/src/utils/loader.ts
+++ b/src/utils/loader.ts
@@ -141,14 +141,15 @@ export async function loadOptional<T>(
   }
 
   // Determine precise reason: prioritize by error class severity.
-  // (corruption > other errors like EACCES > empty > enoent)
-  // This ensures system-level errors are surfaced with high priority, not masked by
-  // missing-file scenarios.
+  // System-level errors (EACCES etc) take priority over corruption because they're
+  // operationally more critical—they may indicate infrastructure issues or security
+  // problems that must not be silently masked by other failures.
+  // Priority: error (system/ops) > invalid-json (corruption) > empty > enoent
   let reason = 'error'; // default for unknown errors
-  if (hadCorruption) {
-    reason = 'invalid-json';
-  } else if (hadOtherError) {
+  if (hadOtherError) {
     reason = 'error';
+  } else if (hadCorruption) {
+    reason = 'invalid-json';
   } else if (hadEmpty) {
     reason = 'empty';
   } else if (hadEnoent) {

--- a/src/utils/loader.ts
+++ b/src/utils/loader.ts
@@ -133,7 +133,7 @@ export async function loadOptional<T>(
     reason = 'invalid-json';
   } else if (lastErr instanceof EmptyFileError) {
     reason = 'empty';
-  } else if (lastErr instanceof Error && 'code' in lastErr && (lastErr as NodeJS.ErrnoException).code === 'ENOENT') {
+  } else if (lastErr instanceof Error && (lastErr as NodeJS.ErrnoException).code === 'ENOENT') {
     reason = 'enoent';
   } else if (lastErr) {
     // For other errors (EACCES, etc), use a generic error code

--- a/src/utils/loader.ts
+++ b/src/utils/loader.ts
@@ -118,6 +118,7 @@ export async function loadOptional<T>(
   let hadCorruption = false;
   let hadEmpty = false;
   let hadEnoent = false;
+  let hadOtherError = false;
   for (const { path, source } of candidates) {
     try {
       const data = await readJsonFile<T>(path);
@@ -133,15 +134,21 @@ export async function loadOptional<T>(
         hadEmpty = true;
       } else if (err instanceof Error && (err as NodeJS.ErrnoException).code === 'ENOENT') {
         hadEnoent = true;
+      } else {
+        hadOtherError = true;
       }
     }
   }
 
-  // Determine precise reason: prioritize by error class severity
-  // (corruption > empty > enoent > other)
+  // Determine precise reason: prioritize by error class severity.
+  // (corruption > other errors like EACCES > empty > enoent)
+  // This ensures system-level errors are surfaced with high priority, not masked by
+  // missing-file scenarios.
   let reason = 'error'; // default for unknown errors
   if (hadCorruption) {
     reason = 'invalid-json';
+  } else if (hadOtherError) {
+    reason = 'error';
   } else if (hadEmpty) {
     reason = 'empty';
   } else if (hadEnoent) {

--- a/src/utils/loader.ts
+++ b/src/utils/loader.ts
@@ -116,6 +116,8 @@ export async function loadOptional<T>(
 
   let lastErr: unknown;
   let hadCorruption = false;
+  let hadEmpty = false;
+  let hadEnoent = false;
   for (const { path, source } of candidates) {
     try {
       const data = await readJsonFile<T>(path);
@@ -127,21 +129,26 @@ export async function loadOptional<T>(
       if (err instanceof InvalidJsonError) {
         hadCorruption = true;
         console.warn(`[${name}] Ignoring corrupt optional artifact at ${path}: ${err.message}`);
+      } else if (err instanceof EmptyFileError) {
+        hadEmpty = true;
+      } else if (err instanceof Error && (err as NodeJS.ErrnoException).code === 'ENOENT') {
+        hadEnoent = true;
       }
     }
   }
 
-  // Determine precise reason: distinguish ENOENT vs EmptyFile vs other errors
-  let reason = 'enoent';
+  // Determine precise reason: prioritize by error class severity
+  // (corruption > empty > enoent > other)
+  let reason = 'error'; // default for unknown errors
   if (hadCorruption) {
     reason = 'invalid-json';
-  } else if (lastErr instanceof EmptyFileError) {
+  } else if (hadEmpty) {
     reason = 'empty';
-  } else if (lastErr instanceof Error && (lastErr as NodeJS.ErrnoException).code === 'ENOENT') {
+  } else if (hadEnoent) {
     reason = 'enoent';
-  } else if (lastErr) {
-    // For other errors (EACCES, etc), use a generic error code
-    reason = 'error';
+  } else if (!lastErr) {
+    // No error occurred (shouldn't happen, but safety check)
+    reason = 'enoent';
   }
 
   return { data: null, source: 'missing', reason };

--- a/src/utils/loader.ts
+++ b/src/utils/loader.ts
@@ -76,3 +76,38 @@ export async function loadWithFallback<T>(
     }
   }
 }
+
+/**
+ * Best-effort load of a *supplementary* artifact (artifact → fixture fallback).
+ *
+ * Unlike {@link loadWithFallback}, this never throws and never participates in
+ * strict-mode aborts: a missing or corrupt supplementary artifact (e.g. the
+ * previous day's insights used only for a comparison) must never break the page
+ * or trip strict-fail. Returns the first readable JSON payload, or a `missing`
+ * result if none can be read.
+ */
+export async function loadOptional<T>(
+  artifactPath: string,
+  fixturePath: string,
+  name = 'Artifact'
+): Promise<LoadResult<T>> {
+  const candidates: Array<{ path: string; source: 'artifact' | 'fixture' }> = [
+    { path: artifactPath, source: 'artifact' },
+    { path: fixturePath, source: 'fixture' },
+  ];
+
+  for (const { path, source } of candidates) {
+    try {
+      const data = await readJsonFile<T>(path);
+      return { data, source, reason: 'ok' };
+    } catch (err) {
+      // ENOENT / empty → silently try the next candidate.
+      // Corrupt JSON is non-fatal here but worth a log so it is not lost silently.
+      if (err instanceof InvalidJsonError) {
+        console.warn(`[${name}] Ignoring corrupt optional artifact at ${path}: ${err.message}`);
+      }
+    }
+  }
+
+  return { data: null, source: 'missing', reason: 'enoent' };
+}

--- a/src/utils/loader.ts
+++ b/src/utils/loader.ts
@@ -96,6 +96,7 @@ export async function loadOptional<T>(
     { path: fixturePath, source: 'fixture' },
   ];
 
+  let hadCorruption = false;
   for (const { path, source } of candidates) {
     try {
       const data = await readJsonFile<T>(path);
@@ -104,10 +105,11 @@ export async function loadOptional<T>(
       // ENOENT / empty → silently try the next candidate.
       // Corrupt JSON is non-fatal here but worth a log so it is not lost silently.
       if (err instanceof InvalidJsonError) {
+        hadCorruption = true;
         console.warn(`[${name}] Ignoring corrupt optional artifact at ${path}: ${err.message}`);
       }
     }
   }
 
-  return { data: null, source: 'missing', reason: 'enoent' };
+  return { data: null, source: 'missing', reason: hadCorruption ? 'invalid-json' : 'enoent' };
 }

--- a/src/utils/loader.ts
+++ b/src/utils/loader.ts
@@ -77,31 +77,47 @@ export async function loadWithFallback<T>(
   }
 }
 
+export interface LoadOptionalOptions {
+  /** Whether to try fixture as fallback. If false, only the artifact path is tried. */
+  allowFixtureFallback?: boolean;
+}
+
 /**
- * Best-effort load of a *supplementary* artifact (artifact → fixture fallback).
+ * Best-effort load of a *supplementary* artifact (artifact → fixture fallback, or artifact-only).
  *
  * Unlike {@link loadWithFallback}, this never throws and never participates in
  * strict-mode aborts: a missing or corrupt supplementary artifact (e.g. the
  * previous day's insights used only for a comparison) must never break the page
  * or trip strict-fail. Returns the first readable JSON payload, or a `missing`
  * result if none can be read.
+ *
+ * Supports source coherence: when `allowFixtureFallback` is false, only the artifact
+ * path is tried, enabling enforcement of artifact→artifact or fixture→fixture pairings.
  */
 export async function loadOptional<T>(
   artifactPath: string,
-  fixturePath: string,
-  name = 'Artifact'
+  fixturePath: string | null,
+  name = 'Artifact',
+  options: LoadOptionalOptions = {}
 ): Promise<LoadResult<T>> {
+  const { allowFixtureFallback = true } = options;
+
   const candidates: Array<{ path: string; source: 'artifact' | 'fixture' }> = [
     { path: artifactPath, source: 'artifact' },
-    { path: fixturePath, source: 'fixture' },
   ];
 
+  if (allowFixtureFallback && fixturePath !== null) {
+    candidates.push({ path: fixturePath, source: 'fixture' });
+  }
+
+  let lastErr: unknown;
   let hadCorruption = false;
   for (const { path, source } of candidates) {
     try {
       const data = await readJsonFile<T>(path);
       return { data, source, reason: 'ok' };
     } catch (err) {
+      lastErr = err;
       // ENOENT / empty → silently try the next candidate.
       // Corrupt JSON is non-fatal here but worth a log so it is not lost silently.
       if (err instanceof InvalidJsonError) {
@@ -111,5 +127,18 @@ export async function loadOptional<T>(
     }
   }
 
-  return { data: null, source: 'missing', reason: hadCorruption ? 'invalid-json' : 'enoent' };
+  // Determine precise reason: distinguish ENOENT vs EmptyFile vs other errors
+  let reason = 'enoent';
+  if (hadCorruption) {
+    reason = 'invalid-json';
+  } else if (lastErr instanceof EmptyFileError) {
+    reason = 'empty';
+  } else if (typeof lastErr === 'object' && lastErr !== null && 'code' in lastErr && (lastErr as { code: unknown }).code === 'ENOENT') {
+    reason = 'enoent';
+  } else if (lastErr) {
+    // For other errors (EACCES, etc), use a generic error code
+    reason = 'error';
+  }
+
+  return { data: null, source: 'missing', reason };
 }

--- a/src/views/insights.ejs
+++ b/src/views/insights.ejs
@@ -629,7 +629,9 @@
         const cmp = (typeof comparison !== 'undefined') ? comparison : null;
         const cmpMeta = (typeof comparison_meta !== 'undefined') ? comparison_meta : null;
         const hasCmpChanges = !!(cmp && cmp.has_changes);
-        const showComparisonMissing = !!(cmpMeta && !cmpMeta.available && insights.ts);
+        // Show missing note only when comparison is unavailable AND we have a valid previous_date to have searched
+        // (i.e., not when reason is 'no-base-date' which means we couldn't derive a previous date at all).
+        const showComparisonMissing = !!(cmpMeta && !cmpMeta.available && insights.ts && cmpMeta.reason !== 'no-base-date');
         const showDeltaSection = insights.deltas.length > 0 || !!cmp || showComparisonMissing;
         const pct = (v) => Math.round(Math.min(Math.max(Number(v), 0), 1) * 100);
         const srcLabel = (k) => k === 'artifact' ? 'Artefakt' : k === 'fixture' ? 'Fixture' : 'unbekannt';
@@ -835,7 +837,7 @@
       </div>
       <% } %>
 
-      <% if (insights.topics.length === 0 && insights.questions.length === 0 && insights.deltas.length === 0 && !hasCmpChanges) { %>
+      <% if (insights.topics.length === 0 && insights.questions.length === 0 && !showDeltaSection) { %>
       <div class="empty-state">
         <div class="icon">◎</div>
         <h2>Erkenntnisdaten leer</h2>

--- a/src/views/insights.ejs
+++ b/src/views/insights.ejs
@@ -631,7 +631,7 @@
         const hasCmpChanges = !!(cmp && cmp.has_changes);
         // Show missing note only when comparison is unavailable AND we have a valid previous_date to have searched
         // (i.e., not when reason is 'no-base-date' which means we couldn't derive a previous date at all).
-        const showComparisonMissing = !!(cmpMeta && !cmpMeta.available && insights.ts && cmpMeta.reason !== 'no-base-date');
+        const showComparisonMissing = !!(cmpMeta && !cmpMeta.available && cmpMeta.reason !== 'no-base-date');
         const showDeltaSection = insights.deltas.length > 0 || !!cmp || showComparisonMissing;
         const pct = (v) => Math.round(Math.min(Math.max(Number(v), 0), 1) * 100);
         const srcLabel = (k) => k === 'artifact' ? 'Artefakt' : k === 'fixture' ? 'Fixture' : 'unbekannt';

--- a/src/views/insights.ejs
+++ b/src/views/insights.ejs
@@ -806,7 +806,7 @@
           <% } %>
         </div>
         <% } else if (cmpMeta && !cmpMeta.available && insights.ts) { %>
-        <div class="comparison-missing">Kein belastbares Vortags-Artefakt gebunden<% if (cmpMeta.previous_date) { %> (gesucht: <%= cmpMeta.previous_date %>)<% } %> – unten nur die vom Producer gemeldeten Deltas.</div>
+        <div class="comparison-missing">Kein belastbares Vortags-Artefakt gebunden<% if (cmpMeta.previous_date) { %> (gesucht: <%= cmpMeta.previous_date %>)<% } %><% if (insights.deltas.length > 0) { %> – unten nur die vom Producer gemeldeten Deltas<% } else { %> – keine berechneten Vortagsdaten verfügbar<% } %>.</div>
         <% } %>
 
         <% if (insights.deltas.length > 0) { %>

--- a/src/views/insights.ejs
+++ b/src/views/insights.ejs
@@ -807,7 +807,7 @@
 
           <% } %>
         </div>
-        <% } else if (cmpMeta && !cmpMeta.available && insights.ts) { %>
+        <% } else if (showComparisonMissing) { %>
         <div class="comparison-missing">Kein belastbares Vortags-Artefakt gebunden<% if (cmpMeta.previous_date) { %> (gesucht: <%= cmpMeta.previous_date %>)<% } %><% if (insights.deltas.length > 0) { %> – unten nur die vom Producer gemeldeten Deltas<% } else { %> – keine berechneten Vortagsdaten verfügbar<% } %>.</div>
         <% } %>
 

--- a/src/views/insights.ejs
+++ b/src/views/insights.ejs
@@ -434,6 +434,105 @@
       margin-bottom: 14px;
     }
 
+    /* Data-bound day-over-day comparison (Vortagsvergleich) */
+    .comparison-block {
+      background: rgba(15, 23, 42, 0.55);
+      border: 1px solid rgba(255, 255, 255, 0.06);
+      border-radius: 12px;
+      padding: 14px 16px;
+      margin-bottom: 14px;
+    }
+
+    .comparison-head {
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-bottom: 12px;
+      font-size: 0.74em;
+      color: var(--text-muted);
+    }
+
+    .comparison-pill {
+      font-size: 0.92em;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      padding: 2px 8px;
+      border-radius: 20px;
+      background: rgba(59, 130, 246, 0.08);
+      border: 1px solid rgba(59, 130, 246, 0.2);
+      color: var(--accent);
+    }
+
+    .comparison-range {
+      font-weight: 600;
+      color: var(--text-secondary);
+    }
+
+    .comparison-source { margin-left: auto; }
+
+    .comparison-group { margin-bottom: 12px; }
+    .comparison-group:last-child { margin-bottom: 0; }
+
+    .comparison-group-label {
+      font-size: 0.66em;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--text-muted);
+      margin-bottom: 8px;
+    }
+
+    .comparison-list {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      padding: 0;
+      margin: 0;
+      list-style: none;
+    }
+
+    .cmp {
+      display: flex;
+      align-items: baseline;
+      gap: 8px;
+      font-size: 0.82em;
+      color: var(--text-secondary);
+      flex-wrap: wrap;
+    }
+
+    .cmp-mark {
+      font-size: 0.78em;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      white-space: nowrap;
+    }
+
+    .cmp-added .cmp-mark { color: #22c55e; }
+    .cmp-removed .cmp-mark { color: #ef4444; }
+    .cmp-up .cmp-mark { color: #22c55e; }
+    .cmp-down .cmp-mark { color: #f59e0b; }
+
+    .cmp-name { color: var(--text-primary); font-weight: 500; }
+    .cmp-val { color: var(--text-muted); font-size: 0.92em; }
+    .cmp-diff { color: var(--text-muted); font-size: 0.88em; }
+    .cmp-text { color: var(--text-secondary); }
+
+    .comparison-note,
+    .comparison-empty {
+      font-size: 0.74em;
+      color: var(--text-muted);
+      margin-top: 8px;
+    }
+
+    .comparison-missing {
+      font-size: 0.74em;
+      color: var(--warn);
+      margin-bottom: 14px;
+    }
+
     /* Evidence path */
     .evidenz-card {
       background: rgba(15, 23, 42, 0.5);
@@ -526,6 +625,12 @@
         const topicDataRefs = insights.data_refs?.topics ?? {};
         const questionDataRefs = insights.data_refs?.questions ?? {};
         const deltaDataRefs = insights.data_refs?.deltas ?? {};
+        // Data-bound previous-day comparison (optional; absent in lightweight mocks).
+        const cmp = (typeof comparison !== 'undefined') ? comparison : null;
+        const cmpMeta = (typeof comparison_meta !== 'undefined') ? comparison_meta : null;
+        const hasCmpChanges = !!(cmp && cmp.has_changes);
+        const pct = (v) => Math.round(Math.min(Math.max(Number(v), 0), 1) * 100);
+        const srcLabel = (k) => k === 'artifact' ? 'Artefakt' : k === 'fixture' ? 'Fixture' : 'unbekannt';
       %>
 
       <!-- ── Beobachtungsebene ───────────────────────────────── -->
@@ -639,7 +744,7 @@
       </div>
       <% } %>
 
-      <% if (insights.deltas.length > 0) { %>
+      <% if (insights.deltas.length > 0 || cmp) { %>
       <div class="section">
         <div class="layer-header" style="margin-bottom:4px;">
           <span class="layer-label interp">Deltas</span>
@@ -648,6 +753,62 @@
         <% if (insights.ts) { %>
         <div class="delta-date-note">Veränderungen zum Vortag · Stand: <%= insights.ts %></div>
         <% } %>
+
+        <% if (cmp) { %>
+        <!-- Belastbarer, datengebundener Vortagsvergleich gegen das konkrete Vortags-Artefakt -->
+        <div class="comparison-block" data-testid="vortagsvergleich">
+          <div class="comparison-head">
+            <span class="comparison-pill">berechnet</span>
+            <span class="comparison-range"><%= cmp.previous_ts || (cmpMeta && cmpMeta.previous_date) || 'Vortag' %> → <%= cmp.current_ts || insights.ts %></span>
+            <% if (cmpMeta) { %><span class="comparison-source">Quelle: <%= srcLabel(cmpMeta.source_kind) %></span><% } %>
+          </div>
+
+          <% if (!cmp.has_changes) { %>
+          <div class="comparison-empty">Keine strukturellen Änderungen gegenüber dem Vortag – Topics und Fragen sind stabil.</div>
+          <% } else { %>
+
+            <% if (cmp.topics.added.length || cmp.topics.removed.length || cmp.topics.changed.length) { %>
+            <div class="comparison-group">
+              <div class="comparison-group-label">Topics</div>
+              <ul class="comparison-list">
+                <% for (const t of cmp.topics.added) { %>
+                <li class="cmp cmp-added"><span class="cmp-mark">＋ neu</span> <span class="cmp-name"><%= t.name %></span> <span class="cmp-val"><%= pct(t.score) %>%</span></li>
+                <% } %>
+                <% for (const t of cmp.topics.changed) { %>
+                <li class="cmp cmp-<%= t.direction %>"><span class="cmp-mark"><%= t.direction === 'up' ? '▲' : '▼' %></span> <span class="cmp-name"><%= t.name %></span> <span class="cmp-val"><%= pct(t.previous) %>% → <%= pct(t.current) %>%</span> <span class="cmp-diff">(<%= t.diff > 0 ? '+' : '' %><%= Math.round(t.diff * 100) %> pp)</span></li>
+                <% } %>
+                <% for (const t of cmp.topics.removed) { %>
+                <li class="cmp cmp-removed"><span class="cmp-mark">－ entfallen</span> <span class="cmp-name"><%= t.name %></span> <span class="cmp-val"><%= pct(t.score) %>%</span></li>
+                <% } %>
+              </ul>
+              <% if (cmp.topics.unchanged > 0) { %>
+              <div class="comparison-note"><%= cmp.topics.unchanged %> Topic(s) unverändert</div>
+              <% } %>
+            </div>
+            <% } %>
+
+            <% if (cmp.questions.added.length || cmp.questions.resolved.length) { %>
+            <div class="comparison-group">
+              <div class="comparison-group-label">Offene Fragen</div>
+              <ul class="comparison-list">
+                <% for (const q of cmp.questions.added) { %>
+                <li class="cmp cmp-added"><span class="cmp-mark">＋ neu</span> <span class="cmp-text"><%= q %></span></li>
+                <% } %>
+                <% for (const q of cmp.questions.resolved) { %>
+                <li class="cmp cmp-removed"><span class="cmp-mark">－ entfallen</span> <span class="cmp-text"><%= q %></span></li>
+                <% } %>
+              </ul>
+            </div>
+            <% } %>
+
+          <% } %>
+        </div>
+        <% } else if (cmpMeta && !cmpMeta.available && insights.ts) { %>
+        <div class="comparison-missing">Kein belastbares Vortags-Artefakt gebunden<% if (cmpMeta.previous_date) { %> (gesucht: <%= cmpMeta.previous_date %>)<% } %> – unten nur die vom Producer gemeldeten Deltas.</div>
+        <% } %>
+
+        <% if (insights.deltas.length > 0) { %>
+        <% if (cmp) { %><div class="comparison-group-label" style="margin-top:14px;">Vom Producer gemeldet</div><% } %>
         <ul class="item-list deltas-list">
           <% for (let idx = 0; idx < insights.deltas.length; idx++) { %>
           <% const delta = insights.deltas[idx]; %>
@@ -668,10 +829,11 @@
           </li>
           <% } %>
         </ul>
+        <% } %>
       </div>
       <% } %>
 
-      <% if (insights.topics.length === 0 && insights.questions.length === 0 && insights.deltas.length === 0) { %>
+      <% if (insights.topics.length === 0 && insights.questions.length === 0 && insights.deltas.length === 0 && !hasCmpChanges) { %>
       <div class="empty-state">
         <div class="icon">◎</div>
         <h2>Erkenntnisdaten leer</h2>

--- a/src/views/insights.ejs
+++ b/src/views/insights.ejs
@@ -629,6 +629,8 @@
         const cmp = (typeof comparison !== 'undefined') ? comparison : null;
         const cmpMeta = (typeof comparison_meta !== 'undefined') ? comparison_meta : null;
         const hasCmpChanges = !!(cmp && cmp.has_changes);
+        const showComparisonMissing = !!(cmpMeta && !cmpMeta.available && insights.ts);
+        const showDeltaSection = insights.deltas.length > 0 || !!cmp || showComparisonMissing;
         const pct = (v) => Math.round(Math.min(Math.max(Number(v), 0), 1) * 100);
         const srcLabel = (k) => k === 'artifact' ? 'Artefakt' : k === 'fixture' ? 'Fixture' : 'unbekannt';
       %>
@@ -744,7 +746,7 @@
       </div>
       <% } %>
 
-      <% if (insights.deltas.length > 0 || cmp) { %>
+      <% if (showDeltaSection) { %>
       <div class="section">
         <div class="layer-header" style="margin-bottom:4px;">
           <span class="layer-label interp">Deltas</span>

--- a/tests/controllers/insights.test.ts
+++ b/tests/controllers/insights.test.ts
@@ -473,5 +473,28 @@ describe('getInsightsData controller', () => {
         previous_date: '2025-12-27',
       });
     });
+
+    it('propagates invalid-json reason when previous-day artifact is corrupt', async () => {
+      vi.mocked(loadWithFallback).mockResolvedValue({
+        data: { ...fixtureInsights, ts: '2025-12-28' },
+        source: 'artifact',
+        reason: 'ok',
+      });
+      vi.mocked(loadOptional).mockResolvedValue({
+        data: null,
+        source: 'missing',
+        reason: 'invalid-json',
+      });
+
+      const result = await getInsightsData();
+
+      expect(result.comparison).toBeNull();
+      expect(result.comparison_meta).toMatchObject({
+        available: false,
+        reason: 'invalid-json',
+        previous_date: '2025-12-27',
+        source_kind: 'missing',
+      });
+    });
   });
 });

--- a/tests/controllers/insights.test.ts
+++ b/tests/controllers/insights.test.ts
@@ -2,10 +2,11 @@ import { stat } from 'fs/promises';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { resetEnvConfig } from '../../src/config.js';
 import { getInsightsData } from '../../src/controllers/insights.js';
-import { loadWithFallback } from '../../src/utils/loader.js';
+import { loadOptional, loadWithFallback } from '../../src/utils/loader.js';
 
 vi.mock('../../src/utils/loader.js', () => ({
   loadWithFallback: vi.fn(),
+  loadOptional: vi.fn(),
 }));
 
 vi.mock('fs/promises', () => ({
@@ -32,6 +33,8 @@ describe('getInsightsData controller', () => {
     resetEnvConfig();
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.mocked(stat).mockResolvedValue({ mtime: new Date('2026-03-30T00:00:00.000Z') } as Awaited<ReturnType<typeof stat>>);
+    // By default no previous-day artifact is available; comparison stays null.
+    vi.mocked(loadOptional).mockResolvedValue({ data: null, source: 'missing', reason: 'enoent' });
   });
 
   afterEach(() => {
@@ -367,5 +370,108 @@ describe('getInsightsData controller', () => {
     const result = await getInsightsData();
 
     expect(result.view_meta.is_strict).toBe(true);
+  });
+
+  describe('previous-day comparison (Vortagsvergleich)', () => {
+    it('binds against the previous-day artifact and computes a structured delta', async () => {
+      vi.mocked(loadWithFallback).mockResolvedValue({
+        data: { ...fixtureInsights, ts: '2025-12-28' },
+        source: 'artifact',
+        reason: 'ok',
+      });
+      vi.mocked(loadOptional).mockResolvedValue({
+        data: {
+          ts: '2025-12-27',
+          topics: [
+            ['observatory', 0.8],
+            ['insights.daily', 0.7],
+            ['chronik-events', 0.6],
+          ],
+          questions: ['Welche Topics sind stabil?'],
+          deltas: [],
+        },
+        source: 'artifact',
+        reason: 'ok',
+      });
+
+      const result = await getInsightsData();
+
+      // Looks up the day before today's ts via the dated-artifact convention.
+      const optionalArgs = vi.mocked(loadOptional).mock.calls[0];
+      expect(optionalArgs[0]).toContain('insights.daily.2025-12-27.json');
+      expect(optionalArgs[1]).toContain('insights.daily.2025-12-27.json');
+
+      expect(result.comparison_meta).toMatchObject({
+        available: true,
+        source_kind: 'artifact',
+        reason: 'ok',
+        previous_date: '2025-12-27',
+        previous_ts: '2025-12-27',
+      });
+
+      const cmp = result.comparison;
+      expect(cmp).not.toBeNull();
+      expect(cmp?.has_changes).toBe(true);
+      // observatory 0.8 → 0.9, insights.daily unchanged, leitstand-ui added, chronik-events removed
+      expect(cmp?.topics.added.map((t) => t.name)).toEqual(['leitstand-ui']);
+      expect(cmp?.topics.removed.map((t) => t.name)).toEqual(['chronik-events']);
+      expect(cmp?.topics.changed).toHaveLength(1);
+      expect(cmp?.topics.changed[0]).toMatchObject({ name: 'observatory', direction: 'up' });
+      expect(cmp?.topics.unchanged).toBe(1);
+    });
+
+    it('reports comparison unavailable when no previous-day artifact exists', async () => {
+      vi.mocked(loadWithFallback).mockResolvedValue({
+        data: { ...fixtureInsights, ts: '2025-12-28' },
+        source: 'artifact',
+        reason: 'ok',
+      });
+      vi.mocked(loadOptional).mockResolvedValue({ data: null, source: 'missing', reason: 'enoent' });
+
+      const result = await getInsightsData();
+
+      expect(result.comparison).toBeNull();
+      expect(result.comparison_meta).toMatchObject({
+        available: false,
+        reason: 'enoent',
+        previous_date: '2025-12-27',
+      });
+    });
+
+    it('skips comparison when today has no parseable base date', async () => {
+      vi.mocked(loadWithFallback).mockResolvedValue({
+        data: { ...fixtureInsights, ts: '', metadata: { generated_at: '2026-03-30T02:00:00.000Z' } },
+        source: 'artifact',
+        reason: 'ok',
+      });
+
+      const result = await getInsightsData();
+
+      expect(result.comparison).toBeNull();
+      expect(result.comparison_meta).toMatchObject({ available: false, reason: 'no-base-date' });
+      expect(loadOptional).not.toHaveBeenCalled();
+    });
+
+    it('degrades to unavailable when the previous-day artifact is invalid', async () => {
+      vi.mocked(loadWithFallback).mockResolvedValue({
+        data: { ...fixtureInsights, ts: '2025-12-28' },
+        source: 'fixture',
+        reason: 'enoent',
+      });
+      vi.mocked(loadOptional).mockResolvedValue({
+        data: { ts: 123, topics: 'nope' },
+        source: 'fixture',
+        reason: 'ok',
+      });
+
+      const result = await getInsightsData();
+
+      expect(result.comparison).toBeNull();
+      expect(result.comparison_meta).toMatchObject({
+        available: false,
+        reason: 'invalid-shape',
+        previous_date: '2025-12-27',
+      });
+    });
   });
 });

--- a/tests/controllers/insights.test.ts
+++ b/tests/controllers/insights.test.ts
@@ -373,7 +373,7 @@ describe('getInsightsData controller', () => {
   });
 
   describe('previous-day comparison (Vortagsvergleich)', () => {
-    it('binds against the previous-day artifact and computes a structured delta', async () => {
+   it('binds against the previous-day artifact and computes a structured delta', async () => {
       vi.mocked(loadWithFallback).mockResolvedValue({
         data: { ...fixtureInsights, ts: '2025-12-28' },
         source: 'artifact',
@@ -397,9 +397,12 @@ describe('getInsightsData controller', () => {
       const result = await getInsightsData();
 
       // Looks up the day before today's ts via the dated-artifact convention.
+      // When today is from artifact, fixturePath is null (enforcing source coherence).
       const optionalArgs = vi.mocked(loadOptional).mock.calls[0];
       expect(optionalArgs[0]).toContain('insights.daily.2025-12-27.json');
-      expect(optionalArgs[1]).toContain('insights.daily.2025-12-27.json');
+      expect(optionalArgs[1]).toBe(null);
+      // allowFixtureFallback option should be false (artifact-only when today is artifact)
+      expect(optionalArgs[3]).toMatchObject({ allowFixtureFallback: false });
 
       expect(result.comparison_meta).toMatchObject({
         available: true,
@@ -433,7 +436,8 @@ describe('getInsightsData controller', () => {
       expect(result.comparison).toBeNull();
       expect(result.comparison_meta).toMatchObject({
         available: false,
-        reason: 'enoent',
+        // When today is from artifact but previous is missing, report no-source-coherence instead of enoent
+        reason: 'no-source-coherence',
         previous_date: '2025-12-27',
       });
     });
@@ -491,7 +495,8 @@ describe('getInsightsData controller', () => {
       expect(result.comparison).toBeNull();
       expect(result.comparison_meta).toMatchObject({
         available: false,
-        reason: 'invalid-json',
+        // When today is from artifact but previous is invalid, report no-source-coherence instead of invalid-json
+        reason: 'no-source-coherence',
         previous_date: '2025-12-27',
         source_kind: 'missing',
       });

--- a/tests/controllers/insights.test.ts
+++ b/tests/controllers/insights.test.ts
@@ -501,5 +501,85 @@ describe('getInsightsData controller', () => {
         source_kind: 'missing',
       });
     });
+
+    it('enforces source coherence: artifact→artifact (no fixture fallback)', async () => {
+      vi.mocked(loadWithFallback).mockResolvedValue({
+        data: { ...fixtureInsights, ts: '2025-12-28' },
+        source: 'artifact',
+        reason: 'ok',
+      });
+      vi.mocked(loadOptional).mockResolvedValue({
+        data: {
+          ts: '2025-12-27',
+          topics: [['observatory', 0.8]],
+          questions: [],
+          deltas: [],
+        },
+        source: 'artifact',
+        reason: 'ok',
+      });
+
+      const result = await getInsightsData();
+
+      // Verify that when today is artifact, loadOptional is called with:
+      // - artifact path as primary
+      // - null as fixturePath (no fallback allowed)
+      // - allowFixtureFallback: false
+      // - primarySource: 'artifact'
+      const optionalCall = vi.mocked(loadOptional).mock.calls[0];
+      expect(optionalCall[0]).toContain('artifacts');
+      expect(optionalCall[0]).toContain('insights.daily.2025-12-27.json');
+      expect(optionalCall[1]).toBe(null); // No fixture fallback
+      expect(optionalCall[3]).toMatchObject({
+        allowFixtureFallback: false,
+        primarySource: 'artifact',
+      });
+
+      // Comparison should succeed with artifact source
+      expect(result.comparison_meta).toMatchObject({
+        available: true,
+        source_kind: 'artifact',
+      });
+    });
+
+    it('enforces source coherence: fixture→fixture (with correct source tracking)', async () => {
+      vi.mocked(loadWithFallback).mockResolvedValue({
+        data: { ...fixtureInsights, ts: '2025-12-28' },
+        source: 'fixture', // Today from fixture
+        reason: 'enoent',
+      });
+      vi.mocked(loadOptional).mockResolvedValue({
+        data: {
+          ts: '2025-12-27',
+          topics: [['observatory', 0.8]],
+          questions: [],
+          deltas: [],
+        },
+        source: 'fixture',
+        reason: 'ok',
+      });
+
+      const result = await getInsightsData();
+
+      // Verify that when today is fixture, loadOptional is called with:
+      // - fixture path as primary (not artifact path)
+      // - null as fixturePath (no dual candidates)
+      // - allowFixtureFallback: false
+      // - primarySource: 'fixture'
+      const optionalCall = vi.mocked(loadOptional).mock.calls[0];
+      expect(optionalCall[0]).toContain('fixtures');
+      expect(optionalCall[0]).toContain('insights.daily.2025-12-27.json');
+      expect(optionalCall[1]).toBe(null); // No additional candidates
+      expect(optionalCall[3]).toMatchObject({
+        allowFixtureFallback: false,
+        primarySource: 'fixture',
+      });
+
+      // Comparison should succeed with fixture source
+      expect(result.comparison_meta).toMatchObject({
+        available: true,
+        source_kind: 'fixture',
+      });
+    });
   });
 });

--- a/tests/insightsComparison.test.ts
+++ b/tests/insightsComparison.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest';
+import { compareInsights, previousDateOf } from '../src/insightsComparison.js';
+import type { DailyInsights } from '../src/insights.js';
+
+function insights(partial: Partial<DailyInsights>): DailyInsights {
+  return {
+    ts: '2025-12-28',
+    topics: [],
+    questions: [],
+    deltas: [],
+    ...partial,
+  };
+}
+
+describe('compareInsights', () => {
+  it('classifies topics into added, removed, changed and unchanged', () => {
+    const current = insights({
+      ts: '2025-12-28',
+      topics: [
+        ['observatory', 0.9],
+        ['insights.daily', 0.7],
+        ['leitstand-ui', 0.5],
+      ],
+    });
+    const previous = insights({
+      ts: '2025-12-27',
+      topics: [
+        ['observatory', 0.8],
+        ['insights.daily', 0.7],
+        ['chronik-events', 0.6],
+      ],
+    });
+
+    const result = compareInsights(current, previous);
+
+    expect(result.current_ts).toBe('2025-12-28');
+    expect(result.previous_ts).toBe('2025-12-27');
+    expect(result.topics.added).toEqual([{ name: 'leitstand-ui', score: 0.5 }]);
+    expect(result.topics.removed).toEqual([{ name: 'chronik-events', score: 0.6 }]);
+    expect(result.topics.changed).toEqual([
+      { name: 'observatory', previous: 0.8, current: 0.9, diff: 0.1, direction: 'up' },
+    ]);
+    expect(result.topics.unchanged).toBe(1);
+    expect(result.has_changes).toBe(true);
+  });
+
+  it('captures downward score movement', () => {
+    const result = compareInsights(
+      insights({ topics: [['ci', 0.3]] }),
+      insights({ topics: [['ci', 0.75]] }),
+    );
+
+    expect(result.topics.changed).toHaveLength(1);
+    expect(result.topics.changed[0]).toMatchObject({ name: 'ci', direction: 'down', diff: -0.45 });
+  });
+
+  it('treats sub-epsilon score noise as unchanged', () => {
+    const result = compareInsights(
+      insights({ topics: [['x', 0.5000001]] }),
+      insights({ topics: [['x', 0.5]] }),
+    );
+
+    expect(result.topics.changed).toHaveLength(0);
+    expect(result.topics.unchanged).toBe(1);
+    expect(result.has_changes).toBe(false);
+  });
+
+  it('diffs questions by trimmed text, preserving order and de-duplicating', () => {
+    const current = insights({
+      questions: ['  Stabil?  ', 'Neu heute?', 'Neu heute?'],
+    });
+    const previous = insights({
+      questions: ['Stabil?', 'Gestern offen?'],
+    });
+
+    const result = compareInsights(current, previous);
+
+    expect(result.questions.added).toEqual(['Neu heute?']);
+    expect(result.questions.resolved).toEqual(['Gestern offen?']);
+  });
+
+  it('sorts added/removed by score desc and changed by absolute delta desc', () => {
+    const current = insights({
+      topics: [
+        ['low', 0.2],
+        ['high', 0.9],
+        ['big-mover', 0.95],
+        ['small-mover', 0.55],
+      ],
+    });
+    const previous = insights({
+      topics: [
+        ['gone-small', 0.1],
+        ['gone-big', 0.8],
+        ['big-mover', 0.15],
+        ['small-mover', 0.5],
+      ],
+    });
+
+    const result = compareInsights(current, previous);
+
+    expect(result.topics.added.map((t) => t.name)).toEqual(['high', 'low']);
+    expect(result.topics.removed.map((t) => t.name)).toEqual(['gone-big', 'gone-small']);
+    expect(result.topics.changed.map((t) => t.name)).toEqual(['big-mover', 'small-mover']);
+  });
+
+  it('keeps only the first occurrence of a duplicated topic name', () => {
+    const result = compareInsights(
+      insights({ topics: [['dup', 0.9], ['dup', 0.1]] }),
+      insights({ topics: [['dup', 0.9]] }),
+    );
+
+    expect(result.topics.changed).toHaveLength(0);
+    expect(result.topics.unchanged).toBe(1);
+  });
+
+  it('reports no changes for identical payloads', () => {
+    const payload = insights({ topics: [['a', 0.5]], questions: ['q?'] });
+    const result = compareInsights(payload, insights({ topics: [['a', 0.5]], questions: ['q?'] }));
+
+    expect(result.has_changes).toBe(false);
+    expect(result.topics.added).toEqual([]);
+    expect(result.topics.removed).toEqual([]);
+    expect(result.topics.changed).toEqual([]);
+    expect(result.questions.added).toEqual([]);
+    expect(result.questions.resolved).toEqual([]);
+  });
+
+  it('exposes null ts when a payload has an empty date', () => {
+    const result = compareInsights(insights({ ts: '' }), insights({ ts: '2025-12-27' }));
+    expect(result.current_ts).toBeNull();
+    expect(result.previous_ts).toBe('2025-12-27');
+  });
+});
+
+describe('previousDateOf', () => {
+  it('returns the day before a valid date', () => {
+    expect(previousDateOf('2025-12-28')).toBe('2025-12-27');
+  });
+
+  it('handles month and year boundaries', () => {
+    expect(previousDateOf('2026-01-01')).toBe('2025-12-31');
+    expect(previousDateOf('2025-03-01')).toBe('2025-02-28');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(previousDateOf('  2025-12-28  ')).toBe('2025-12-27');
+  });
+
+  it('rejects malformed or non-calendar dates', () => {
+    expect(previousDateOf('')).toBeNull();
+    expect(previousDateOf('2025-12')).toBeNull();
+    expect(previousDateOf('not-a-date')).toBeNull();
+    expect(previousDateOf('2025-13-40')).toBeNull();
+    expect(previousDateOf('2025-02-30')).toBeNull();
+  });
+});

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -635,6 +635,113 @@ describe('GET /insights', () => {
     expect(res.text).toContain('Neue Observatory-Quelle verfügbar.');
   });
 
+  it('should render the data-bound previous-day comparison when available', async () => {
+    const insightsController = await import('../src/controllers/insights.js');
+    vi.spyOn(insightsController, 'getInsightsData').mockResolvedValueOnce({
+      insights: {
+        ts: '2025-12-28',
+        topics: [['observatory', 0.9], ['leitstand-ui', 0.5]],
+        questions: ['Welche Deltas sind echte Trendwechsel?'],
+        deltas: ['Producer-Notiz zum Tag.'],
+      },
+      comparison: {
+        current_ts: '2025-12-28',
+        previous_ts: '2025-12-27',
+        topics: {
+          added: [{ name: 'leitstand-ui', score: 0.5 }],
+          removed: [{ name: 'chronik-events', score: 0.6 }],
+          changed: [{ name: 'observatory', previous: 0.8, current: 0.9, diff: 0.1, direction: 'up' }],
+          unchanged: 1,
+        },
+        questions: {
+          added: ['Welche Deltas sind echte Trendwechsel?'],
+          resolved: ['Ist die Observatory-Quelle erreichbar?'],
+        },
+        has_changes: true,
+      },
+      comparison_meta: {
+        available: true,
+        source_kind: 'fixture',
+        reason: 'ok',
+        previous_date: '2025-12-27',
+        previous_ts: '2025-12-27',
+      },
+      view_meta: {
+        source_kind: 'fixture',
+        missing_reason: 'enoent',
+        is_strict: false,
+        data_timestamp: '2025-12-28T00:00:00.000Z',
+        data_age_minutes: 60,
+        freshness_state: 'fresh',
+        freshness_source: 'ts',
+        freshness_degraded: false,
+        stale_after_hours: 30,
+        uncertainty: null,
+        observatory_ref: null,
+      },
+    });
+
+    const res = await request(app).get('/insights');
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('data-testid="vortagsvergleich"');
+    expect(res.text).toContain('berechnet');
+    // Range header references both dates of the bound artifacts
+    expect(res.text).toContain('2025-12-27 → 2025-12-28');
+    // Topic transitions
+    expect(res.text).toContain('leitstand-ui');
+    expect(res.text).toContain('chronik-events');
+    expect(res.text).toContain('observatory');
+    expect(res.text).toContain('80% → 90%');
+    expect(res.text).toContain('1 Topic(s) unverändert');
+    // Question transitions
+    expect(res.text).toContain('Ist die Observatory-Quelle erreichbar?');
+    // Producer deltas remain, but clearly separated
+    expect(res.text).toContain('Vom Producer gemeldet');
+    expect(res.text).toContain('Producer-Notiz zum Tag.');
+  });
+
+  it('should note a missing previous-day artifact instead of faking a comparison', async () => {
+    const insightsController = await import('../src/controllers/insights.js');
+    vi.spyOn(insightsController, 'getInsightsData').mockResolvedValueOnce({
+      insights: {
+        ts: '2025-12-28',
+        topics: [['observatory', 0.9]],
+        questions: [],
+        deltas: ['Producer-only delta'],
+      },
+      comparison: null,
+      comparison_meta: {
+        available: false,
+        source_kind: 'missing',
+        reason: 'enoent',
+        previous_date: '2025-12-27',
+        previous_ts: null,
+      },
+      view_meta: {
+        source_kind: 'artifact',
+        missing_reason: 'ok',
+        is_strict: false,
+        data_timestamp: '2025-12-28T00:00:00.000Z',
+        data_age_minutes: 60,
+        freshness_state: 'fresh',
+        freshness_source: 'ts',
+        freshness_degraded: false,
+        stale_after_hours: 30,
+        uncertainty: null,
+        observatory_ref: null,
+      },
+    });
+
+    const res = await request(app).get('/insights');
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Kein belastbares Vortags-Artefakt gebunden');
+    expect(res.text).toContain('2025-12-27');
+    expect(res.text).toContain('Producer-only delta');
+    expect(res.text).not.toContain('data-testid="vortagsvergleich"');
+  });
+
   it('should render evidence path without observatory node when ref is absent', async () => {
     const insightsController = await import('../src/controllers/insights.js');
     vi.spyOn(insightsController, 'getInsightsData').mockResolvedValueOnce({

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -701,6 +701,46 @@ describe('GET /insights', () => {
     expect(res.text).toContain('Producer-Notiz zum Tag.');
   });
 
+  it('should show missing-artifact note even when deltas array is empty', async () => {
+    const insightsController = await import('../src/controllers/insights.js');
+    vi.spyOn(insightsController, 'getInsightsData').mockResolvedValueOnce({
+      insights: {
+        ts: '2025-12-28',
+        topics: [['observatory', 0.9]],
+        questions: ['Stabil?'],
+        deltas: [],
+      },
+      comparison: null,
+      comparison_meta: {
+        available: false,
+        source_kind: 'missing',
+        reason: 'enoent',
+        previous_date: '2025-12-27',
+        previous_ts: null,
+      },
+      view_meta: {
+        source_kind: 'artifact',
+        missing_reason: 'ok',
+        is_strict: false,
+        data_timestamp: '2025-12-28T00:00:00.000Z',
+        data_age_minutes: 60,
+        freshness_state: 'fresh',
+        freshness_source: 'ts',
+        freshness_degraded: false,
+        stale_after_hours: 30,
+        uncertainty: null,
+        observatory_ref: null,
+      },
+    });
+
+    const res = await request(app).get('/insights');
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Kein belastbares Vortags-Artefakt gebunden');
+    expect(res.text).toContain('2025-12-27');
+    expect(res.text).not.toContain('data-testid="vortagsvergleich"');
+  });
+
   it('should note a missing previous-day artifact instead of faking a comparison', async () => {
     const insightsController = await import('../src/controllers/insights.js');
     vi.spyOn(insightsController, 'getInsightsData').mockResolvedValueOnce({

--- a/tests/utils/loader.test.ts
+++ b/tests/utils/loader.test.ts
@@ -3,7 +3,6 @@ import { mkdtemp, writeFile, rm } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { loadWithFallback, loadOptional } from '../../src/utils/loader.js';
-import { EmptyFileError } from '../../src/utils/fs.js';
 
 describe('loadWithFallback', () => {
   let testDir: string;
@@ -168,16 +167,16 @@ describe('loadWithFallback', () => {
       // Create an empty artifact file (only whitespace)
       await createArtifact('   \n  \t  ');
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-      
+
       const result = await loadOptional(artifactPath, fixturePath, 'Test');
-      
+
       // Should report 'empty' reason
       expect(result).toMatchObject({
         data: null,
         source: 'missing',
         reason: 'empty',
       });
-      
+
       warnSpy.mockRestore();
     });
 
@@ -187,16 +186,16 @@ describe('loadWithFallback', () => {
       // Create a valid fixture
       await createFixture('{"val": 88}');
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-      
+
       const result = await loadOptional(artifactPath, fixturePath, 'Test');
-      
+
       // Should load from fixture successfully
       expect(result).toMatchObject({
         data: { val: 88 },
         source: 'fixture',
         reason: 'ok',
       });
-      
+
       warnSpy.mockRestore();
     });
   });

--- a/tests/utils/loader.test.ts
+++ b/tests/utils/loader.test.ts
@@ -139,6 +139,70 @@ describe('loadWithFallback', () => {
       await expect(loadOptional(artifactPath, fixturePath, 'Test')).resolves.not.toThrow();
       warnSpy.mockRestore();
     });
+
+    it('prioritizes other errors (e.g., EACCES) over enoent and empty', async () => {
+      // Simulate a permission error on the artifact path
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const permissionError = new Error('EACCES: permission denied');
+      (permissionError as NodeJS.ErrnoException).code = 'EACCES';
+      
+      // Mock readJsonFile to throw EACCES for artifact, then ENOENT for fixture
+      const fsModule = await import('../../src/utils/fs.js');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const readJsonFileMock = vi.spyOn(fsModule, 'readJsonFile' as any);
+      
+      readJsonFileMock.mockImplementation(async (path: string) => {
+        if (path === artifactPath) {
+          throw permissionError;
+        } else {
+          const enoentError = new Error('ENOENT: no such file');
+          (enoentError as NodeJS.ErrnoException).code = 'ENOENT';
+          throw enoentError;
+        }
+      });
+
+      const result = await loadOptional(artifactPath, fixturePath, 'Test');
+      
+      // Should report 'error' (the permission denied) rather than 'enoent'
+      expect(result).toMatchObject({
+        data: null,
+        source: 'missing',
+        reason: 'error',
+      });
+      
+      readJsonFileMock.mockRestore();
+      vi.restoreAllMocks();
+    });
+
+    it('prioritizes other errors over empty', async () => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const permissionError = new Error('EACCES: permission denied');
+      (permissionError as NodeJS.ErrnoException).code = 'EACCES';
+      
+      const fsModule = await import('../../src/utils/fs.js');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const readJsonFileMock = vi.spyOn(fsModule, 'readJsonFile' as any);
+      
+      readJsonFileMock.mockImplementation(async (path: string) => {
+        if (path === artifactPath) {
+          throw permissionError;
+        } else {
+          throw new Error('Empty file');
+        }
+      });
+
+      const result = await loadOptional(artifactPath, fixturePath, 'Test');
+      
+      // Should report 'error' (permission denied) rather than 'empty'
+      expect(result).toMatchObject({
+        data: null,
+        source: 'missing',
+        reason: 'error',
+      });
+      
+      readJsonFileMock.mockRestore();
+      vi.restoreAllMocks();
+    });
   });
 
   describe('Strict Fail: ON (strictFail=true)', () => {

--- a/tests/utils/loader.test.ts
+++ b/tests/utils/loader.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtemp, writeFile, rm } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { loadWithFallback } from '../../src/utils/loader.js';
+import { loadWithFallback, loadOptional } from '../../src/utils/loader.js';
 
 describe('loadWithFallback', () => {
   let testDir: string;
@@ -86,6 +86,58 @@ describe('loadWithFallback', () => {
       await createArtifact('{ invalid }');
       await expect(loadWithFallback(artifactPath, fixturePath, options))
         .rejects.toThrow('Strict: Test artifact contains invalid JSON');
+    });
+  });
+
+  describe('loadOptional', () => {
+    it('returns artifact data when artifact is valid', async () => {
+      await createArtifact('{"val": 42}');
+      const result = await loadOptional(artifactPath, fixturePath, 'Test');
+      expect(result).toEqual({ data: { val: 42 }, source: 'artifact', reason: 'ok' });
+    });
+
+    it('falls back to fixture when artifact is missing', async () => {
+      await createFixture('{"val": 99}');
+      const result = await loadOptional(artifactPath, fixturePath, 'Test');
+      expect(result).toEqual({ data: { val: 99 }, source: 'fixture', reason: 'ok' });
+    });
+
+    it('returns enoent when both artifact and fixture are missing', async () => {
+      const result = await loadOptional(artifactPath, fixturePath, 'Test');
+      expect(result).toEqual({ data: null, source: 'missing', reason: 'enoent' });
+    });
+
+    it('returns invalid-json when artifact is corrupt and fixture is missing', async () => {
+      await createArtifact('{ not valid json }');
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const result = await loadOptional(artifactPath, fixturePath, 'Test');
+      expect(result).toEqual({ data: null, source: 'missing', reason: 'invalid-json' });
+      warnSpy.mockRestore();
+    });
+
+    it('returns invalid-json when both artifact and fixture are corrupt', async () => {
+      await createArtifact('{ bad }');
+      await createFixture('{ also bad }');
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const result = await loadOptional(artifactPath, fixturePath, 'Test');
+      expect(result).toEqual({ data: null, source: 'missing', reason: 'invalid-json' });
+      warnSpy.mockRestore();
+    });
+
+    it('succeeds with fixture when only artifact is corrupt', async () => {
+      await createArtifact('{ bad }');
+      await createFixture('{"val": 7}');
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const result = await loadOptional(artifactPath, fixturePath, 'Test');
+      expect(result).toEqual({ data: { val: 7 }, source: 'fixture', reason: 'ok' });
+      warnSpy.mockRestore();
+    });
+
+    it('never throws even when both candidates fail', async () => {
+      await createArtifact('{ bad }');
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      await expect(loadOptional(artifactPath, fixturePath, 'Test')).resolves.not.toThrow();
+      warnSpy.mockRestore();
     });
   });
 

--- a/tests/utils/loader.test.ts
+++ b/tests/utils/loader.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, writeFile, rm } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { loadWithFallback, loadOptional } from '../../src/utils/loader.js';
+import { EmptyFileError } from '../../src/utils/fs.js';
 
 describe('loadWithFallback', () => {
   let testDir: string;
@@ -140,6 +141,29 @@ describe('loadWithFallback', () => {
       warnSpy.mockRestore();
     });
 
+    it('correctly labels source as fixture when primarySource is fixture', async () => {
+      await createFixture('{"val": 123}');
+      const result = await loadOptional(artifactPath, fixturePath, 'Test', {
+        primarySource: 'fixture',
+      });
+      expect(result).toEqual({
+        data: { val: 123 },
+        source: 'fixture',
+        reason: 'ok',
+      });
+    });
+
+    it('returns missing with correct source when primarySource is fixture and path missing', async () => {
+      const result = await loadOptional(artifactPath, fixturePath, 'Test', {
+        primarySource: 'fixture',
+      });
+      expect(result).toEqual({
+        data: null,
+        source: 'missing',
+        reason: 'enoent',
+      });
+    });
+
     it('prioritizes other errors (e.g., EACCES) over enoent and empty', async () => {
       // Simulate a permission error on the artifact path
       vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -187,7 +211,7 @@ describe('loadWithFallback', () => {
         if (path === artifactPath) {
           throw permissionError;
         } else {
-          throw new Error('Empty file');
+          throw new EmptyFileError(path);
         }
       });
 

--- a/tests/utils/loader.test.ts
+++ b/tests/utils/loader.test.ts
@@ -164,68 +164,40 @@ describe('loadWithFallback', () => {
       });
     });
 
-    it('prioritizes other errors (e.g., EACCES) over enoent and empty', async () => {
-      // Simulate a permission error on the artifact path
-      vi.spyOn(console, 'warn').mockImplementation(() => {});
-      const permissionError = new Error('EACCES: permission denied');
-      (permissionError as NodeJS.ErrnoException).code = 'EACCES';
+    it('returns empty when artifact is empty and fixture is missing', async () => {
+      // Create an empty artifact file (only whitespace)
+      await createArtifact('   \n  \t  ');
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       
-      // Mock readJsonFile to throw EACCES for artifact, then ENOENT for fixture
-      const fsModule = await import('../../src/utils/fs.js');
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const readJsonFileMock = vi.spyOn(fsModule, 'readJsonFile' as any);
-      
-      readJsonFileMock.mockImplementation(async (path: string) => {
-        if (path === artifactPath) {
-          throw permissionError;
-        } else {
-          const enoentError = new Error('ENOENT: no such file');
-          (enoentError as NodeJS.ErrnoException).code = 'ENOENT';
-          throw enoentError;
-        }
-      });
-
       const result = await loadOptional(artifactPath, fixturePath, 'Test');
       
-      // Should report 'error' (the permission denied) rather than 'enoent'
+      // Should report 'empty' reason
       expect(result).toMatchObject({
         data: null,
         source: 'missing',
-        reason: 'error',
+        reason: 'empty',
       });
       
-      readJsonFileMock.mockRestore();
-      vi.restoreAllMocks();
+      warnSpy.mockRestore();
     });
 
-    it('prioritizes other errors over empty', async () => {
-      vi.spyOn(console, 'warn').mockImplementation(() => {});
-      const permissionError = new Error('EACCES: permission denied');
-      (permissionError as NodeJS.ErrnoException).code = 'EACCES';
+    it('loads fixture when artifact is empty and fixture has valid data', async () => {
+      // Create an empty artifact
+      await createArtifact('   ');
+      // Create a valid fixture
+      await createFixture('{"val": 88}');
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       
-      const fsModule = await import('../../src/utils/fs.js');
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const readJsonFileMock = vi.spyOn(fsModule, 'readJsonFile' as any);
-      
-      readJsonFileMock.mockImplementation(async (path: string) => {
-        if (path === artifactPath) {
-          throw permissionError;
-        } else {
-          throw new EmptyFileError(path);
-        }
-      });
-
       const result = await loadOptional(artifactPath, fixturePath, 'Test');
       
-      // Should report 'error' (permission denied) rather than 'empty'
+      // Should load from fixture successfully
       expect(result).toMatchObject({
-        data: null,
-        source: 'missing',
-        reason: 'error',
+        data: { val: 88 },
+        source: 'fixture',
+        reason: 'ok',
       });
       
-      readJsonFileMock.mockRestore();
-      vi.restoreAllMocks();
+      warnSpy.mockRestore();
     });
   });
 


### PR DESCRIPTION
## Summary

Adds a structured, verifiable day-over-day comparison feature for daily insights. Instead of relying solely on free-text producer-supplied deltas, this implementation computes a concrete delta by binding today's insights artifact against the previous day's artifact, enabling full traceability of topic and question changes.

Enforces strict **source coherence**: artifact insights are compared only with artifact previous-day data (never with fixtures), fixture insights can be compared with fixture data, and missing insights skip comparison entirely. This maintains the truth boundary between production data and example data, preventing misleading cross-source comparisons.

## Key Changes

- **New module `src/insightsComparison.ts`**: Core comparison logic
  - `compareInsights()`: Computes structured delta between two `DailyInsights` payloads with trimmed timestamp handling
  - Classifies topics into: added, removed, changed (with direction and magnitude), and unchanged
  - Diffs questions by trimmed text with deduplication
  - Sorts results by relevance (score descending for added/removed, absolute delta descending for changed)
  - Treats sub-epsilon score noise (< 1e-6) as unchanged to suppress float representation artifacts
  - `previousDateOf()`: Derives previous calendar date from ISO date string with validation

- **Controller enhancement `src/controllers/insights.ts`**:
  - `buildComparison()`: Now receives `currentSource` parameter to enforce source coherence
  - Loads previous-day artifact via dated-file convention (`insights.daily.<YYYY-MM-DD>.json`)
  - When today's source is artifact: loads previous day from artifact only (no fixture fallback)
  - When today's source is fixture: can load previous day from fixture
  - Returns `no-source-coherence` reason when source mismatch occurs, preventing mixed-source comparisons
  - Uses `loadOptional()` for graceful degradation—missing or corrupt previous artifacts never block the page
  - Returns `ComparisonMeta` with availability status, source kind, and precise reason codes
  - Validates previous payload shape before comparison

- **Enhanced utility `src/utils/loader.ts`**:
  - `loadOptional()`: Best-effort supplementary artifact loader with controllable fallback strategy
  - Added `LoadOptionalOptions` interface with `allowFixtureFallback` parameter
  - Supports source coherence enforcement: can be restricted to artifact-only loading when needed
  - Returns precise error reasons: `enoent`, `empty`, `invalid-json`, `error` (distinguishing failure modes)
  - Never throws or participates in strict-mode aborts
  - Returns `{ data: null, source: 'missing', reason: ... }` on failure with specific failure reason

- **View layer `src/views/insights.ejs`**:
  - New `.comparison-block` section rendering computed delta with visual hierarchy
  - Displays added/removed topics (with scores), changed topics (with direction, previous/current %, percentage points)
  - Shows added/resolved questions
  - Unchanged topic count summary
  - Gracefully notes when previous artifact is unavailable
  - Suppresses missing-artifact note when base date is unparseable (`reason === 'no-base-date'`)
  - Separates computed comparison from producer-supplied deltas with "Vom Producer gemeldet" label
  - Uses correct empty-state condition (`!showDeltaSection`) to avoid misleading empty messages

- **Comprehensive test coverage**:
  - `tests/insightsComparison.test.ts`: Unit tests for comparison logic and date derivation
  - `tests/controllers/insights.test.ts`: Integration tests for artifact binding, source coherence enforcement, validation, and degradation
  - `tests/server.test.ts`: End-to-end rendering tests for both success and unavailable cases

- **Test fixture**: `src/fixtures/insights.daily.2025-12-27.json` for previous-day artifact testing

- **Documentation**: Updated `docs/blueprints/leitstand_visualization.md` to mark Vortagsvergleich as complete

## Notable Implementation Details

- **Source coherence rule**: artifact → artifact, fixture → fixture, never artifact → fixture. This preserves the truth boundary between production and example data in the UI.
- **Precise reason codes**: Distinguishes between `enoent`, `empty`, `invalid-json`, and `error` to enable better debugging and audit trails
- **Deduplication**: When a topic name appears multiple times in a payload, only the first (highest-ranked) occurrence is used for comparison
- **Float noise suppression**: Differences below 1e-6 are treated as unchanged to avoid reporting representation artifacts
- **Date validation**: `previousDateOf()` validates round-trip through JS Date to reject invalid dates like 2025-13-40
- **Graceful degradation**: Missing or corrupt previous artifacts are logged but never abort the page; comparison simply reports unavailable with the specific reason
- **Stable sorting**: Tie-breaker on topic name ensures deterministic ordering across runs
- **Source tracking**: `ComparisonMeta` records whether previous artifact came from live artifact store or test fixture, and includes `no-source-coherence` reason when source boundaries are violated