### PR TITLE
feat: add RepoBrief observability view

### DIFF
--- a/src/controllers/repoBrief.ts
+++ b/src/controllers/repoBrief.ts
@@ -1,0 +1,175 @@
+import { readFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+
+export type RepoBriefSourceKind = 'artifact' | 'missing' | 'corrupt';
+export type RepoBriefStatus = 'ok' | 'warn' | 'fail' | 'unknown';
+
+export interface RepoBriefBundleView {
+  repo: string;
+  bundle_stem: string;
+  bundle_directory: string;
+  bundle_manifest: string;
+  agent_reading_pack: string;
+  canonical_dump: string;
+  source_commit: string | null;
+  snapshot_status: RepoBriefStatus;
+  preflight_status: RepoBriefStatus;
+  export_safety: RepoBriefStatus;
+  public_export_ready: boolean;
+  summary: string;
+  required_artifacts: string[];
+  warnings: string[];
+}
+
+export interface RepoBriefViewData {
+  bundles: RepoBriefBundleView[];
+  view_meta: {
+    source_kind: RepoBriefSourceKind;
+    source_path: string;
+    missing_reason: string;
+    generated_at: string | null;
+    bundle_count: number;
+    public_export_ready_count: number;
+    warning_count: number;
+    does_not_establish: string[];
+  };
+}
+
+const CONTRACT_KIND = 'leitstand_repobrief_bundle_index';
+const DEFAULT_NON_CLAIMS = [
+  'repo_understanding',
+  'public_export_safety',
+  'review_completeness',
+  'runtime_correctness',
+  'test_sufficiency',
+];
+
+function configuredBundleIndexPath(): string {
+  return process.env.LEITSTAND_REPOBRIEF_BUNDLES_PATH
+    || join(process.cwd(), 'src', 'fixtures', 'repobrief-bundles.json');
+}
+
+function normalizeStatus(value: unknown): RepoBriefStatus {
+  if (value === 'ok' || value === 'pass') return 'ok';
+  if (value === 'warn' || value === 'warning') return 'warn';
+  if (value === 'fail' || value === 'failed' || value === 'error') return 'fail';
+  return 'unknown';
+}
+
+function classifyError(error: unknown): { kind: RepoBriefSourceKind; reason: string } {
+  const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+  if (message.includes('enoent') || message.includes('no such file')) {
+    return { kind: 'missing', reason: 'repobrief_bundle_index_missing' };
+  }
+  if (message.includes('json') || message.includes('invalid') || message.includes('unexpected')) {
+    return { kind: 'corrupt', reason: 'repobrief_bundle_index_corrupt' };
+  }
+  return { kind: 'corrupt', reason: 'repobrief_bundle_index_load_failed' };
+}
+
+function emptyData(kind: RepoBriefSourceKind, reason: string, sourcePath: string): RepoBriefViewData {
+  return {
+    bundles: [],
+    view_meta: {
+      source_kind: kind,
+      source_path: sourcePath,
+      missing_reason: reason,
+      generated_at: null,
+      bundle_count: 0,
+      public_export_ready_count: 0,
+      warning_count: 0,
+      does_not_establish: DEFAULT_NON_CLAIMS,
+    },
+  };
+}
+
+function parseStringArray(raw: unknown): string[] {
+  return Array.isArray(raw) ? raw.filter((item): item is string => typeof item === 'string') : [];
+}
+
+function parseBundle(raw: unknown): RepoBriefBundleView {
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('invalid RepoBrief bundle: must be object');
+  }
+  const bundle = raw as Record<string, unknown>;
+  const repo = typeof bundle.repo === 'string' ? bundle.repo : '';
+  const bundleStem = typeof bundle.bundleStem === 'string' ? bundle.bundleStem : '';
+  const bundleDirectory = typeof bundle.bundleDirectory === 'string' ? bundle.bundleDirectory : '';
+  const bundleManifest = typeof bundle.bundleManifest === 'string' ? bundle.bundleManifest : '';
+  const agentReadingPack = typeof bundle.agentReadingPack === 'string' ? bundle.agentReadingPack : '';
+  const canonicalDump = typeof bundle.canonicalDump === 'string' ? bundle.canonicalDump : '';
+  if (!repo || !bundleStem || !bundleDirectory || !bundleManifest || !agentReadingPack || !canonicalDump) {
+    throw new Error('invalid RepoBrief bundle: missing required path fields');
+  }
+  return {
+    repo,
+    bundle_stem: bundleStem,
+    bundle_directory: bundleDirectory,
+    bundle_manifest: bundleManifest,
+    agent_reading_pack: agentReadingPack,
+    canonical_dump: canonicalDump,
+    source_commit: typeof bundle.sourceCommit === 'string' ? bundle.sourceCommit : null,
+    snapshot_status: normalizeStatus(bundle.snapshotStatus),
+    preflight_status: normalizeStatus(bundle.preflightStatus),
+    export_safety: normalizeStatus(bundle.exportSafety),
+    public_export_ready: bundle.publicExportReady === true,
+    summary: typeof bundle.summary === 'string' ? bundle.summary : '',
+    required_artifacts: parseStringArray(bundle.requiredArtifacts),
+    warnings: parseStringArray(bundle.warnings),
+  };
+}
+
+function parseIndex(raw: unknown): {
+  bundles: RepoBriefBundleView[];
+  generatedAt: string | null;
+  doesNotEstablish: string[];
+} {
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('invalid RepoBrief bundle index: root must be object');
+  }
+  const index = raw as {
+    schemaVersion?: unknown;
+    kind?: unknown;
+    generatedAt?: unknown;
+    bundles?: unknown;
+    doesNotEstablish?: unknown;
+  };
+  if (index.schemaVersion !== 1 || index.kind !== CONTRACT_KIND) {
+    throw new Error('invalid RepoBrief bundle index: kind or schemaVersion mismatch');
+  }
+  if (!Array.isArray(index.bundles)) {
+    throw new Error('invalid RepoBrief bundle index: bundles must be a list');
+  }
+  const bundles = index.bundles.map(parseBundle);
+  return {
+    bundles,
+    generatedAt: typeof index.generatedAt === 'string' ? index.generatedAt : null,
+    doesNotEstablish: parseStringArray(index.doesNotEstablish).length > 0
+      ? parseStringArray(index.doesNotEstablish)
+      : DEFAULT_NON_CLAIMS,
+  };
+}
+
+export async function getRepoBriefData(): Promise<RepoBriefViewData> {
+  const sourcePath = resolve(configuredBundleIndexPath());
+  try {
+    const parsed = parseIndex(JSON.parse(await readFile(sourcePath, 'utf-8')) as unknown);
+    const warningCount = parsed.bundles.reduce((total, bundle) => total + bundle.warnings.length, 0);
+    return {
+      bundles: parsed.bundles,
+      view_meta: {
+        source_kind: 'artifact',
+        source_path: sourcePath,
+        missing_reason: 'ok',
+        generated_at: parsed.generatedAt,
+        bundle_count: parsed.bundles.length,
+        public_export_ready_count: parsed.bundles.filter((bundle) => bundle.public_export_ready).length,
+        warning_count: warningCount,
+        does_not_establish: parsed.doesNotEstablish,
+      },
+    };
+  } catch (error) {
+    const classified = classifyError(error);
+    return emptyData(classified.kind, classified.reason, sourcePath);
+  }
+}

