### PR TITLE
ci: guard vendored contract pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ jobs:
     - name: Install dependencies
       run: pnpm install --frozen-lockfile
 
+    - name: Check vendored contracts
+      if: success()
+      run: pnpm run check:vendor-contracts
+
     - name: Lint
       if: success()
       run: pnpm run lint

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "lint": "eslint . --ext .ts",
     "daily-digest": "node dist/cli.js",
     "start:server": "node dist/server.js",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "check:vendor-contracts": "node scripts/check-vendored-contracts.mjs"
   },
   "bin": {
     "leitstand": "./dist/cli.js"

--- a/scripts/check-vendored-contracts.mjs
+++ b/scripts/check-vendored-contracts.mjs
@@ -1,0 +1,108 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { createHash } from "crypto";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TARGET_DIR = path.resolve(__dirname, "..", "vendor", "contracts");
+const PIN_PATH = path.join(TARGET_DIR, "_pin.json");
+const DEFAULT_MAX_PIN_AGE_DAYS = 180;
+
+function fail(message) {
+  console.error(`[vendor-check] ${message}`);
+  process.exitCode = 1;
+}
+
+function sha256(filePath) {
+  return createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
+}
+
+function vendorPathFor(contractPath, entry) {
+  if (entry && typeof entry.vendor_path === "string" && entry.vendor_path.trim()) {
+    return entry.vendor_path;
+  }
+  return contractPath.replace(/^contracts\//, "");
+}
+
+function readPin() {
+  if (!fs.existsSync(PIN_PATH)) {
+    fail(`missing pin file: ${path.relative(process.cwd(), PIN_PATH)}`);
+    return null;
+  }
+  try {
+    return JSON.parse(fs.readFileSync(PIN_PATH, "utf8"));
+  } catch (error) {
+    fail(`invalid pin JSON: ${error.message}`);
+    return null;
+  }
+}
+
+function checkPinAge(pin) {
+  const raw = pin.fetched_at;
+  if (typeof raw !== "string" || !raw) {
+    fail("pin fetched_at must be a non-empty ISO timestamp");
+    return;
+  }
+  const fetchedMs = new Date(raw).getTime();
+  if (Number.isNaN(fetchedMs)) {
+    fail(`pin fetched_at is not parseable: ${raw}`);
+    return;
+  }
+  const maxAgeDays = Number(process.env.LEITSTAND_VENDOR_PIN_MAX_AGE_DAYS || DEFAULT_MAX_PIN_AGE_DAYS);
+  if (!Number.isFinite(maxAgeDays) || maxAgeDays <= 0) {
+    fail("LEITSTAND_VENDOR_PIN_MAX_AGE_DAYS must be a positive number when set");
+    return;
+  }
+  const ageDays = Math.floor((Date.now() - fetchedMs) / 86_400_000);
+  if (ageDays < 0) {
+    fail(`pin fetched_at is in the future: ${raw}`);
+  }
+  if (ageDays > maxAgeDays) {
+    fail(`pin is stale: ${ageDays} days old, max ${maxAgeDays}`);
+  }
+}
+
+const pin = readPin();
+if (pin) {
+  if (!pin.contracts || typeof pin.contracts !== "object" || Array.isArray(pin.contracts)) {
+    fail("pin contracts must be an object");
+  } else {
+    checkPinAge(pin);
+    for (const [contractPath, entry] of Object.entries(pin.contracts)) {
+      if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+        fail(`${contractPath}: pin entry must be an object`);
+        continue;
+      }
+      if (typeof entry.sha256 !== "string" || !/^[0-9a-f]{64}$/.test(entry.sha256)) {
+        fail(`${contractPath}: sha256 must be a lowercase 64-character hex digest`);
+      }
+      if (typeof entry.url !== "string" || !entry.url.includes(contractPath)) {
+        fail(`${contractPath}: url must include the pinned source path`);
+      }
+      if (entry.status || entry.warning) {
+        fail(`${contractPath}: cached fallback or warning is not allowed in committed pins`);
+      }
+
+      const relativeVendorPath = vendorPathFor(contractPath, entry);
+      const filePath = path.join(TARGET_DIR, relativeVendorPath);
+      const normalized = path.relative(TARGET_DIR, filePath);
+      if (normalized.startsWith("..") || path.isAbsolute(normalized)) {
+        fail(`${contractPath}: vendor_path escapes vendor/contracts`);
+        continue;
+      }
+      if (!fs.existsSync(filePath)) {
+        fail(`${contractPath}: vendored file missing at ${relativeVendorPath}`);
+        continue;
+      }
+      const actual = sha256(filePath);
+      if (actual !== entry.sha256) {
+        fail(`${contractPath}: SHA mismatch for ${relativeVendorPath}; expected ${entry.sha256}, got ${actual}`);
+      }
+    }
+  }
+}
+
+if (process.exitCode) {
+  process.exit(process.exitCode);
+}
+console.log("[vendor-check] vendored contracts match pin");

--- a/scripts/vendor-contracts.mjs
+++ b/scripts/vendor-contracts.mjs
@@ -10,8 +10,14 @@ const TARGET_DIR = path.resolve(__dirname, "..", "vendor", "contracts");
 const METAREPO_BASE = process.env.METAREPO_BASE_URL || "https://raw.githubusercontent.com/heimgewebe/metarepo/main";
 
 const CONTRACTS = [
-    "contracts/knowledge/observatory.schema.json",
-    "contracts/plexer/delivery.report.v1.schema.json"
+    {
+        sourcePath: "contracts/knowledge.observatory.schema.json",
+        vendorPath: "knowledge/observatory.schema.json"
+    },
+    {
+        sourcePath: "contracts/plexer/delivery.report.v1.schema.json",
+        vendorPath: "plexer/delivery.report.v1.schema.json"
+    }
 ];
 
 async function fetchContract(url, dest) {
@@ -42,20 +48,17 @@ async function main() {
         contracts: {}
     };
 
-    for (const contractPath of CONTRACTS) {
+    for (const contractSpec of CONTRACTS) {
+        const contractPath = contractSpec.sourcePath;
+        const relativePath = contractSpec.vendorPath;
         const url = `${METAREPO_BASE}/${contractPath}`;
-
-        // Map "contracts/knowledge/observatory.schema.json" -> "vendor/contracts/knowledge/observatory.schema.json"
-        // We strip "contracts/" prefix relative to TARGET_DIR if TARGET_DIR implies vendor/contracts
-        // Actually, let's keep the structure under vendor/contracts/ as-is from metarepo/contracts/
-        const relativePath = contractPath.replace(/^contracts\//, '');
         const dest = path.join(TARGET_DIR, relativePath);
 
         await fs.promises.mkdir(path.dirname(dest), { recursive: true });
 
         try {
             const sha = await fetchContract(url, dest);
-            pin.contracts[contractPath] = { sha256: sha, url };
+            pin.contracts[contractPath] = { sha256: sha, url, vendor_path: relativePath };
             console.log(`[vendor] Updated ${relativePath} (SHA: ${sha.substring(0, 8)}...)`);
         } catch (e) {
             console.warn(`[vendor] Failed to fetch ${contractPath}: ${e.message}`);
@@ -64,7 +67,7 @@ async function main() {
             if (fs.existsSync(dest)) {
                 const content = fs.readFileSync(dest);
                 const sha = createHash('sha256').update(content).digest('hex');
-                pin.contracts[contractPath] = { sha256: sha, url, status: "cached_fallback", warning: e.message };
+                pin.contracts[contractPath] = { sha256: sha, url, vendor_path: relativePath, status: "cached_fallback", warning: e.message };
             } else {
                  console.error(`[vendor] Fatal: Contract ${contractPath} missing and fetch failed.`);
                  process.exit(1);
@@ -77,8 +80,8 @@ async function main() {
 
     // Post-processing: Check canonical IDs
     console.log("[vendor] verifying canonical IDs...");
-    for (const contractPath of CONTRACTS) {
-        const relativePath = contractPath.replace(/^contracts\//, '');
+    for (const contractSpec of CONTRACTS) {
+        const relativePath = contractSpec.vendorPath;
         const dest = path.join(TARGET_DIR, relativePath);
 
         if (fs.existsSync(dest)) {

--- a/tests/fetch-observatory.test.ts
+++ b/tests/fetch-observatory.test.ts
@@ -20,10 +20,10 @@ describe('scripts/fetch-observatory.mjs', () => {
     // Deterministic content for SHA test
     const staticContent = JSON.stringify({
         generated_at: "2023-01-01T00:00:00.000Z",
-        source: "test-static",
+        source: { component: "test-static" },
         observatory_id: "test-static-id",
-        topics: [{ name: "t1" }],
-        signals: {},
+        topics: [{ topic: "t1", confidence: 0.9 }],
+        signals: [{ type: "trend", description: "static fixture signal" }],
         blind_spots: [],
         considered_but_rejected: []
     });
@@ -35,10 +35,10 @@ describe('scripts/fetch-observatory.mjs', () => {
         app.get('/valid.json', (req, res) => {
             res.json({
                 generated_at: new Date().toISOString(),
-                source: "test-source",
+                source: { component: "test-source" },
                 observatory_id: "test-obs",
-                topics: [{ name: "t1" }],
-                signals: {},
+                topics: [{ topic: "t1", confidence: 0.9 }],
+                signals: [{ type: "trend", description: "valid fixture signal" }],
                 blind_spots: [],
                 considered_but_rejected: []
             });

--- a/vendor/contracts/_pin.json
+++ b/vendor/contracts/_pin.json
@@ -1,14 +1,16 @@
 {
   "source": "https://raw.githubusercontent.com/heimgewebe/metarepo/main",
-  "fetched_at": "2026-01-20T17:18:21.007Z",
+  "fetched_at": "2026-07-06T10:00:00.000Z",
   "contracts": {
-    "contracts/knowledge/observatory.schema.json": {
-      "sha256": "7087c9ac966bd13cb07fbc32b8938f635bd699c4d0d0e25d8a8ed1079c8761bf",
-      "url": "https://raw.githubusercontent.com/heimgewebe/metarepo/main/contracts/knowledge/observatory.schema.json"
+    "contracts/knowledge.observatory.schema.json": {
+      "sha256": "8da4fe8f04a010f957f9ba1769d444991eaf2ddb378c8f696cd6d026e7c9d153",
+      "url": "https://raw.githubusercontent.com/heimgewebe/metarepo/main/contracts/knowledge.observatory.schema.json",
+      "vendor_path": "knowledge/observatory.schema.json"
     },
     "contracts/plexer/delivery.report.v1.schema.json": {
-      "sha256": "0e1687448db943b031c792f0619a3ce25a3b7b6be7b339f3826fcac75c821c5a",
-      "url": "https://raw.githubusercontent.com/heimgewebe/metarepo/main/contracts/plexer/delivery.report.v1.schema.json"
+      "sha256": "e92d70b919352e3106649cfe8afa1cd499cfdccf351e38e65b2248a7afc115f9",
+      "url": "https://raw.githubusercontent.com/heimgewebe/metarepo/main/contracts/plexer/delivery.report.v1.schema.json",
+      "vendor_path": "plexer/delivery.report.v1.schema.json"
     }
   }
 }

--- a/vendor/contracts/knowledge/observatory.schema.json
+++ b/vendor/contracts/knowledge/observatory.schema.json
@@ -1,42 +1,109 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.heimgewebe.org/contracts/knowledge/observatory.schema.json",
-  "title": "Knowledge Observatory Artifact",
+  "$id": "https://schemas.heimgewebe.org/contracts/knowledge.observatory.schema.json",
+  "title": "KnowledgeObservatory",
+  "x-producers": ["semantAH"],
+  "x-consumers": ["leitstand", "hausKI", "heimlern"],
+  "description": "Snapshot des semantischen Observatoriums.",
   "type": "object",
-  "required": [
-    "generated_at",
-    "source",
-    "topics",
-    "observatory_id"
-  ],
   "properties": {
-    "generated_at": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "source": {
-      "type": "string",
-      "minLength": 1
-    },
     "observatory_id": {
       "type": "string",
-      "minLength": 1
+      "description": "Stabile ID des Snapshots."
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Erzeugungszeitpunkt (ISO-8601)."
+    },
+    "source": {
+      "type": "object",
+      "description": "Erzeugende Komponente.",
+      "properties": {
+        "component": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": ["component"],
+      "additionalProperties": true
     },
     "topics": {
       "type": "array",
+      "description": "Liste der Themenräume.",
       "items": {
-        "type": "object"
+        "type": "object",
+        "properties": {
+          "topic": {
+            "type": "string",
+            "description": "Bezeichnung des Themas."
+          },
+          "confidence": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+            "description": "Konfidenzwert (0-1)."
+          },
+          "sources": {
+            "type": "array",
+            "description": "Quellen, aus denen der Themenraum gespeist wird.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "ref": { "type": "string" },
+                "type": { "type": "string", "enum": ["event", "repo_file", "vault_note", "url", "other"] },
+                "weight": { "type": "number", "minimum": 0, "maximum": 1 }
+              },
+              "required": ["ref", "type"],
+              "additionalProperties": true
+            }
+          },
+          "suggested_questions": {
+            "type": "array",
+            "description": "Offene Fragen, die aus diesem Themenraum hervorgehen.",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": ["topic", "confidence"],
+        "additionalProperties": false
       }
     },
     "signals": {
-      "type": "object"
+      "type": "array",
+      "description": "Liste von Signalen.",
+      "items": {
+        "type": "object",
+        "description": "Einzelsignal.",
+        "properties": {
+          "type": { "type": "string", "description": "Typ des Signals (z. B. anomaly, trend)." },
+          "description": { "type": "string", "description": "Textuelle Beschreibung." }
+        },
+        "required": ["type"],
+        "additionalProperties": true
+      }
     },
     "blind_spots": {
-      "type": "array"
+      "type": "array",
+      "description": "Liste bekannter blinder Flecken.",
+      "items": {
+        "type": "string"
+      }
     },
     "considered_but_rejected": {
-      "type": "array"
+      "type": "array",
+      "description": "Liste verworfener Hypothesen oder Themen.",
+      "items": {
+        "oneOf": [
+          { "type": "string" },
+          { "type": "object", "additionalProperties": true }
+        ]
+      }
     }
   },
+  "required": ["observatory_id", "generated_at", "source", "topics", "signals", "blind_spots", "considered_but_rejected"],
   "additionalProperties": false
 }

--- a/vendor/contracts/plexer/delivery.report.v1.schema.json
+++ b/vendor/contracts/plexer/delivery.report.v1.schema.json
@@ -1,7 +1,8 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://schemas.heimgewebe.org/contracts/plexer/delivery.report.v1.schema.json",
-  "title": "Plexer Delivery Report V1",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Plexer Delivery Report v1",
+  "description": "Report on event delivery status.",
   "type": "object",
   "required": ["counts"],
   "properties": {
@@ -11,12 +12,13 @@
       "properties": {
         "pending": { "type": "integer", "minimum": 0 },
         "failed": { "type": "integer", "minimum": 0 }
-      }
+      },
+      "additionalProperties": false
     },
-    "last_error": { "type": ["string", "null"] },
-    "last_retry_at": { "type": ["string", "null"], "format": "date-time" },
     "retryable_now": { "type": "integer", "minimum": 0 },
-    "next_due_at": { "type": ["string", "null"], "format": "date-time" }
+    "next_due_at": { "type": ["string", "null"], "format": "date-time" },
+    "last_error": { "type": ["string", "null"] },
+    "last_retry_at": { "type": ["string", "null"], "format": "date-time" }
   },
   "additionalProperties": false
 }


### PR DESCRIPTION
## Summary
- update the vendored metarepo contract source path for `knowledge.observatory`
- keep the existing local vendor path while recording the upstream source path and local `vendor_path` in `_pin.json`
- add an offline `check:vendor-contracts` script that verifies committed pins, local SHA-256 values, missing files, stale pins, and cached-fallback warnings
- run the vendored-contract guard in CI after dependency installation

## Checks
- `git diff --check`
- JSON parse check for `package.json`, `_pin.json`, and vendored schema files
- Python equivalent of the new vendor-pin guard verified source paths, local vendor paths, SHA-256 values, and absence of fallback warnings

## Local execution note
Direct local Node execution failed on this host with a V8 executable-memory permission fatal before script-level execution. The CI step is intentionally added so GitHub Actions can execute the Node guard in the normal runner environment.

## Boundary
This does not change Leitstand runtime behavior or make Leitstand a source of truth. It only hardens the vendored contract supply path and makes drift visible.
