### PR TITLE
docs: add role guard

### DIFF
--- a/scripts/check_role.py
+++ b/scripts/check_role.py
@@ -1,0 +1,5 @@
+from pathlib import Path
+text=Path('repo.meta.yaml').read_text()
+assert 'role_contract:' in text
+assert 'observer_digest_view_surface' in text
+print('role-contract: OK leitstand')


### PR DESCRIPTION
Adds scripts/check_role.py as a small local guard for the Leitstand operator role contract.