--- a/src/fixtures/ecosystem-map-links.json
+++ b/src/fixtures/ecosystem-map-links.json
@@ -78,16 +78,26 @@
     {
       "nodeId": "repo:lenskit",
       "label": "Lenskit / RepoBrief implementation",
-      "status": "unmapped",
-      "reason": "RepoBrief observability view is planned but not implemented yet.",
-      "links": []
+      "status": "linked",
+      "links": [
+        {
+          "view": "repobriefs",
+          "href": "/repobriefs",
+          "title": "RepoBrief bundle observability"
+        }
+      ]
     },
     {
       "nodeId": "concept:repobrief",
       "label": "RepoBrief",
-      "status": "unmapped",
-      "reason": "RepoBrief observability view is planned but not implemented yet.",
-      "links": []
+      "status": "linked",
+      "links": [
+        {
+          "view": "repobriefs",
+          "href": "/repobriefs",
+          "title": "RepoBrief bundle observability"
+        }
+      ]
     }
   ]
 }

--- a/src/fixtures/repobrief-bundles.json
+++ b/src/fixtures/repobrief-bundles.json
@@ -1,0 +1,40 @@
+{
+  "schemaVersion": 1,
+  "kind": "leitstand_repobrief_bundle_index",
+  "generatedAt": "2026-07-05T06:43:00Z",
+  "source": "local_operator_index",
+  "doesNotEstablish": [
+    "repo_understanding",
+    "public_export_safety",
+    "review_completeness",
+    "runtime_correctness",
+    "test_sufficiency"
+  ],
+  "bundles": [
+    {
+      "repo": "leitstand",
+      "bundleStem": "leitstand-max-260705-0443",
+      "bundleDirectory": "/home/alex/repos/merges/leitstand-max-260705-0643",
+      "bundleManifest": "/home/alex/repos/merges/leitstand-max-260705-0643/leitstand-max-260705-0443_merge.bundle.manifest.json",
+      "agentReadingPack": "/home/alex/repos/merges/leitstand-max-260705-0643/leitstand-max-260705-0443_merge.agent_reading_pack.md",
+      "canonicalDump": "/home/alex/repos/merges/leitstand-max-260705-0643/leitstand-max-260705-0443_merge.md",
+      "sourceCommit": "0aeb59942d4b70d92129516139b4f46d3e07ec1d",
+      "snapshotStatus": "ok",
+      "preflightStatus": "warn",
+      "exportSafety": "fail",
+      "publicExportReady": false,
+      "summary": "Fresh Leitstand origin/main RepoBrief used as evidence for visualization-layer planning. Export-safety is not public-ready even though redaction was observed.",
+      "requiredArtifacts": [
+        "bundle_manifest",
+        "canonical_dump",
+        "agent_reading_pack",
+        "chunk_index",
+        "sqlite_index"
+      ],
+      "warnings": [
+        "claim-evidence sidecars skipped; no missing required artifacts",
+        "export gate missing or not pass; treat as internal analysis only"
+      ]
+    }
+  ]
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,6 +14,7 @@ import { getTimelineData } from './controllers/timeline.js';
 import { getReflexionData } from './controllers/reflexion.js';
 import { getDashboardData } from './controllers/dashboard.js';
 import { getEcosystemMapData } from './controllers/ecosystemMap.js';
+import { getRepoBriefData } from './controllers/repoBrief.js';
 import { getEventFamily, listEventFamilies } from './utils/eventKind.js';
 import fs from 'fs';
 import { validatePlexerReport } from './validation/validators.js';
@@ -303,6 +304,19 @@ app.get('/', async (_req, res) => {
   }
 });
 
