### PR TITLE
docs: add role contract overlay

### DIFF
--- a/docs/operator-ecosystem-alignment.md
+++ b/docs/operator-ecosystem-alignment.md
@@ -1,3 +1,12 @@
+---
+id: docs.operator-ecosystem-alignment
+title: Operator Ecosystem Alignment
+status: active
+doc_type: guide
+canonicality: supporting
+owner: leitstand
+---
+
 # Operator ecosystem alignment
 
 Leitstand is a read-only observer surface in the Heimgewebe operator ecosystem.

--- a/docs/operator-ecosystem-alignment.md
+++ b/docs/operator-ecosystem-alignment.md
@@ -5,6 +5,8 @@ status: active
 doc_type: guide
 canonicality: supporting
 owner: leitstand
+summary: >
+  Read-only Leitstand boundary in the Heimgewebe role map.
 ---
 
 # Operator ecosystem alignment

--- a/repo.meta.yaml
+++ b/repo.meta.yaml
@@ -1,9 +1,29 @@
 repo_name: leitstand
 repo_type: service
-role: dashboard_and_digest_generator
+role: observer_digest_view_surface
 status: active
 summary: >
-  Dashboard and control-room for the heimgewebe organism - daily system digest generator.
+  Read-only observer, digest and view surface for the Heimgewebe operator ecosystem.
+
+role_contract:
+  name: observer_digest_view_surface
+  authority: read_only_projection
+  owns:
+    - dashboards
+    - digests
+    - view_routes
+  consumes:
+    - chronik_events
+    - bureau_state
+    - plexer_delivery_reports
+  produces:
+    - rendered_views
+    - daily_digests
+  limits:
+    - no_task_ownership
+    - no_worker_execution
+    - no_ledger_writes
+  unavailable_effect: execution_truth_continues_without_leitstand
 
 owners:
   - heimgewebe-team
@@ -84,9 +104,15 @@ related_repos:
   - semantAH
   - chronik
   - hausKI
+  - bureau
+  - grabowski
+  - plexer
+  - heimlern
 
 keywords:
   - dashboard
   - digest
-  - control-room
+  - read-only
+  - observer
+  - view-surface
   - agent-ready


### PR DESCRIPTION
Adds role_contract metadata for the read-only Leitstand role. Validation: YAML parse and git diff --check.