### PR TITLE
docs: operator ecosystem alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Leitstand
 
+## Operator ecosystem correction
+
+Leitstand is a read-only observer surface in the new operator ecosystem. Chronik owns event history; Plexer transports bounded operational events; Bureau owns tasks and claims; Grabowski owns local execution and receipts; Heimlern produces learning and proposal reports. Leitstand renders views and digests and does not execute or orchestrate.
+
+This correction supersedes older local role lists that mention only metarepo, wgx, semantAH, chronik, hausKI and leitstand.
+
 Dashboard and control-room for the **heimgewebe** organism.
 
 ## Overview
@@ -325,7 +331,7 @@ MIT
 This repository is part of the **Heimgewebe Organism**.
 
 The overarching architecture, axes, roles, and contracts are centrally described in:
-👉 [`metarepo/docs/heimgewebe-organismus.md`](https://github.com/heimgewebe/metarepo/blob/main/docs/heimgewebe-organismus.md)
+👉 [`metarepo/docs/system/heimgewebe-organismus.md`](https://github.com/heimgewebe/metarepo/blob/main/docs/heimgewebe-organismus.md)
 and the target vision:
 👉 [`metarepo/docs/heimgewebe-zielbild.md`](https://github.com/heimgewebe/metarepo/blob/main/docs/heimgewebe-zielbild.md).
 

--- a/docs/operator-ecosystem-alignment.md
+++ b/docs/operator-ecosystem-alignment.md
@@ -1,0 +1,12 @@
+# Operator ecosystem alignment
+
+Leitstand is a read-only observer surface in the Heimgewebe operator ecosystem.
+
+- Chronik owns append-only event history.
+- Plexer transports bounded operational events and delivery status.
+- Bureau owns tasks, claims, dispatch and completion records.
+- Grabowski owns local execution, leases, receipts and audit.
+- Heimlern produces retrospective learning and policy-adaptation proposals.
+- Leitstand renders views and digests; it does not execute or orchestrate.
+
+Plexer is not the only communication path. Contracts, GitHub/CI, direct artifact reads, Chronik queries and Plexer events are parallel channels. Use the path that preserves evidence and avoids hidden coupling.


### PR DESCRIPTION
Docs-only update for the current operator ecosystem role boundary. Validation: fetched branch README after push.