### PR TITLE
feat: add ecosystem cross-view links

### DIFF
--- a/src/controllers/ecosystemMap.ts
+++ b/src/controllers/ecosystemMap.ts
@@ -1,5 +1,10 @@
 import { readFile } from 'node:fs/promises';
 import { basename, dirname, join, resolve, relative } from 'node:path';
+import {
+  loadEcosystemCrossLinks,
+  type EcosystemCrossLinkData,
+  type EcosystemCrossViewLink,
+} from './ecosystemMapLinks.js';
 
 const MANIFEST_KIND = 'cabinet_ecosystem_map_artifact_manifest';
 const DEFAULT_STALE_AFTER_HOURS = 168;
@@ -42,6 +47,13 @@ export interface EcosystemMapArtifactView {
 export interface EcosystemMapViewData {
   overview: EcosystemMapArtifactView | null;
   registry_projection: EcosystemMapArtifactView | null;
+  cross_links: EcosystemCrossViewLink[];
+  cross_link_meta: {
+    source_kind: string;
+    source_path: string;
+    missing_reason: string;
+    does_not_establish: string[];
+  };
   view_meta: {
     source_kind: EcosystemMapSourceKind;
     missing_reason: string;
@@ -88,10 +100,17 @@ function classifyError(error: unknown): { kind: EcosystemMapSourceKind; reason: 
   return { kind: 'corrupt', reason: 'manifest_load_failed' };
 }
 
-function emptyData(kind: EcosystemMapSourceKind, reason: string, manifestPath: string): EcosystemMapViewData {
+function emptyData(
+  kind: EcosystemMapSourceKind,
+  reason: string,
+  manifestPath: string,
+  crossLinks: EcosystemCrossLinkData,
+): EcosystemMapViewData {
   return {
     overview: null,
     registry_projection: null,
+    cross_links: crossLinks.links,
+    cross_link_meta: crossLinks.meta,
     view_meta: {
       source_kind: kind,
       missing_reason: reason,
@@ -203,6 +222,7 @@ async function readArtifact(sourceRoot: string, artifact: MapManifestArtifact | 
 export async function getEcosystemMapData(): Promise<EcosystemMapViewData> {
   const manifestPath = resolve(configuredManifestPath());
   const staleAfterHours = configuredStaleAfterHours();
+  const crossLinks = await loadEcosystemCrossLinks();
   try {
     const raw = JSON.parse(await readFile(manifestPath, 'utf-8')) as unknown;
     const manifest = parseManifest(raw);
@@ -220,6 +240,8 @@ export async function getEcosystemMapData(): Promise<EcosystemMapViewData> {
     return {
       overview,
       registry_projection: registryProjection,
+      cross_links: crossLinks.links,
+      cross_link_meta: crossLinks.meta,
       view_meta: {
         source_kind: missingReason === 'ok' ? 'artifact' : 'missing',
         missing_reason: missingReason,
@@ -236,6 +258,6 @@ export async function getEcosystemMapData(): Promise<EcosystemMapViewData> {
     };
   } catch (error) {
     const classified = classifyError(error);
-    return emptyData(classified.kind, classified.reason, manifestPath);
+    return emptyData(classified.kind, classified.reason, manifestPath, crossLinks);
   }
 }

--- a/src/controllers/ecosystemMapLinks.ts
+++ b/src/controllers/ecosystemMapLinks.ts
@@ -1,0 +1,182 @@
+import { readFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+
+export type EcosystemCrossLinkStatus = 'linked' | 'unmapped';
+export type EcosystemCrossLinkSourceKind = 'artifact' | 'missing' | 'corrupt';
+
+export interface EcosystemCrossViewTarget {
+  view: string;
+  href: string;
+  title: string;
+}
+
+export interface EcosystemCrossViewLink {
+  node_id: string;
+  label: string;
+  status: EcosystemCrossLinkStatus;
+  reason: string | null;
+  links: EcosystemCrossViewTarget[];
+}
+
+export interface EcosystemCrossLinkData {
+  links: EcosystemCrossViewLink[];
+  meta: {
+    source_kind: EcosystemCrossLinkSourceKind;
+    source_path: string;
+    missing_reason: string;
+    does_not_establish: string[];
+  };
+}
+
+const CONTRACT_KIND = 'leitstand_ecosystem_map_cross_view_links';
+const DEFAULT_NON_CLAIMS = [
+  'relation_truth',
+  'runtime_dependency',
+  'change_impact',
+  'claim_truth',
+  'dispatch_readiness',
+];
+
+function configuredLinksPath(): string {
+  return process.env.LEITSTAND_ECOSYSTEM_MAP_LINKS_PATH
+    || join(process.cwd(), 'src', 'fixtures', 'ecosystem-map-links.json');
+}
+
+function emptyLinkData(kind: EcosystemCrossLinkSourceKind, reason: string, sourcePath: string): EcosystemCrossLinkData {
+  return {
+    links: [],
+    meta: {
+      source_kind: kind,
+      source_path: sourcePath,
+      missing_reason: reason,
+      does_not_establish: DEFAULT_NON_CLAIMS,
+    },
+  };
+}
+
+function classifyError(error: unknown): { kind: EcosystemCrossLinkSourceKind; reason: string } {
+  const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+  if (message.includes('enoent') || message.includes('no such file')) {
+    return { kind: 'missing', reason: 'cross_link_contract_missing' };
+  }
+  if (message.includes('json') || message.includes('invalid') || message.includes('unexpected')) {
+    return { kind: 'corrupt', reason: 'cross_link_contract_corrupt' };
+  }
+  return { kind: 'corrupt', reason: 'cross_link_contract_load_failed' };
+}
+
+function parseTarget(raw: unknown): EcosystemCrossViewTarget {
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('invalid cross-view target: must be object');
+  }
+  const target = raw as Partial<EcosystemCrossViewTarget>;
+  if (!target.view || !target.href || !target.title) {
+    throw new Error('invalid cross-view target: missing fields');
+  }
+  if (!target.href.startsWith('/')) {
+    throw new Error('invalid cross-view target: href must be local');
+  }
+  return {
+    view: String(target.view),
+    href: String(target.href),
+    title: String(target.title),
+  };
+}
+
+function parseLink(raw: unknown): EcosystemCrossViewLink {
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('invalid cross-view link: must be object');
+  }
+  const link = raw as {
+    nodeId?: unknown;
+    label?: unknown;
+    status?: unknown;
+    reason?: unknown;
+    links?: unknown;
+  };
+  const nodeId = typeof link.nodeId === 'string' ? link.nodeId : '';
+  const label = typeof link.label === 'string' ? link.label : '';
+  if (!nodeId || !label) {
+    throw new Error('invalid cross-view link: nodeId and label are required');
+  }
+  if (link.status !== 'linked' && link.status !== 'unmapped') {
+    throw new Error('invalid cross-view link: unsupported status');
+  }
+  const targets = Array.isArray(link.links) ? link.links.map(parseTarget) : [];
+  if (link.status === 'linked' && targets.length === 0) {
+    throw new Error('invalid cross-view link: linked nodes need at least one target');
+  }
+  if (link.status === 'unmapped' && targets.length !== 0) {
+    throw new Error('invalid cross-view link: unmapped nodes must not have targets');
+  }
+  return {
+    node_id: nodeId,
+    label,
+    status: link.status,
+    reason: typeof link.reason === 'string' ? link.reason : null,
+    links: targets,
+  };
+}
+
+function parseContract(raw: unknown): Omit<EcosystemCrossLinkData, 'meta'> & { nonClaims: string[] } {
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('invalid cross-link contract: root must be object');
+  }
+  const contract = raw as {
+    schemaVersion?: unknown;
+    kind?: unknown;
+    mappings?: unknown;
+    doesNotEstablish?: unknown;
+  };
+  if (contract.schemaVersion !== 1 || contract.kind !== CONTRACT_KIND) {
+    throw new Error('invalid cross-link contract: kind or schemaVersion mismatch');
+  }
+  if (!Array.isArray(contract.mappings)) {
+    throw new Error('invalid cross-link contract: mappings must be a list');
+  }
+  const links = contract.mappings.map(parseLink);
+  const seen = new Set<string>();
+  for (const link of links) {
+    if (seen.has(link.node_id)) {
+      throw new Error(`invalid cross-link contract: duplicate node ${link.node_id}`);
+    }
+    seen.add(link.node_id);
+  }
+  const nonClaims = Array.isArray(contract.doesNotEstablish)
+    ? contract.doesNotEstablish.filter((item): item is string => typeof item === 'string')
+    : DEFAULT_NON_CLAIMS;
+  return { links, nonClaims };
+}
+
+export function resolveEcosystemCrossLink(
+  data: EcosystemCrossLinkData,
+  nodeId: string,
+): EcosystemCrossViewLink {
+  return data.links.find((link) => link.node_id === nodeId) || {
+    node_id: nodeId,
+    label: nodeId,
+    status: 'unmapped',
+    reason: 'node_id_not_in_cross_view_contract',
+    links: [],
+  };
+}
+
+export async function loadEcosystemCrossLinks(): Promise<EcosystemCrossLinkData> {
+  const sourcePath = resolve(configuredLinksPath());
+  try {
+    const raw = JSON.parse(await readFile(sourcePath, 'utf-8')) as unknown;
+    const parsed = parseContract(raw);
+    return {
+      links: parsed.links,
+      meta: {
+        source_kind: 'artifact',
+        source_path: sourcePath,
+        missing_reason: 'ok',
+        does_not_establish: parsed.nonClaims,
+      },
+    };
+  } catch (error) {
+    const classified = classifyError(error);
+    return emptyLinkData(classified.kind, classified.reason, sourcePath);
+  }
+}

--- a/src/fixtures/ecosystem-map-links.json
+++ b/src/fixtures/ecosystem-map-links.json
@@ -1,0 +1,93 @@
+{
+  "schemaVersion": 1,
+  "kind": "leitstand_ecosystem_map_cross_view_links",
+  "source": "cabinet.ecosystem_map.v0.node_ids",
+  "doesNotEstablish": [
+    "relation_truth",
+    "runtime_dependency",
+    "change_impact",
+    "claim_truth",
+    "dispatch_readiness"
+  ],
+  "mappings": [
+    {
+      "nodeId": "artifact:ecosystem-map",
+      "label": "Ecosystem Map v0",
+      "status": "linked",
+      "links": [
+        {
+          "view": "ecosystem-map",
+          "href": "/ecosystem-map",
+          "title": "Cabinet map source view"
+        }
+      ]
+    },
+    {
+      "nodeId": "repo:cabinet",
+      "label": "Cabinet",
+      "status": "linked",
+      "links": [
+        {
+          "view": "ecosystem-map",
+          "href": "/ecosystem-map",
+          "title": "Cabinet-owned map artifacts"
+        }
+      ]
+    },
+    {
+      "nodeId": "repo:chronik",
+      "label": "Chronik",
+      "status": "linked",
+      "links": [
+        {
+          "view": "timeline",
+          "href": "/timeline?node=repo%3Achronik",
+          "title": "Chronik timeline context"
+        }
+      ]
+    },
+    {
+      "nodeId": "repo:weltgewebe",
+      "label": "Weltgewebe",
+      "status": "linked",
+      "links": [
+        {
+          "view": "anatomy",
+          "href": "/anatomy?node=repo%3Aweltgewebe",
+          "title": "Weltgewebe structural context"
+        },
+        {
+          "view": "timeline",
+          "href": "/timeline?node=repo%3Aweltgewebe",
+          "title": "Weltgewebe timeline context"
+        }
+      ]
+    },
+    {
+      "nodeId": "repo:schauwerk",
+      "label": "Schauwerk",
+      "status": "linked",
+      "links": [
+        {
+          "view": "ecosystem-map",
+          "href": "/ecosystem-map?node=repo%3Aschauwerk",
+          "title": "Visualization handoff context"
+        }
+      ]
+    },
+    {
+      "nodeId": "repo:lenskit",
+      "label": "Lenskit / RepoBrief implementation",
+      "status": "unmapped",
+      "reason": "RepoBrief observability view is planned but not implemented yet.",
+      "links": []
+    },
+    {
+      "nodeId": "concept:repobrief",
+      "label": "RepoBrief",
+      "status": "unmapped",
+      "reason": "RepoBrief observability view is planned but not implemented yet.",
+      "links": []
+    }
+  ]
+}

--- a/src/views/ecosystem-map.ejs
+++ b/src/views/ecosystem-map.ejs
@@ -50,6 +50,29 @@
       <div class="meta-item"><div class="label">Freshness</div><div class="value"><%= view_meta.freshness_state %><% if (view_meta.data_age_minutes !== null) { %> · <%= view_meta.data_age_minutes %> min<% } %></div></div>
     </section>
 
+    <section class="panel" aria-label="Cross-view identity mapping">
+      <h2>Cross-view links</h2>
+      <p class="artifact-meta">Contract: <%= cross_link_meta.source_kind %> / <%= cross_link_meta.missing_reason %> · <%= cross_link_meta.source_path %></p>
+      <% if (cross_links.length === 0) { %>
+        <p class="empty">No cross-view mapping contract is available. Unknown nodes remain unlinked.</p>
+      <% } else { %>
+        <ul>
+          <% for (const link of cross_links) { %>
+            <li>
+              <strong><%= link.node_id %></strong> — <%= link.label %> — <%= link.status %>
+              <% if (link.links.length > 0) { %>
+                <% for (const target of link.links) { %>
+                  · <a href="<%= target.href %>"><%= target.title %></a>
+                <% } %>
+              <% } else { %>
+                · <%= link.reason || 'unmapped' %>
+              <% } %>
+            </li>
+          <% } %>
+        </ul>
+      <% } %>
+    </section>
+
     <section class="panel">
       <h2>Readable overview</h2>
       <% if (overview && overview.content) { %>

--- a/tests/controllers/ecosystemMap.test.ts
+++ b/tests/controllers/ecosystemMap.test.ts
@@ -3,10 +3,12 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import { afterEach, describe, expect, it } from 'vitest';
 import { getEcosystemMapData } from '../../src/controllers/ecosystemMap.js';
+import { loadEcosystemCrossLinks, resolveEcosystemCrossLink } from '../../src/controllers/ecosystemMapLinks.js';
 
 const OLD_MANIFEST = process.env.LEITSTAND_ECOSYSTEM_MAP_MANIFEST_PATH;
 const OLD_ROOT = process.env.LEITSTAND_ECOSYSTEM_MAP_SOURCE_ROOT;
 const OLD_STALE = process.env.LEITSTAND_ECOSYSTEM_MAP_STALE_AFTER_HOURS;
+const OLD_LINKS = process.env.LEITSTAND_ECOSYSTEM_MAP_LINKS_PATH;
 
 let tempRoots: string[] = [];
 
@@ -17,6 +19,8 @@ afterEach(async () => {
   else process.env.LEITSTAND_ECOSYSTEM_MAP_SOURCE_ROOT = OLD_ROOT;
   if (OLD_STALE === undefined) delete process.env.LEITSTAND_ECOSYSTEM_MAP_STALE_AFTER_HOURS;
   else process.env.LEITSTAND_ECOSYSTEM_MAP_STALE_AFTER_HOURS = OLD_STALE;
+  if (OLD_LINKS === undefined) delete process.env.LEITSTAND_ECOSYSTEM_MAP_LINKS_PATH;
+  else process.env.LEITSTAND_ECOSYSTEM_MAP_LINKS_PATH = OLD_LINKS;
 
   for (const root of tempRoots) {
     await rm(root, { recursive: true, force: true });
@@ -103,4 +107,17 @@ describe('getEcosystemMapData', () => {
     expect(data.view_meta.freshness_state).toBe('stale');
     expect(data.view_meta.source_kind).toBe('artifact');
   });
+
+  it('loads deterministic cross-view links and degrades unknown node IDs', async () => {
+    const links = await loadEcosystemCrossLinks();
+    const cabinet = resolveEcosystemCrossLink(links, 'repo:cabinet');
+    const unknown = resolveEcosystemCrossLink(links, 'repo:unknown');
+
+    expect(links.meta.source_kind).toBe('artifact');
+    expect(cabinet.status).toBe('linked');
+    expect(cabinet.links[0].href).toBe('/ecosystem-map');
+    expect(unknown.status).toBe('unmapped');
+    expect(unknown.reason).toBe('node_id_not_in_cross_view_contract');
+  });
+
 });


### PR DESCRIPTION
## Summary

- add an explicit cross-view link contract for selected Cabinet ecosystem node IDs
- load the mapping in the ecosystem map controller without Mermaid parsing or label heuristics
- show linked and unmapped nodes in the `/ecosystem-map` source view
- degrade unknown node IDs to explicit `unmapped` state

## Validation

- `NODE_OPTIONS=--jitless ./node_modules/.bin/tsc --noEmit` passed using a temporary local node_modules symlink
- touched-file whitespace check passed
- Vitest is left to CI because the local Node/V8 environment is not compatible with the normal Vitest path here

## Boundary

- no dispatch actions
- no external fetch
- no Cabinet mutation
- no relation truth, runtime dependency or change-impact claim
- links are local read-only navigation only