+
+
+app.get('/repobriefs', async (_req, res) => {
+  try {
+    const data = await getRepoBriefData();
+    res.render('repobriefs', data);
+  } catch (error) {
+    if (!res.headersSent) {
+      console.error('[RepoBriefs] Error:', error);
+      res.status(500).send('Error loading RepoBrief data');
+    }
+  }
+});
 
 app.get('/ecosystem-map', async (_req, res) => {
   try {

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -265,6 +265,7 @@
     <a href="/" class="active" aria-current="page">Home</a>
     <a href="/observatory">Observatorium</a>
     <a href="/ecosystem-map">Ecosystem Map</a>
+    <a href="/repobriefs">RepoBriefs</a>
     <a href="/anatomy">Anatomie</a>
     <a href="/timeline">Zeitachse</a>
     <a href="/insights">Erkenntnisse</a>
@@ -286,6 +287,14 @@
       <p>
         Read-only Cabinet map source view: zeigt Mermaid-Quellen, Commit, Manifest, Freshness und Boundary-Hinweis.
         <a href="/ecosystem-map">Ecosystem Map öffnen</a>.
+      </p>
+    </section>
+
+    <section class="info-card" aria-labelledby="repobrief-heading">
+      <h2 id="repobrief-heading">RepoBrief / rLens</h2>
+      <p>
+        Read-only bundle observability: zeigt Snapshot-Status, Required Artifacts und Export-Safety-Warnungen.
+        <a href="/repobriefs">RepoBriefs öffnen</a>.
       </p>
     </section>
 

--- a/src/views/repobriefs.ejs
+++ b/src/views/repobriefs.ejs
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <title>RepoBriefs – Leitstand</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0a0e1a; color: #f1f5f9; margin: 0; }
+    nav { position: sticky; top: 0; display: flex; gap: 4px; padding: 10px 20px; background: rgba(10,14,26,.92); border-bottom: 1px solid rgba(255,255,255,.08); }
+    nav a { color: #94a3b8; text-decoration: none; padding: 6px 14px; border-radius: 6px; font-size: .82em; }
+    nav a.active, nav a:hover { color: #3b82f6; background: rgba(59,130,246,.1); }
+    nav .title { color: #f1f5f9; font-weight: 700; margin-right: 16px; }
+    main { max-width: 1180px; margin: 0 auto; padding: 42px 24px 80px; }
+    .subtitle, .muted, li { color: #94a3b8; line-height: 1.55; }
+    .notice, .card, .meta-item { background: rgba(17,24,39,.88); border: 1px solid rgba(255,255,255,.08); border-radius: 14px; padding: 20px 22px; margin-bottom: 18px; }
+    .notice strong { color: #3b82f6; }
+    .meta-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; margin: 22px 0; }
+    .label { color: #64748b; font-size: .72em; text-transform: uppercase; letter-spacing: .08em; margin-bottom: 5px; }
+    .value { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .82em; overflow-wrap: anywhere; }
+    .status-ok { color: #22c55e; }
+    .status-warn, .status-unknown { color: #f59e0b; }
+    .status-fail { color: #ef4444; }
+    code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: #dbeafe; }
+    ul { margin-left: 20px; }
+  </style>
+</head>
+<body>
+  <nav aria-label="Hauptnavigation">
+    <span class="title">Leitstand</span>
+    <a href="/">Home</a>
+    <a href="/ecosystem-map">Ecosystem Map</a>
+    <a href="/repobriefs" class="active" aria-current="page">RepoBriefs</a>
+    <a href="/anatomy">Anatomie</a>
+    <a href="/timeline">Zeitachse</a>
+    <a href="/insights">Erkenntnisse</a>
+    <a href="/reflexion">Reflexion</a>
+    <a href="/ops">Ops</a>
+  </nav>
+
+  <main>
+    <h1>RepoBrief / rLens Observability</h1>
+    <p class="subtitle">Read-only surface for repository snapshot bundles. This view shows status, required artifacts and export-safety warnings; it does not generate bundles or claim repository understanding.</p>
+
+    <section class="notice">
+      <strong>View only.</strong> Local bundle paths are operator pointers. Export-safety failures must remain visible and block public-share framing.
+    </section>
+
+    <section class="meta-grid" aria-label="RepoBrief source metadata">
+      <div class="meta-item"><div class="label">Source state</div><div class="value"><%= view_meta.source_kind %> / <%= view_meta.missing_reason %></div></div>
+      <div class="meta-item"><div class="label">Source path</div><div class="value"><%= view_meta.source_path %></div></div>
+      <div class="meta-item"><div class="label">Generated</div><div class="value"><%= view_meta.generated_at || '—' %></div></div>
+      <div class="meta-item"><div class="label">Bundles</div><div class="value"><%= view_meta.bundle_count %></div></div>
+      <div class="meta-item"><div class="label">Public export ready</div><div class="value"><%= view_meta.public_export_ready_count %></div></div>
+      <div class="meta-item"><div class="label">Warnings</div><div class="value"><%= view_meta.warning_count %></div></div>
+    </section>
+
+    <% if (bundles.length === 0) { %>
+      <section class="card"><p class="muted">No RepoBrief bundle index is available. This is a degraded read-only state, not a green status.</p></section>
+    <% } %>
+
+    <% for (const bundle of bundles) { %>
+      <section class="card" data-repo="<%= bundle.repo %>">
+        <h2><%= bundle.repo %> · <%= bundle.bundle_stem %></h2>
+        <p class="muted"><%= bundle.summary %></p>
+        <div class="meta-grid">
+          <div class="meta-item"><div class="label">Snapshot</div><div class="value status-<%= bundle.snapshot_status %>"><%= bundle.snapshot_status %></div></div>
+          <div class="meta-item"><div class="label">Preflight</div><div class="value status-<%= bundle.preflight_status %>"><%= bundle.preflight_status %></div></div>
+          <div class="meta-item"><div class="label">Export safety</div><div class="value status-<%= bundle.export_safety %>"><%= bundle.export_safety %></div></div>
+          <div class="meta-item"><div class="label">Public export ready</div><div class="value"><%= bundle.public_export_ready ? 'yes' : 'no' %></div></div>
+          <div class="meta-item"><div class="label">Source commit</div><div class="value"><%= bundle.source_commit || '—' %></div></div>
+          <div class="meta-item"><div class="label">Manifest</div><div class="value"><%= bundle.bundle_manifest %></div></div>
+        </div>
+        <h3>Local operator pointers</h3>
+        <ul>
+          <li>Bundle directory: <code><%= bundle.bundle_directory %></code></li>
+          <li>Agent reading pack: <code><%= bundle.agent_reading_pack %></code></li>
+          <li>Canonical dump: <code><%= bundle.canonical_dump %></code></li>
+        </ul>
+        <h3>Required artifacts</h3>
+        <ul>
+          <% for (const item of bundle.required_artifacts) { %><li><%= item %></li><% } %>
+        </ul>
+        <% if (bundle.warnings.length > 0) { %>
+          <h3>Warnings</h3>
+          <ul>
+            <% for (const warning of bundle.warnings) { %><li class="status-warn"><%= warning %></li><% } %>
+          </ul>
+        <% } %>
+      </section>
+    <% } %>
+
+    <section class="card">
+      <h2>Does not establish</h2>
+      <ul>
+        <% for (const item of view_meta.does_not_establish) { %><li><%= item %></li><% } %>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/tests/controllers/repoBrief.test.ts
+++ b/tests/controllers/repoBrief.test.ts
@@ -1,0 +1,75 @@
+import { mkdtemp, writeFile, rm } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { afterEach, describe, expect, it } from 'vitest';
+import { getRepoBriefData } from '../../src/controllers/repoBrief.js';
+
+const OLD_INDEX = process.env.LEITSTAND_REPOBRIEF_BUNDLES_PATH;
+let tempRoots: string[] = [];
+
+afterEach(async () => {
+  if (OLD_INDEX === undefined) delete process.env.LEITSTAND_REPOBRIEF_BUNDLES_PATH;
+  else process.env.LEITSTAND_REPOBRIEF_BUNDLES_PATH = OLD_INDEX;
+  for (const root of tempRoots) {
+    await rm(root, { recursive: true, force: true });
+  }
+  tempRoots = [];
+});
+
+async function writeBundleIndex(publicExportReady = false) {
+  const root = await mkdtemp(join(tmpdir(), 'leitstand-repobrief-'));
+  tempRoots.push(root);
+  const path = join(root, 'bundles.json');
+  await writeFile(path, JSON.stringify({
+    schemaVersion: 1,
+    kind: 'leitstand_repobrief_bundle_index',
+    generatedAt: '2026-07-05T06:43:00Z',
+    doesNotEstablish: ['repo_understanding', 'public_export_safety'],
+    bundles: [
+      {
+        repo: 'leitstand',
+        bundleStem: 'leitstand-max-260705-0443',
+        bundleDirectory: '/tmp/leitstand-bundle',
+        bundleManifest: '/tmp/leitstand-bundle/manifest.json',
+        agentReadingPack: '/tmp/leitstand-bundle/pack.md',
+        canonicalDump: '/tmp/leitstand-bundle/dump.md',
+        sourceCommit: 'a'.repeat(40),
+        snapshotStatus: 'ok',
+        preflightStatus: 'warn',
+        exportSafety: publicExportReady ? 'ok' : 'fail',
+        publicExportReady,
+        summary: 'fixture bundle',
+        requiredArtifacts: ['bundle_manifest', 'canonical_dump'],
+        warnings: publicExportReady ? [] : ['export gate missing or not pass'],
+      },
+    ],
+  }), 'utf-8');
+  return path;
+}
+
+describe('getRepoBriefData', () => {
+  it('loads bundle status and keeps export-safety failures visible', async () => {
+    process.env.LEITSTAND_REPOBRIEF_BUNDLES_PATH = await writeBundleIndex(false);
+    const data = await getRepoBriefData();
+    expect(data.view_meta.source_kind).toBe('artifact');
+    expect(data.view_meta.bundle_count).toBe(1);
+    expect(data.view_meta.public_export_ready_count).toBe(0);
+    expect(data.view_meta.warning_count).toBe(1);
+    expect(data.bundles[0].repo).toBe('leitstand');
+    expect(data.bundles[0].snapshot_status).toBe('ok');
+    expect(data.bundles[0].preflight_status).toBe('warn');
+    expect(data.bundles[0].export_safety).toBe('fail');
+    expect(data.bundles[0].public_export_ready).toBe(false);
+  });
+
+  it('reports missing index as degraded, not green', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'leitstand-repobrief-missing-'));
+    tempRoots.push(root);
+    process.env.LEITSTAND_REPOBRIEF_BUNDLES_PATH = join(root, 'missing.json');
+    const data = await getRepoBriefData();
+    expect(data.view_meta.source_kind).toBe('missing');
+    expect(data.view_meta.missing_reason).toBe('repobrief_bundle_index_missing');
+    expect(data.view_meta.bundle_count).toBe(0);
+    expect(data.bundles).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- add a read-only `/repobriefs` view for RepoBrief/rLens bundle observability
- add a configurable bundle-index loader with degraded missing/corrupt states
- show snapshot/preflight/export-safety status, required artifacts, warnings, local operator pointers, and non-claims
- link RepoBrief-related ecosystem nodes to the new view

## Validation

- `NODE_OPTIONS=--jitless ./node_modules/.bin/tsc --noEmit` passed using a temporary local node_modules symlink
- touched-file whitespace check passed
- Vitest is left to CI because the local Node/V8 environment is not compatible with the normal Vitest path here

## Boundary

- no bundle generation from Leitstand
- no external fetch
- no public-export greenwashing
- local paths are operator pointers only
- export-safety failures remain visible