### PR TITLE
feat: add ecosystem map source view

### DIFF
--- a/src/controllers/ecosystemMap.ts
+++ b/src/controllers/ecosystemMap.ts
@@ -1,0 +1,241 @@
+import { readFile } from 'node:fs/promises';
+import { basename, dirname, join, resolve, relative } from 'node:path';
+
+const MANIFEST_KIND = 'cabinet_ecosystem_map_artifact_manifest';
+const DEFAULT_STALE_AFTER_HOURS = 168;
+
+export type EcosystemMapSourceKind = 'artifact' | 'missing' | 'corrupt';
+export type EcosystemMapFreshness = 'fresh' | 'stale' | 'unknown';
+
+interface MapManifestArtifact {
+  role: string;
+  path: string;
+  contentType: string;
+  bytes: number;
+  sha256: string;
+}
+
+interface MapManifest {
+  schemaVersion: number;
+  kind: string;
+  contractVersion: string;
+  source: {
+    repository: string;
+    commit: string;
+    generatedAt: string;
+  };
+  artifactCount: number;
+  artifacts: MapManifestArtifact[];
+  doesNotEstablish: string[];
+}
+
+export interface EcosystemMapArtifactView {
+  role: string;
+  path: string;
+  content_type: string;
+  bytes: number;
+  sha256: string;
+  content: string | null;
+  missing_reason: string | null;
+}
+
+export interface EcosystemMapViewData {
+  overview: EcosystemMapArtifactView | null;
+  registry_projection: EcosystemMapArtifactView | null;
+  view_meta: {
+    source_kind: EcosystemMapSourceKind;
+    missing_reason: string;
+    manifest_path: string;
+    source_root: string | null;
+    source_repository: string | null;
+    source_commit: string | null;
+    generated_at: string | null;
+    data_age_minutes: number | null;
+    freshness_state: EcosystemMapFreshness;
+    stale_after_hours: number;
+    does_not_establish: string[];
+  };
+}
+
+function configuredManifestPath(): string {
+  return process.env.LEITSTAND_ECOSYSTEM_MAP_MANIFEST_PATH
+    || join(process.cwd(), 'artifacts', 'ecosystem-map-artifact-manifest.json');
+}
+
+function configuredStaleAfterHours(): number {
+  const raw = process.env.LEITSTAND_ECOSYSTEM_MAP_STALE_AFTER_HOURS;
+  const parsed = raw ? Number(raw) : DEFAULT_STALE_AFTER_HOURS;
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : DEFAULT_STALE_AFTER_HOURS;
+}
+
+function sourceRootForManifest(manifestPath: string): string {
+  if (process.env.LEITSTAND_ECOSYSTEM_MAP_SOURCE_ROOT) {
+    return resolve(process.env.LEITSTAND_ECOSYSTEM_MAP_SOURCE_ROOT);
+  }
+
+  const manifestDir = dirname(resolve(manifestPath));
+  return basename(manifestDir) === 'rendered' ? dirname(manifestDir) : manifestDir;
+}
+
+function classifyError(error: unknown): { kind: EcosystemMapSourceKind; reason: string } {
+  const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+  if (message.includes('enoent') || message.includes('no such file')) {
+    return { kind: 'missing', reason: 'manifest_missing' };
+  }
+  if (message.includes('json') || message.includes('invalid') || message.includes('unexpected')) {
+    return { kind: 'corrupt', reason: 'manifest_corrupt' };
+  }
+  return { kind: 'corrupt', reason: 'manifest_load_failed' };
+}
+
+function emptyData(kind: EcosystemMapSourceKind, reason: string, manifestPath: string): EcosystemMapViewData {
+  return {
+    overview: null,
+    registry_projection: null,
+    view_meta: {
+      source_kind: kind,
+      missing_reason: reason,
+      manifest_path: manifestPath,
+      source_root: null,
+      source_repository: null,
+      source_commit: null,
+      generated_at: null,
+      data_age_minutes: null,
+      freshness_state: 'unknown',
+      stale_after_hours: configuredStaleAfterHours(),
+      does_not_establish: [
+        'claim_truth',
+        'runtime_correctness',
+        'merge_readiness',
+      ],
+    },
+  };
+}
+
+function parseManifest(raw: unknown): MapManifest {
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('invalid ecosystem map manifest: root must be object');
+  }
+  const manifest = raw as Partial<MapManifest>;
+  if (manifest.schemaVersion !== 1) {
+    throw new Error('invalid ecosystem map manifest: schemaVersion must be 1');
+  }
+  if (manifest.kind !== MANIFEST_KIND) {
+    throw new Error('invalid ecosystem map manifest: kind mismatch');
+  }
+  if (!manifest.source || typeof manifest.source !== 'object') {
+    throw new Error('invalid ecosystem map manifest: source missing');
+  }
+  if (manifest.source.repository !== 'heimgewebe/cabinet') {
+    throw new Error('invalid ecosystem map manifest: source repository mismatch');
+  }
+  if (!/^[0-9a-f]{40}$/.test(manifest.source.commit || '')) {
+    throw new Error('invalid ecosystem map manifest: source commit mismatch');
+  }
+  if (!Array.isArray(manifest.artifacts)) {
+    throw new Error('invalid ecosystem map manifest: artifacts missing');
+  }
+  if (!Array.isArray(manifest.doesNotEstablish)) {
+    throw new Error('invalid ecosystem map manifest: non-claims missing');
+  }
+  return manifest as MapManifest;
+}
+
+function freshness(generatedAt: string | null, staleAfterHours: number): {
+  generated_at: string | null;
+  data_age_minutes: number | null;
+  freshness_state: EcosystemMapFreshness;
+} {
+  if (!generatedAt) {
+    return { generated_at: null, data_age_minutes: null, freshness_state: 'unknown' };
+  }
+  const generatedMs = new Date(generatedAt).getTime();
+  if (Number.isNaN(generatedMs)) {
+    return { generated_at: generatedAt, data_age_minutes: null, freshness_state: 'unknown' };
+  }
+  const ageMinutes = Math.max(0, Math.floor((Date.now() - generatedMs) / 60000));
+  return {
+    generated_at: new Date(generatedMs).toISOString(),
+    data_age_minutes: ageMinutes,
+    freshness_state: ageMinutes > staleAfterHours * 60 ? 'stale' : 'fresh',
+  };
+}
+
+function resolveArtifactPath(sourceRoot: string, artifactPath: string): string {
+  if (artifactPath.startsWith('/') || artifactPath.includes('..')) {
+    throw new Error('invalid ecosystem map manifest: artifact path escapes source root');
+  }
+  const resolved = resolve(sourceRoot, artifactPath);
+  const rel = relative(sourceRoot, resolved);
+  if (rel.startsWith('..') || rel === '') {
+    throw new Error('invalid ecosystem map manifest: artifact path escapes source root');
+  }
+  return resolved;
+}
+
+async function readArtifact(sourceRoot: string, artifact: MapManifestArtifact | undefined): Promise<EcosystemMapArtifactView | null> {
+  if (!artifact) return null;
+  const resolvedPath = resolveArtifactPath(sourceRoot, artifact.path);
+  try {
+    const content = await readFile(resolvedPath, 'utf-8');
+    return {
+      role: artifact.role,
+      path: artifact.path,
+      content_type: artifact.contentType,
+      bytes: artifact.bytes,
+      sha256: artifact.sha256,
+      content,
+      missing_reason: null,
+    };
+  } catch {
+    return {
+      role: artifact.role,
+      path: artifact.path,
+      content_type: artifact.contentType,
+      bytes: artifact.bytes,
+      sha256: artifact.sha256,
+      content: null,
+      missing_reason: 'artifact_missing',
+    };
+  }
+}
+
+export async function getEcosystemMapData(): Promise<EcosystemMapViewData> {
+  const manifestPath = resolve(configuredManifestPath());
+  const staleAfterHours = configuredStaleAfterHours();
+  try {
+    const raw = JSON.parse(await readFile(manifestPath, 'utf-8')) as unknown;
+    const manifest = parseManifest(raw);
+    const sourceRoot = sourceRootForManifest(manifestPath);
+    const freshnessState = freshness(manifest.source.generatedAt, staleAfterHours);
+    const overviewSpec = manifest.artifacts.find((artifact) => artifact.role === 'readable_overview_mermaid');
+    const registrySpec = manifest.artifacts.find((artifact) => artifact.role === 'generated_registry_projection_mermaid');
+    const [overview, registryProjection] = await Promise.all([
+      readArtifact(sourceRoot, overviewSpec),
+      readArtifact(sourceRoot, registrySpec),
+    ]);
+
+    const missingReason = overview?.missing_reason || registryProjection?.missing_reason || 'ok';
+
+    return {
+      overview,
+      registry_projection: registryProjection,
+      view_meta: {
+        source_kind: missingReason === 'ok' ? 'artifact' : 'missing',
+        missing_reason: missingReason,
+        manifest_path: manifestPath,
+        source_root: sourceRoot,
+        source_repository: manifest.source.repository,
+        source_commit: manifest.source.commit,
+        generated_at: freshnessState.generated_at,
+        data_age_minutes: freshnessState.data_age_minutes,
+        freshness_state: freshnessState.freshness_state,
+        stale_after_hours: staleAfterHours,
+        does_not_establish: manifest.doesNotEstablish,
+      },
+    };
+  } catch (error) {
+    const classified = classifyError(error);
+    return emptyData(classified.kind, classified.reason, manifestPath);
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,6 +13,7 @@ import { getInsightsData } from './controllers/insights.js';
 import { getTimelineData } from './controllers/timeline.js';
 import { getReflexionData } from './controllers/reflexion.js';
 import { getDashboardData } from './controllers/dashboard.js';
+import { getEcosystemMapData } from './controllers/ecosystemMap.js';
 import { getEventFamily, listEventFamilies } from './utils/eventKind.js';
 import fs from 'fs';
 import { validatePlexerReport } from './validation/validators.js';
@@ -299,6 +300,19 @@ app.get('/', async (_req, res) => {
     // than crashing the landing page.
     console.error('[Dashboard] Unexpected error:', error);
     res.render('index', { phases: [] });
+  }
+});
+
+
+app.get('/ecosystem-map', async (_req, res) => {
+  try {
+    const data = await getEcosystemMapData();
+    res.render('ecosystem-map', data);
+  } catch (error) {
+    if (!res.headersSent) {
+      console.error('[EcosystemMap] Error:', error);
+      res.status(500).send('Error loading ecosystem map data');
+    }
   }
 });
 

--- a/src/views/ecosystem-map.ejs
+++ b/src/views/ecosystem-map.ejs
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <title>Ecosystem Map – Leitstand</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0a0e1a; color: #f1f5f9; margin: 0; }
+    nav { position: sticky; top: 0; display: flex; gap: 4px; padding: 10px 20px; background: rgba(10, 14, 26, 0.92); border-bottom: 1px solid rgba(255,255,255,.08); }
+    nav a { color: #94a3b8; text-decoration: none; padding: 6px 14px; border-radius: 6px; font-size: .82em; }
+    nav a.active, nav a:hover { color: #3b82f6; background: rgba(59,130,246,.1); }
+    nav .title { color: #f1f5f9; font-weight: 700; margin-right: 16px; }
+    main { max-width: 1180px; margin: 0 auto; padding: 42px 24px 80px; }
+    h1 { font-size: 1.9em; margin-bottom: 10px; }
+    .subtitle, .empty, .artifact-meta, li { color: #94a3b8; line-height: 1.55; }
+    .notice, .panel, .meta-item { background: rgba(17,24,39,.88); border: 1px solid rgba(255,255,255,.08); border-radius: 14px; padding: 20px 22px; margin-bottom: 18px; }
+    .notice strong { color: #3b82f6; }
+    .meta-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; margin-bottom: 22px; }
+    .label { color: #64748b; font-size: .72em; text-transform: uppercase; letter-spacing: .08em; margin-bottom: 5px; }
+    .value { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .82em; overflow-wrap: anywhere; }
+    pre { background: rgba(2,6,23,.72); color: #dbeafe; border: 1px solid rgba(255,255,255,.08); border-radius: 10px; padding: 16px; overflow: auto; font-size: .78em; line-height: 1.45; max-height: 520px; }
+  </style>
+</head>
+<body>
+  <nav aria-label="Hauptnavigation">
+    <span class="title">Leitstand</span>
+    <a href="/">Home</a>
+    <a href="/ecosystem-map" class="active" aria-current="page">Ecosystem Map</a>
+    <a href="/anatomy">Anatomie</a>
+    <a href="/timeline">Zeitachse</a>
+    <a href="/insights">Erkenntnisse</a>
+    <a href="/reflexion">Reflexion</a>
+    <a href="/ops">Ops</a>
+  </nav>
+
+  <main>
+    <h1>Ecosystem Map</h1>
+    <p class="subtitle">Read-only source view for the Cabinet-owned Heimgewebe ecosystem map.</p>
+
+    <section class="notice" aria-label="Boundary">
+      <strong>View only.</strong> Canonical map semantics live in Cabinet. Leitstand displays pinned artifacts and freshness metadata; it does not edit the map, infer claim truth, dispatch tasks, or prove runtime correctness or merge readiness.
+    </section>
+
+    <section class="meta-grid" aria-label="Source metadata">
+      <div class="meta-item"><div class="label">Source state</div><div class="value"><%= view_meta.source_kind %> / <%= view_meta.missing_reason %></div></div>
+      <div class="meta-item"><div class="label">Manifest</div><div class="value"><%= view_meta.manifest_path %></div></div>
+      <div class="meta-item"><div class="label">Source root</div><div class="value"><%= view_meta.source_root || '—' %></div></div>
+      <div class="meta-item"><div class="label">Repository</div><div class="value"><%= view_meta.source_repository || '—' %></div></div>
+      <div class="meta-item"><div class="label">Commit</div><div class="value"><%= view_meta.source_commit || '—' %></div></div>
+      <div class="meta-item"><div class="label">Freshness</div><div class="value"><%= view_meta.freshness_state %><% if (view_meta.data_age_minutes !== null) { %> · <%= view_meta.data_age_minutes %> min<% } %></div></div>
+    </section>
+
+    <section class="panel">
+      <h2>Readable overview</h2>
+      <% if (overview && overview.content) { %>
+        <div class="artifact-meta"><%= overview.path %> · <%= overview.bytes %> bytes · sha256 <%= overview.sha256 %></div>
+        <pre><%= overview.content %></pre>
+      <% } else { %>
+        <p class="empty">Overview Mermaid source is not available. Reason: <%= overview ? overview.missing_reason : view_meta.missing_reason %>.</p>
+      <% } %>
+    </section>
+
+    <section class="panel">
+      <h2>Generated registry projection</h2>
+      <% if (registry_projection && registry_projection.content) { %>
+        <div class="artifact-meta"><%= registry_projection.path %> · <%= registry_projection.bytes %> bytes · sha256 <%= registry_projection.sha256 %></div>
+        <pre><%= registry_projection.content %></pre>
+      <% } else { %>
+        <p class="empty">Registry projection Mermaid source is not available. Reason: <%= registry_projection ? registry_projection.missing_reason : view_meta.missing_reason %>.</p>
+      <% } %>
+    </section>
+
+    <section class="panel">
+      <h2>Does not establish</h2>
+      <ul>
+        <% for (const item of view_meta.does_not_establish) { %>
+          <li><%= item %></li>
+        <% } %>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -264,6 +264,7 @@
     <span class="title">Leitstand</span>
     <a href="/" class="active" aria-current="page">Home</a>
     <a href="/observatory">Observatorium</a>
+    <a href="/ecosystem-map">Ecosystem Map</a>
     <a href="/anatomy">Anatomie</a>
     <a href="/timeline">Zeitachse</a>
     <a href="/insights">Erkenntnisse</a>
@@ -279,6 +280,14 @@
         Strikter Observer: visualisiert Zustände, ohne externe Systeme zu mutieren.
       </p>
     </header>
+
+    <section class="info-card" aria-labelledby="ecosystem-map-heading">
+      <h2 id="ecosystem-map-heading">Ecosystem Map</h2>
+      <p>
+        Read-only Cabinet map source view: zeigt Mermaid-Quellen, Commit, Manifest, Freshness und Boundary-Hinweis.
+        <a href="/ecosystem-map">Ecosystem Map öffnen</a>.
+      </p>
+    </section>
 
     <section aria-labelledby="phasen-heading">
       <h2 id="phasen-heading" class="section-title">Erkenntnisphasen</h2>

--- a/tests/controllers/ecosystemMap.test.ts
+++ b/tests/controllers/ecosystemMap.test.ts
@@ -1,0 +1,106 @@
+import { mkdtemp, mkdir, writeFile, rm } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { afterEach, describe, expect, it } from 'vitest';
+import { getEcosystemMapData } from '../../src/controllers/ecosystemMap.js';
+
+const OLD_MANIFEST = process.env.LEITSTAND_ECOSYSTEM_MAP_MANIFEST_PATH;
+const OLD_ROOT = process.env.LEITSTAND_ECOSYSTEM_MAP_SOURCE_ROOT;
+const OLD_STALE = process.env.LEITSTAND_ECOSYSTEM_MAP_STALE_AFTER_HOURS;
+
+let tempRoots: string[] = [];
+
+afterEach(async () => {
+  if (OLD_MANIFEST === undefined) delete process.env.LEITSTAND_ECOSYSTEM_MAP_MANIFEST_PATH;
+  else process.env.LEITSTAND_ECOSYSTEM_MAP_MANIFEST_PATH = OLD_MANIFEST;
+  if (OLD_ROOT === undefined) delete process.env.LEITSTAND_ECOSYSTEM_MAP_SOURCE_ROOT;
+  else process.env.LEITSTAND_ECOSYSTEM_MAP_SOURCE_ROOT = OLD_ROOT;
+  if (OLD_STALE === undefined) delete process.env.LEITSTAND_ECOSYSTEM_MAP_STALE_AFTER_HOURS;
+  else process.env.LEITSTAND_ECOSYSTEM_MAP_STALE_AFTER_HOURS = OLD_STALE;
+
+  for (const root of tempRoots) {
+    await rm(root, { recursive: true, force: true });
+  }
+  tempRoots = [];
+});
+
+async function makeFixture(generatedAt = new Date().toISOString()) {
+  const root = await mkdtemp(join(tmpdir(), 'leitstand-map-'));
+  tempRoots.push(root);
+  const sourceRoot = join(root, 'cabinet');
+  await mkdir(join(sourceRoot, 'rendered'), { recursive: true });
+  await writeFile(join(sourceRoot, 'rendered', 'ecosystem-map.mmd'), 'flowchart TD\n  A[Cabinet]\n', 'utf-8');
+  await writeFile(join(sourceRoot, 'rendered', 'ecosystem-registry-map.mmd'), 'flowchart TD\n  B[Registry]\n', 'utf-8');
+  const manifestPath = join(sourceRoot, 'rendered', 'ecosystem-map-artifact-manifest.json');
+  const manifest = {
+    schemaVersion: 1,
+    kind: 'cabinet_ecosystem_map_artifact_manifest',
+    contractVersion: '1',
+    source: {
+      repository: 'heimgewebe/cabinet',
+      commit: 'a'.repeat(40),
+      generatedAt,
+    },
+    artifactCount: 2,
+    artifacts: [
+      {
+        role: 'readable_overview_mermaid',
+        path: 'rendered/ecosystem-map.mmd',
+        contentType: 'text/mermaid',
+        bytes: 24,
+        sha256: 'b'.repeat(64),
+      },
+      {
+        role: 'generated_registry_projection_mermaid',
+        path: 'rendered/ecosystem-registry-map.mmd',
+        contentType: 'text/mermaid',
+        bytes: 25,
+        sha256: 'c'.repeat(64),
+      },
+    ],
+    doesNotEstablish: ['claim_truth', 'runtime_correctness', 'merge_readiness'],
+  };
+  await writeFile(manifestPath, JSON.stringify(manifest), 'utf-8');
+  return { sourceRoot, manifestPath };
+}
+
+describe('getEcosystemMapData', () => {
+  it('loads a Cabinet ecosystem map manifest and Mermaid sources read-only', async () => {
+    const fixture = await makeFixture();
+    process.env.LEITSTAND_ECOSYSTEM_MAP_MANIFEST_PATH = fixture.manifestPath;
+
+    const data = await getEcosystemMapData();
+
+    expect(data.view_meta.source_kind).toBe('artifact');
+    expect(data.view_meta.source_repository).toBe('heimgewebe/cabinet');
+    expect(data.view_meta.source_commit).toBe('a'.repeat(40));
+    expect(data.view_meta.source_root).toBe(fixture.sourceRoot);
+    expect(data.overview?.content).toContain('Cabinet');
+    expect(data.registry_projection?.content).toContain('Registry');
+    expect(data.view_meta.does_not_establish).toContain('runtime_correctness');
+  });
+
+  it('reports a missing manifest as a missing source instead of throwing', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'leitstand-map-missing-'));
+    tempRoots.push(root);
+    process.env.LEITSTAND_ECOSYSTEM_MAP_MANIFEST_PATH = join(root, 'missing.json');
+
+    const data = await getEcosystemMapData();
+
+    expect(data.view_meta.source_kind).toBe('missing');
+    expect(data.view_meta.missing_reason).toBe('manifest_missing');
+    expect(data.overview).toBeNull();
+    expect(data.registry_projection).toBeNull();
+  });
+
+  it('marks stale manifests without repairing them', async () => {
+    const fixture = await makeFixture('2020-01-01T00:00:00Z');
+    process.env.LEITSTAND_ECOSYSTEM_MAP_MANIFEST_PATH = fixture.manifestPath;
+    process.env.LEITSTAND_ECOSYSTEM_MAP_STALE_AFTER_HOURS = '1';
+
+    const data = await getEcosystemMapData();
+
+    expect(data.view_meta.freshness_state).toBe('stale');
+    expect(data.view_meta.source_kind).toBe('artifact');
+  });
+});


### PR DESCRIPTION
## Summary

- add a read-only ecosystem map loader for Cabinet map artifact manifests
- add `/ecosystem-map` source view showing Manifest, source root, Cabinet commit, freshness, Mermaid sources and non-claims
- link the source view from the Leitstand dashboard and nav
- add controller tests for valid, missing and stale manifest states

## Validation

- `NODE_OPTIONS=--jitless ./node_modules/.bin/tsc --noEmit` passed using a temporary node_modules symlink to the local Leitstand dependency tree
- Vitest could not run locally because the available Node/V8 environment crashes without `--jitless`, while Vite requires WebAssembly under Vitest with that flag; CI is expected to run the normal test path

## Boundary

- no Cabinet editing
- no Git/fetch from Leitstand
- no task dispatch
- no Mermaid rendering yet
- no runtime truth, merge-readiness or claim-truth assertion