### PR TITLE
feat: add operator execution observability views

### DIFF
--- a/.ai-context.yml
+++ b/.ai-context.yml
@@ -3,8 +3,8 @@ ai_context_version: 1.1
 
 project:
   name: leitstand
-  summary: "Dashboard and control-room for the heimgewebe organism - daily system digest generator."
-  role: dashboard_and_digest_generator
+  summary: "Read-only dashboard and observation surface for the heimgewebe operator ecosystem."
+  role: observer_digest_view_surface
   primary_language: typescript
   visibility: internal
 
@@ -42,6 +42,12 @@ dependencies:
     - name: chronik
       relationship: consumes
       interface: [event.line]
+    - name: bureau
+      relationship: consumes
+      interface: [leitstand_bureau_task_snapshot]
+    - name: grabowski
+      relationship: consumes
+      interface: [leitstand_checkout_inventory]
   external:
     - name: node
       version: ">=18.0.0"
@@ -61,17 +67,19 @@ architecture:
       purpose: "Static data for UI (e.g. observatory.json)"
     - path: "src/views/"
       purpose: "EJS templates for the web server"
+    - path: "artifacts/"
+      purpose: "Producer-side snapshots consumed by read-only views"
   data_flow:
-    input: "Consumes fleet.health, insights.daily, and event.line files."
-    processing: "Aggregates data into daily digests and serves dashboard views."
-    output: "Displays dashboard UI and generates digest files."
+    input: "Consumes fleet.health, insights.daily, event.line files, and producer-side Bureau/Grabowski snapshot artifacts."
+    processing: "Aggregates data into daily digests and serves read-only dashboard/operator-observer views."
+    output: "Displays dashboard UI, operator observation views, and generated digest files."
 
 boundaries:
   not_responsible_for:
     - "Generating raw insights (responsibility of specialized agents)"
     - "Executing motorik actions (except for self-healing if needed)"
-    - "UI repo is profile-free by policy."
-    - "Don’t add .wgx/profile.yml unless policy changes."
+    - "Executing or dispatching Bureau/Grabowski work."
+    - "Mutating checkouts, leases, claims, tasks, runtime services, or deployment state."
   dangerous_assumptions:
     - "Assuming all data sources are always present (must handle missing files gracefully)"
     - "Assume npm; repo uses pnpm (see packageManager/pnpm-lock.yaml)."

--- a/.ai-context.yml
+++ b/.ai-context.yml
@@ -22,6 +22,8 @@ interfaces:
     - "event.line"
     - "fleet.health"
     - "insights.daily"
+    - "leitstand_bureau_task_snapshot"
+    - "leitstand_checkout_inventory"
   produces:
     - "insights.digest"
     - "dashboard.view"

--- a/docs/blueprints/operator-execution-observability.md
+++ b/docs/blueprints/operator-execution-observability.md
@@ -71,16 +71,18 @@ snapshot.
 Two local view contracts (`schemaVersion: 1`), pinned by the bridge:
 
 - **`leitstand_bureau_task_snapshot`** — `tasks[]` with normalised lifecycle
-  states (`queued|claimed|running|blocked|done|failed`), claimant, repo,
+  states (`queued|claimed|running|blocked|done|failed|unknown`), claimant, repo,
   timestamps and optional receipt reference. Rendered as a lifecycle board.
 - **`leitstand_checkout_inventory`** — `checkouts[]` with a retention verdict
-  (`retained|archivable|orphan`), process/lease/runtime-match flags. Surfaces
+  (`retained|archivable|orphan|unknown`), process/lease/runtime-match flags. Surfaces
   worktree **sprawl** (checkouts with no retention owner, process, or lease).
 
 Both controllers degrade visibly on a missing/corrupt snapshot ("degraded
 read-only state, not a green status") rather than hiding data loss. Preview
 fixtures are also visibly marked as degraded/demo data and do not establish
-execution truth.
+execution truth. Demo fixtures must use synthetic example paths; internal source
+artifact paths are rendered through a display label rather than exposed verbatim
+in public/degraded notices.
 
 ## Implementation status (2026-07-07)
 

--- a/docs/blueprints/operator-execution-observability.md
+++ b/docs/blueprints/operator-execution-observability.md
@@ -1,0 +1,104 @@
+---
+id: docs.blueprints.operator-execution-observability
+title: "Blueprint: Operator Execution Observability"
+doc_type: architecture
+status: active
+canonicality: supporting
+owner: leitstand
+summary: >
+  Widen the read-only Leitstand observation surface to the execution axis
+  (Bureau tasks, Grabowski checkouts) via producer-side snapshot bridges.
+---
+
+# Blueprint: Operator Execution Observability
+
+## Motivation
+
+Leitstand today visualises mostly the **knowledge axis** of the Heimgewebe
+(Insights, Observatory, Reflexion) plus fleet health. The live operator
+ecosystem — driven by **Grabowski** (local execution, leases, receipts, audit)
+and **Bureau** (tasks, claims, dispatch) — emits far more observable operational
+state than Leitstand renders. `repo.meta.yaml` even declares `bureau_state` as a
+consumed input, yet no controller consumed it. This blueprint closes that gap
+while preserving the read-only observer invariant.
+
+## Gap at a glance
+
+| Live operator state | Grabowski source | Before | After |
+|---|---|---|---|
+| Bureau tasks / claims / lifecycle | `bureau_state` export | ❌ declared, unimplemented | ✅ `/bureau` |
+| Checkout / worktree inventory (sprawl) | `checkout_inventory` | ❌ | ✅ `/checkouts` |
+| Deployment / contract drift (live) | `contract_drift`, `runtime_health` | ⚠️ static docs only | ▶ planned |
+| Audit-chain health | `verify_audit` | ❌ | ▶ planned |
+| Fleet hosts (heim-pc, heimserver, …) | `fleet_list` | ⚠️ repos only | ▶ planned |
+| Friction / recovery gate | `friction_summary`, `recovery_status` | ❌ | ▶ planned |
+
+## Architecture principle — the producer seam
+
+The observer invariant means **Leitstand must not call Grabowski or Bureau at
+request time**; doing so would couple the observer to execution. Instead every
+operator surface follows the same seam that RepoBrief already demonstrates:
+
+```
+Grabowski / Bureau  →  [producer bridge]  →  contract-shaped JSON snapshot  →  Leitstand controller  →  view
+   (execution truth)     scripts/export-        e.g. artifacts/bureau-tasks     read + validate +        read-only
+                         operator-snapshots.mjs  .json                          freshness               render
+```
+
+The bridge (`scripts/export-operator-snapshots.mjs`) is producer-side: it reads
+raw Grabowski/Bureau output and writes local snapshot artifacts. It performs no
+external mutation. If Leitstand is down, execution truth continues unaffected
+(`unavailable_effect: execution_truth_continues_without_leitstand`).
+
+Every execution-axis view carries the same guarantees as the rest of Leitstand:
+source kind, `generatedAt`, a freshness verdict, and an explicit
+`doesNotEstablish` non-claims list so the UI never implies live control.
+
+Default source paths are artifact paths:
+
+- `artifacts/bureau-tasks.json`
+- `artifacts/checkout-inventory.json`
+
+Fixture data in `src/fixtures/` is demo/preview material only. Controllers may
+use it only when `LEITSTAND_BUREAU_FIXTURE_FALLBACK=1`,
+`LEITSTAND_CHECKOUT_FIXTURE_FALLBACK=1`, or explicit non-strict preview mode
+(`LEITSTAND_STRICT=false|0`) is set. A fixture source is rendered as
+`source_kind=fixture`; it is never labelled as an artifact or a green live
+snapshot.
+
+## Contracts
+
+Two local view contracts (`schemaVersion: 1`), pinned by the bridge:
+
+- **`leitstand_bureau_task_snapshot`** — `tasks[]` with normalised lifecycle
+  states (`queued|claimed|running|blocked|done|failed`), claimant, repo,
+  timestamps and optional receipt reference. Rendered as a lifecycle board.
+- **`leitstand_checkout_inventory`** — `checkouts[]` with a retention verdict
+  (`retained|archivable|orphan`), process/lease/runtime-match flags. Surfaces
+  worktree **sprawl** (checkouts with no retention owner, process, or lease).
+
+Both controllers degrade visibly on a missing/corrupt snapshot ("degraded
+read-only state, not a green status") rather than hiding data loss. Preview
+fixtures are also visibly marked as degraded/demo data and do not establish
+execution truth.
+
+## Implementation status (2026-07-07)
+
+- [x] `src/controllers/bureau.ts` + `/bureau` view + tests.
+- [x] `src/controllers/checkouts.ts` + `/checkouts` view + tests.
+- [x] Producer bridge `scripts/export-operator-snapshots.mjs`.
+- [x] Landing page + nav integration (execution-axis info card).
+- [x] `repo.meta.yaml` / `.ai-context.yml` / [Data Flow](../data-flow.md) made honest.
+- [ ] Live drift + audit-chain health tiles (`contract_drift`, `verify_audit`).
+- [ ] Fleet-host layer in Anatomy (physical hosts as an axis).
+- [ ] Friction / recovery-gate weak signals in the Reflexion layer.
+
+## Invariants preserved
+
+- No runtime calls from Leitstand to Grabowski/Bureau; snapshots only.
+- Read-only: controllers only read and render; the observer-invariant guard
+  (`scripts/ci/observer-invariant-guard.sh`) continues to pass.
+- Missing/stale snapshots are shown, not concealed.
+
+See also the [Leitstand Visualization Blueprint](leitstand_visualization.md) for
+the phase model this extends.

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -128,7 +128,7 @@ Details: siehe [Operator Execution Observability Blueprint](blueprints/operator-
 - `insights.daily` – 1× täglich, bereit bis 08:00
 - `event.line` – kontinuierlich, Append-only
 
-Leitstand verarbeitet diese Daten asynchron; fehlende Quellen werden angezeigt, nicht verschwiegen. Fixture-Fallbacks werden als `fixture` angezeigt und gelten nicht als operative Wahrheit.
+Leitstand verarbeitet diese Daten asynchron; fehlende Quellen werden angezeigt, nicht verschwiegen. Fixture-Fallbacks werden als `fixture` angezeigt und gelten nicht als operative Wahrheit. Demo-Fixtures verwenden synthetische Beispielpfade; Source-Pfade werden in den Views als Anzeigename gerendert, nicht als rohe interne Operator-Pfade.
 
 ---
 

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -86,13 +86,49 @@ Verwendung:
 
 ---
 
+### 1.4 `leitstand_bureau_task_snapshot` (Ausführungs-Achse)
+Contract-`kind`: `leitstand_bureau_task_snapshot` (schemaVersion 1)
+
+Quelle:
+  - Primär: `artifacts/bureau-tasks.json`
+  - Bureau-Task-/Claim-Zustand, normalisiert durch die Producer-Bridge
+    `scripts/export-operator-snapshots.mjs`
+  - Dev/Preview-Fixture nur bei explizitem Fallback:
+    `LEITSTAND_BUREAU_FIXTURE_FALLBACK=1` oder `LEITSTAND_STRICT=false|0`
+
+Wichtig (Invariante):
+  - Leitstand ruft Bureau/Grabowski **nicht zur Laufzeit** auf. Der Zustand kommt
+    ausschließlich als Snapshot-Artefakt eines separaten Producers. Fällt
+    Leitstand aus, läuft die Ausführungswahrheit ungestört weiter.
+
+Verwendung:
+  - Task-Board (`/bureau`): Lifecycle-Zustände, Claims, Blocked/Failed-Zähler.
+
+### 1.5 `leitstand_checkout_inventory` (Ausführungs-Achse)
+Contract-`kind`: `leitstand_checkout_inventory` (schemaVersion 1)
+
+Quelle:
+  - Primär: `artifacts/checkout-inventory.json`
+  - Grabowski-Linked-Checkout-Inventar (`grabowski_checkout_inventory`),
+    normalisiert durch dieselbe Producer-Bridge.
+  - Dev/Preview-Fixture nur bei explizitem Fallback:
+    `LEITSTAND_CHECKOUT_FIXTURE_FALLBACK=1` oder `LEITSTAND_STRICT=false|0`
+
+Verwendung:
+  - Checkout Health (`/checkouts`): Retention-Ampel und **Sprawl**-Erkennung
+    (Worktrees ohne Retention-Owner, Prozess oder Lease).
+
+Details: siehe [Operator Execution Observability Blueprint](blueprints/operator-execution-observability.md).
+
+---
+
 ## 2. Aktualisierungsfrequenzen
 
 - `fleet.health` – bei jedem wgx-guard/smoke Lauf, min. täglich
 - `insights.daily` – 1× täglich, bereit bis 08:00
 - `event.line` – kontinuierlich, Append-only
 
-Leitstand verarbeitet diese Daten asynchron; fehlende Quellen werden angezeigt, nicht verschwiegen.
+Leitstand verarbeitet diese Daten asynchron; fehlende Quellen werden angezeigt, nicht verschwiegen. Fixture-Fallbacks werden als `fixture` angezeigt und gelten nicht als operative Wahrheit.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,6 +47,7 @@ Tools that enforce the rules automatically.
 - [Leitstand Manifest Blueprint](blueprints/leitstand_manifest.md)
 - [Leitstand Visualization Blueprint](blueprints/leitstand_visualization.md)
 - [Ecosystem Map View Blueprint](blueprints/ecosystem-map-view.md)
+- [Operator Execution Observability Blueprint](blueprints/operator-execution-observability.md)
 
 ## 5. Reports
 

--- a/repo.meta.yaml
+++ b/repo.meta.yaml
@@ -16,9 +16,14 @@ role_contract:
     - chronik_events
     - bureau_state
     - plexer_delivery_reports
+    - grabowski_checkout_inventory
   produces:
     - rendered_views
     - daily_digests
+  # Execution-axis inputs (bureau_state, grabowski_checkout_inventory) arrive as
+  # contract-shaped snapshot artifacts produced by a separate producer bridge
+  # (scripts/export-operator-snapshots.mjs); Leitstand never calls Bureau or
+  # Grabowski at request time. See docs/blueprints/operator-execution-observability.md.
   limits:
     - no_task_ownership
     - no_worker_execution

--- a/scripts/export-operator-snapshots.mjs
+++ b/scripts/export-operator-snapshots.mjs
@@ -53,12 +53,31 @@ const CHECKOUT_NON_CLAIMS = [
   'checkout_ownership', 'cleanup_authority', 'branch_deletion', 'retention_decision', 'process_control',
 ];
 
+function normalizeBureauState(value) {
+  const v = typeof value === 'string' ? value.toLowerCase() : '';
+  if (v === 'queued' || v === 'pending' || v === 'open') return 'queued';
+  if (v === 'claimed' || v === 'assigned') return 'claimed';
+  if (v === 'running' || v === 'in_progress' || v === 'active') return 'running';
+  if (v === 'blocked' || v === 'waiting' || v === 'stalled') return 'blocked';
+  if (v === 'done' || v === 'completed' || v === 'complete') return 'done';
+  if (v === 'failed' || v === 'error' || v === 'cancelled' || v === 'canceled') return 'failed';
+  return 'unknown';
+}
+
+function normalizeCheckoutRetention(value) {
+  const v = typeof value === 'string' ? value.toLowerCase() : '';
+  if (v === 'retained' || v === 'kept' || v === 'owned') return 'retained';
+  if (v === 'archivable' || v === 'archived' || v === 'stale') return 'archivable';
+  if (v === 'orphan' || v === 'orphaned' || v === 'untracked') return 'orphan';
+  return 'unknown';
+}
+
 /** Map a raw Bureau task record → contract task. Unknown fields are dropped. */
 function mapBureauTask(raw) {
   return {
     id: String(raw.id ?? raw.task_id ?? ''),
     title: raw.title ?? raw.name ?? raw.summary ?? String(raw.id ?? ''),
-    state: raw.state ?? raw.status ?? 'unknown',
+    state: normalizeBureauState(raw.state ?? raw.status),
     claimant: raw.claimant ?? raw.owner ?? raw.assignee ?? null,
     repo: raw.repo ?? raw.repository ?? null,
     createdAt: raw.createdAt ?? raw.created_at ?? null,
@@ -87,8 +106,8 @@ function mapCheckout(raw, runtimeHead) {
 
   let retention;
   if (retentionRecord) retention = 'retained';
-  else if (typeof raw.retention === 'string') retention = raw.retention;
   else if (raw.cleanup_candidate) retention = 'archivable';
+  else if (typeof raw.retention === 'string') retention = normalizeCheckoutRetention(raw.retention);
   else if (!hasProcess && !hasLease && !hasTask) retention = 'orphan';
   else retention = 'unknown';
 

--- a/scripts/export-operator-snapshots.mjs
+++ b/scripts/export-operator-snapshots.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+// @ts-nocheck
+/**
+ * export-operator-snapshots — PRODUCER-SIDE BRIDGE (not part of the observer).
+ *
+ * Leitstand is a read-only observer and must never call Grabowski/Bureau at
+ * request time. This script is the deliberate seam that keeps that invariant:
+ * the operator runs it (or a cron does) to transform *raw* Grabowski/Bureau
+ * output into the contract-shaped snapshot artifacts Leitstand's controllers
+ * read (`leitstand_bureau_task_snapshot`, `leitstand_checkout_inventory`).
+ *
+ * It only reads raw JSON and writes local snapshot files — no external mutation.
+ *
+ * Usage:
+ *   node scripts/export-operator-snapshots.mjs \
+ *     --checkout-raw <grabowski_checkout_inventory.json> \
+ *     --bureau-raw   <bureau_task_list.json> \
+ *     --out-dir      artifacts
+ *
+ * Any input may be omitted; only the provided snapshots are (re)written. The
+ * raw inputs are whatever `grabowski_checkout_inventory` / the Bureau task
+ * listing emit — this bridge is where their vocab is pinned to our contract.
+ */
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { join, resolve, dirname } from 'node:path';
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const key = argv[i];
+    if (key.startsWith('--')) args[key.slice(2)] = argv[i + 1];
+  }
+  return args;
+}
+
+async function readJson(path) {
+  return JSON.parse(await readFile(path, 'utf-8'));
+}
+
+/** Atomic write (tmp → rename), consistent with Leitstand's artifact convention. */
+async function writeJsonAtomic(path, data) {
+  await mkdir(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp`;
+  await writeFile(tmp, `${JSON.stringify(data, null, 2)}\n`, 'utf-8');
+  const { rename } = await import('node:fs/promises');
+  await rename(tmp, path);
+}
+
+const BUREAU_NON_CLAIMS = [
+  'task_ownership', 'claim_authority', 'execution_truth', 'dispatch_control', 'completion_guarantee',
+];
+const CHECKOUT_NON_CLAIMS = [
+  'checkout_ownership', 'cleanup_authority', 'branch_deletion', 'retention_decision', 'process_control',
+];
+
+/** Map a raw Bureau task record → contract task. Unknown fields are dropped. */
+function mapBureauTask(raw) {
+  return {
+    id: String(raw.id ?? raw.task_id ?? ''),
+    title: raw.title ?? raw.name ?? raw.summary ?? String(raw.id ?? ''),
+    state: raw.state ?? raw.status ?? 'unknown',
+    claimant: raw.claimant ?? raw.owner ?? raw.assignee ?? null,
+    repo: raw.repo ?? raw.repository ?? null,
+    createdAt: raw.createdAt ?? raw.created_at ?? null,
+    updatedAt: raw.updatedAt ?? raw.updated_at ?? null,
+    receiptRef: raw.receiptRef ?? raw.receipt_ref ?? raw.receipt ?? null,
+    note: raw.note ?? raw.detail ?? '',
+  };
+}
+
+/**
+ * Map a raw `grabowski_checkout_inventory` worktree record → contract checkout.
+ *
+ * Derives a retention verdict from the real coordination/lifecycle shape:
+ *   - `lifecycle.retention` object present        → retained (owner-anchored)
+ *   - `cleanup_candidate` true                    → archivable
+ *   - no retention, no process/lease/task anchor  → orphan (prime sprawl)
+ *   - otherwise (anchored by coordination only)   → unknown
+ * `runtimeHead` (optional) lets the bridge flag the runtime-matching checkout.
+ */
+function mapCheckout(raw, runtimeHead) {
+  const coord = raw.coordination ?? {};
+  const hasProcess = Array.isArray(coord.processes) ? coord.processes.length > 0 : Boolean(raw.hasProcess);
+  const hasLease = Array.isArray(coord.resource_leases) ? coord.resource_leases.length > 0 : Boolean(raw.hasResourceLease);
+  const hasTask = Array.isArray(coord.tasks) ? coord.tasks.length > 0 : false;
+  const retentionRecord = raw.lifecycle?.retention ?? (typeof raw.retention === 'object' ? raw.retention : null);
+
+  let retention;
+  if (retentionRecord) retention = 'retained';
+  else if (typeof raw.retention === 'string') retention = raw.retention;
+  else if (raw.cleanup_candidate) retention = 'archivable';
+  else if (!hasProcess && !hasLease && !hasTask) retention = 'orphan';
+  else retention = 'unknown';
+
+  const head = (raw.head ?? '').slice(0, 12) || null;
+  const dirtyNote = raw.status?.dirty ? `dirty (${raw.status.entry_count ?? '?'} entries)` : '';
+  const note = raw.note ?? retentionRecord?.purpose ?? dirtyNote;
+
+  return {
+    path: raw.path,
+    repo: raw.repo ?? raw.repository ?? null,
+    branch: raw.branch ?? null,
+    head,
+    retention,
+    hasProcess,
+    hasResourceLease: hasLease,
+    matchesRuntime: Boolean(raw.matchesRuntime ?? raw.matches_runtime)
+      || (runtimeHead != null && raw.head === runtimeHead),
+    note,
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const outDir = resolve(args['out-dir'] ?? 'artifacts');
+  const generatedAt = new Date().toISOString();
+  let wrote = 0;
+
+  if (args['bureau-raw']) {
+    const raw = await readJson(resolve(args['bureau-raw']));
+    const tasks = (raw.tasks ?? raw.records ?? raw ?? []).map(mapBureauTask).filter((t) => t.id);
+    const snapshot = {
+      schemaVersion: 1,
+      kind: 'leitstand_bureau_task_snapshot',
+      generatedAt,
+      source: 'bureau_state_export',
+      doesNotEstablish: BUREAU_NON_CLAIMS,
+      tasks,
+    };
+    const out = join(outDir, 'bureau-tasks.json');
+    await writeJsonAtomic(out, snapshot);
+    console.log(`bureau snapshot: ${tasks.length} tasks → ${out}`);
+    wrote += 1;
+  }
+
+  if (args['checkout-raw']) {
+    const raw = await readJson(resolve(args['checkout-raw']));
+    const source = raw.checkout?.worktrees ?? raw.worktrees ?? raw.checkouts ?? raw ?? [];
+    const runtimeHead = args['runtime-head'] ?? null;
+    const checkouts = source.filter((c) => c && c.path).map((c) => mapCheckout(c, runtimeHead));
+    const snapshot = {
+      schemaVersion: 1,
+      kind: 'leitstand_checkout_inventory',
+      generatedAt,
+      source: 'grabowski_checkout_inventory',
+      doesNotEstablish: CHECKOUT_NON_CLAIMS,
+      checkouts,
+    };
+    const out = join(outDir, 'checkout-inventory.json');
+    await writeJsonAtomic(out, snapshot);
+    console.log(`checkout snapshot: ${checkouts.length} checkouts → ${out}`);
+    wrote += 1;
+  }
+
+  if (wrote === 0) {
+    console.error('No inputs given. Provide --bureau-raw and/or --checkout-raw. See header for usage.');
+    process.exit(2);
+  }
+}
+
+main().catch((err) => {
+  console.error('export-operator-snapshots failed:', err);
+  process.exit(1);
+});

--- a/src/controllers/bureau.ts
+++ b/src/controllers/bureau.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises';
-import { join, resolve } from 'node:path';
+import { join, relative, resolve } from 'node:path';
 
 /**
  * Bureau task-board controller — Phase "Ausführungs-Achse".
@@ -44,6 +44,7 @@ export interface BureauViewData {
   view_meta: {
     source_kind: BureauSourceKind;
     source_path: string;
+    source_path_display: string;
     missing_reason: string;
     generated_at: string | null;
     freshness_state: BureauFreshness;
@@ -197,6 +198,13 @@ function buildColumns(tasks: BureauTaskView[]): BureauViewData['columns'] {
   }));
 }
 
+
+function displaySourcePath(sourcePath: string): string {
+  const rel = relative(resolve(process.cwd()), resolve(sourcePath));
+  if (rel && !rel.startsWith('..') && !rel.startsWith('/')) return rel;
+  return '<external snapshot>';
+}
+
 function emptyData(kind: BureauSourceKind, reason: string, sourcePath: string): BureauViewData {
   return {
     tasks: [],
@@ -204,6 +212,7 @@ function emptyData(kind: BureauSourceKind, reason: string, sourcePath: string): 
     view_meta: {
       source_kind: kind,
       source_path: sourcePath,
+      source_path_display: displaySourcePath(sourcePath),
       missing_reason: reason,
       generated_at: null,
       freshness_state: 'unknown',
@@ -228,6 +237,7 @@ function dataFromParsed(
     view_meta: {
       source_kind: sourceKind,
       source_path: sourcePath,
+      source_path_display: displaySourcePath(sourcePath),
       missing_reason: missingReason,
       generated_at: parsed.generatedAt,
       freshness_state: freshnessOf(parsed.generatedAt),

--- a/src/controllers/bureau.ts
+++ b/src/controllers/bureau.ts
@@ -1,0 +1,271 @@
+import { readFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+
+/**
+ * Bureau task-board controller — Phase "Ausführungs-Achse".
+ *
+ * Read-only projection of Bureau task/claim state. Leitstand does NOT talk to
+ * Bureau or Grabowski directly (that would couple the observer to execution);
+ * it reads a contract-shaped snapshot artifact produced by a separate bridge
+ * (see scripts/export-operator-snapshots.mjs) and renders it. Mirrors the
+ * RepoBrief controller pattern: env-overridable path, contract-kind check,
+ * source/freshness metadata and a `doesNotEstablish` non-claims list.
+ */
+
+export type BureauSourceKind = 'artifact' | 'fixture' | 'missing' | 'corrupt';
+export type BureauFreshness = 'fresh' | 'stale' | 'unknown';
+
+/** Canonical Bureau lifecycle states, normalised from producer vocab. */
+export type BureauTaskState =
+  | 'queued'
+  | 'claimed'
+  | 'running'
+  | 'blocked'
+  | 'done'
+  | 'failed'
+  | 'unknown';
+
+export interface BureauTaskView {
+  id: string;
+  title: string;
+  state: BureauTaskState;
+  claimant: string | null;
+  repo: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+  receipt_ref: string | null;
+  note: string;
+}
+
+export interface BureauViewData {
+  tasks: BureauTaskView[];
+  /** Ordered lifecycle columns for the board, each with its tasks. */
+  columns: Array<{ state: BureauTaskState; label: string; tasks: BureauTaskView[] }>;
+  view_meta: {
+    source_kind: BureauSourceKind;
+    source_path: string;
+    missing_reason: string;
+    generated_at: string | null;
+    freshness_state: BureauFreshness;
+    task_count: number;
+    open_count: number;
+    blocked_count: number;
+    failed_count: number;
+    does_not_establish: string[];
+  };
+}
+
+const CONTRACT_KIND = 'leitstand_bureau_task_snapshot';
+/** Bureau tasks are operational; a snapshot older than this reads as stale. */
+const STALE_AFTER_MS = 6 * 60 * 60 * 1000; // 6h
+
+const DEFAULT_NON_CLAIMS = [
+  'task_ownership',
+  'claim_authority',
+  'execution_truth',
+  'dispatch_control',
+  'completion_guarantee',
+];
+
+const COLUMN_ORDER: Array<{ state: BureauTaskState; label: string }> = [
+  { state: 'queued', label: 'Queued' },
+  { state: 'claimed', label: 'Claimed' },
+  { state: 'running', label: 'Running' },
+  { state: 'blocked', label: 'Blocked' },
+  { state: 'done', label: 'Done' },
+  { state: 'failed', label: 'Failed' },
+];
+
+/** States that still demand operator attention (used for the open counter). */
+const OPEN_STATES: ReadonlySet<BureauTaskState> = new Set<BureauTaskState>([
+  'queued',
+  'claimed',
+  'running',
+  'blocked',
+]);
+
+function artifactSnapshotPath(): string {
+  return process.env.LEITSTAND_BUREAU_SNAPSHOT_PATH
+    || join(process.cwd(), 'artifacts', 'bureau-tasks.json');
+}
+
+function fixtureSnapshotPath(): string {
+  return join(process.cwd(), 'src', 'fixtures', 'bureau-tasks.json');
+}
+
+function fixtureFallbackEnabled(): boolean {
+  const explicit = process.env.LEITSTAND_BUREAU_FIXTURE_FALLBACK;
+  if (explicit !== undefined) {
+    return explicit === '1' || explicit.toLowerCase() === 'true';
+  }
+  return process.env.LEITSTAND_STRICT === '0' || process.env.LEITSTAND_STRICT === 'false';
+}
+
+function normalizeState(value: unknown): BureauTaskState {
+  const v = typeof value === 'string' ? value.toLowerCase() : '';
+  if (v === 'queued' || v === 'pending' || v === 'open') return 'queued';
+  if (v === 'claimed' || v === 'assigned') return 'claimed';
+  if (v === 'running' || v === 'in_progress' || v === 'active') return 'running';
+  if (v === 'blocked' || v === 'waiting' || v === 'stalled') return 'blocked';
+  if (v === 'done' || v === 'completed' || v === 'complete') return 'done';
+  if (v === 'failed' || v === 'error' || v === 'cancelled' || v === 'canceled') return 'failed';
+  return 'unknown';
+}
+
+function classifyError(error: unknown): { kind: BureauSourceKind; reason: string } {
+  const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+  if (message.includes('enoent') || message.includes('no such file')) {
+    return { kind: 'missing', reason: 'bureau_snapshot_missing' };
+  }
+  if (message.includes('json') || message.includes('invalid') || message.includes('unexpected')) {
+    return { kind: 'corrupt', reason: 'bureau_snapshot_corrupt' };
+  }
+  return { kind: 'corrupt', reason: 'bureau_snapshot_load_failed' };
+}
+
+function freshnessOf(generatedAt: string | null): BureauFreshness {
+  if (!generatedAt) return 'unknown';
+  const ts = Date.parse(generatedAt);
+  if (Number.isNaN(ts)) return 'unknown';
+  return Date.now() - ts <= STALE_AFTER_MS ? 'fresh' : 'stale';
+}
+
+function nullableString(raw: unknown): string | null {
+  return typeof raw === 'string' && raw.length > 0 ? raw : null;
+}
+
+function parseTask(raw: unknown): BureauTaskView {
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('invalid Bureau task: must be object');
+  }
+  const task = raw as Record<string, unknown>;
+  const id = typeof task.id === 'string' ? task.id : '';
+  if (!id) {
+    throw new Error('invalid Bureau task: missing id');
+  }
+  return {
+    id,
+    title: typeof task.title === 'string' ? task.title : id,
+    state: normalizeState(task.state),
+    claimant: nullableString(task.claimant),
+    repo: nullableString(task.repo),
+    created_at: nullableString(task.createdAt),
+    updated_at: nullableString(task.updatedAt),
+    receipt_ref: nullableString(task.receiptRef),
+    note: typeof task.note === 'string' ? task.note : '',
+  };
+}
+
+function parseStringArray(raw: unknown): string[] {
+  return Array.isArray(raw) ? raw.filter((item): item is string => typeof item === 'string') : [];
+}
+
+function parseSnapshot(raw: unknown): {
+  tasks: BureauTaskView[];
+  generatedAt: string | null;
+  doesNotEstablish: string[];
+} {
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('invalid Bureau snapshot: root must be object');
+  }
+  const snapshot = raw as {
+    schemaVersion?: unknown;
+    kind?: unknown;
+    generatedAt?: unknown;
+    tasks?: unknown;
+    doesNotEstablish?: unknown;
+  };
+  if (snapshot.schemaVersion !== 1 || snapshot.kind !== CONTRACT_KIND) {
+    throw new Error('invalid Bureau snapshot: kind or schemaVersion mismatch');
+  }
+  if (!Array.isArray(snapshot.tasks)) {
+    throw new Error('invalid Bureau snapshot: tasks must be a list');
+  }
+  const nonClaims = parseStringArray(snapshot.doesNotEstablish);
+  return {
+    tasks: snapshot.tasks.map(parseTask),
+    generatedAt: typeof snapshot.generatedAt === 'string' ? snapshot.generatedAt : null,
+    doesNotEstablish: nonClaims.length > 0 ? nonClaims : DEFAULT_NON_CLAIMS,
+  };
+}
+
+function buildColumns(tasks: BureauTaskView[]): BureauViewData['columns'] {
+  return COLUMN_ORDER.map(({ state, label }) => ({
+    state,
+    label,
+    tasks: tasks.filter((task) => task.state === state),
+  }));
+}
+
+function emptyData(kind: BureauSourceKind, reason: string, sourcePath: string): BureauViewData {
+  return {
+    tasks: [],
+    columns: buildColumns([]),
+    view_meta: {
+      source_kind: kind,
+      source_path: sourcePath,
+      missing_reason: reason,
+      generated_at: null,
+      freshness_state: 'unknown',
+      task_count: 0,
+      open_count: 0,
+      blocked_count: 0,
+      failed_count: 0,
+      does_not_establish: DEFAULT_NON_CLAIMS,
+    },
+  };
+}
+
+function dataFromParsed(
+  parsed: ReturnType<typeof parseSnapshot>,
+  sourceKind: BureauSourceKind,
+  sourcePath: string,
+  missingReason: string,
+): BureauViewData {
+  return {
+    tasks: parsed.tasks,
+    columns: buildColumns(parsed.tasks),
+    view_meta: {
+      source_kind: sourceKind,
+      source_path: sourcePath,
+      missing_reason: missingReason,
+      generated_at: parsed.generatedAt,
+      freshness_state: freshnessOf(parsed.generatedAt),
+      task_count: parsed.tasks.length,
+      open_count: parsed.tasks.filter((task) => OPEN_STATES.has(task.state)).length,
+      blocked_count: parsed.tasks.filter((task) => task.state === 'blocked').length,
+      failed_count: parsed.tasks.filter((task) => task.state === 'failed').length,
+      does_not_establish: parsed.doesNotEstablish,
+    },
+  };
+}
+
+async function loadSnapshot(path: string): Promise<ReturnType<typeof parseSnapshot>> {
+  return parseSnapshot(JSON.parse(await readFile(path, 'utf-8')) as unknown);
+}
+
+export async function getBureauData(): Promise<BureauViewData> {
+  const sourcePath = resolve(artifactSnapshotPath());
+  try {
+    return dataFromParsed(await loadSnapshot(sourcePath), 'artifact', sourcePath, 'ok');
+  } catch (error) {
+    const classified = classifyError(error);
+    const envOverride = process.env.LEITSTAND_BUREAU_SNAPSHOT_PATH !== undefined;
+    if (envOverride || classified.kind !== 'missing' || !fixtureFallbackEnabled()) {
+      return emptyData(classified.kind, classified.reason, sourcePath);
+    }
+
+    const fallbackPath = resolve(fixtureSnapshotPath());
+    try {
+      return dataFromParsed(
+        await loadSnapshot(fallbackPath),
+        'fixture',
+        fallbackPath,
+        'bureau_snapshot_missing_fixture_fallback',
+      );
+    } catch (fallbackError) {
+      const fallbackClassified = classifyError(fallbackError);
+      return emptyData(fallbackClassified.kind, fallbackClassified.reason, fallbackPath);
+    }
+  }
+}

--- a/src/controllers/checkouts.ts
+++ b/src/controllers/checkouts.ts
@@ -1,0 +1,247 @@
+import { readFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+
+/**
+ * Checkout / worktree health controller — Phase "Ausführungs-Achse".
+ *
+ * Read-only projection of Grabowski's linked-checkout inventory. Worktree
+ * sprawl (many long-lived, unretained checkouts) is an operational health
+ * signal the observer should surface, not act on. Leitstand reads a
+ * contract-shaped snapshot artifact produced by a separate bridge; it never
+ * calls Grabowski to enumerate or mutate checkouts itself.
+ */
+
+export type CheckoutSourceKind = 'artifact' | 'fixture' | 'missing' | 'corrupt';
+export type CheckoutFreshness = 'fresh' | 'stale' | 'unknown';
+
+/** Retention verdict, normalised from producer vocab. Ordered worst→best for triage. */
+export type CheckoutRetention = 'orphan' | 'archivable' | 'retained' | 'unknown';
+
+export interface CheckoutView {
+  path: string;
+  repo: string | null;
+  branch: string | null;
+  head: string | null;
+  retention: CheckoutRetention;
+  has_process: boolean;
+  has_resource_lease: boolean;
+  matches_runtime: boolean;
+  note: string;
+}
+
+export interface CheckoutViewData {
+  checkouts: CheckoutView[];
+  view_meta: {
+    source_kind: CheckoutSourceKind;
+    source_path: string;
+    missing_reason: string;
+    generated_at: string | null;
+    freshness_state: CheckoutFreshness;
+    checkout_count: number;
+    orphan_count: number;
+    archivable_count: number;
+    retained_count: number;
+    /** Checkouts with no retention owner AND no process/lease → prime sprawl candidates. */
+    sprawl_count: number;
+    does_not_establish: string[];
+  };
+}
+
+const CONTRACT_KIND = 'leitstand_checkout_inventory';
+/** Checkout inventory changes slowly; a day-old snapshot is still useful but flagged. */
+const STALE_AFTER_MS = 24 * 60 * 60 * 1000; // 24h
+
+const DEFAULT_NON_CLAIMS = [
+  'checkout_ownership',
+  'cleanup_authority',
+  'branch_deletion',
+  'retention_decision',
+  'process_control',
+];
+
+function artifactSnapshotPath(): string {
+  return process.env.LEITSTAND_CHECKOUT_SNAPSHOT_PATH
+    || join(process.cwd(), 'artifacts', 'checkout-inventory.json');
+}
+
+function fixtureSnapshotPath(): string {
+  return join(process.cwd(), 'src', 'fixtures', 'checkout-inventory.json');
+}
+
+function fixtureFallbackEnabled(): boolean {
+  const explicit = process.env.LEITSTAND_CHECKOUT_FIXTURE_FALLBACK;
+  if (explicit !== undefined) {
+    return explicit === '1' || explicit.toLowerCase() === 'true';
+  }
+  return process.env.LEITSTAND_STRICT === '0' || process.env.LEITSTAND_STRICT === 'false';
+}
+
+function normalizeRetention(value: unknown): CheckoutRetention {
+  const v = typeof value === 'string' ? value.toLowerCase() : '';
+  if (v === 'retained' || v === 'kept' || v === 'owned') return 'retained';
+  if (v === 'archivable' || v === 'archived' || v === 'stale') return 'archivable';
+  if (v === 'orphan' || v === 'orphaned' || v === 'untracked') return 'orphan';
+  return 'unknown';
+}
+
+function classifyError(error: unknown): { kind: CheckoutSourceKind; reason: string } {
+  const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+  if (message.includes('enoent') || message.includes('no such file')) {
+    return { kind: 'missing', reason: 'checkout_inventory_missing' };
+  }
+  if (message.includes('json') || message.includes('invalid') || message.includes('unexpected')) {
+    return { kind: 'corrupt', reason: 'checkout_inventory_corrupt' };
+  }
+  return { kind: 'corrupt', reason: 'checkout_inventory_load_failed' };
+}
+
+function freshnessOf(generatedAt: string | null): CheckoutFreshness {
+  if (!generatedAt) return 'unknown';
+  const ts = Date.parse(generatedAt);
+  if (Number.isNaN(ts)) return 'unknown';
+  return Date.now() - ts <= STALE_AFTER_MS ? 'fresh' : 'stale';
+}
+
+function nullableString(raw: unknown): string | null {
+  return typeof raw === 'string' && raw.length > 0 ? raw : null;
+}
+
+function parseStringArray(raw: unknown): string[] {
+  return Array.isArray(raw) ? raw.filter((item): item is string => typeof item === 'string') : [];
+}
+
+function parseCheckout(raw: unknown): CheckoutView {
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('invalid checkout entry: must be object');
+  }
+  const entry = raw as Record<string, unknown>;
+  const path = typeof entry.path === 'string' ? entry.path : '';
+  if (!path) {
+    throw new Error('invalid checkout entry: missing path');
+  }
+  return {
+    path,
+    repo: nullableString(entry.repo),
+    branch: nullableString(entry.branch),
+    head: nullableString(entry.head),
+    retention: normalizeRetention(entry.retention),
+    has_process: entry.hasProcess === true,
+    has_resource_lease: entry.hasResourceLease === true,
+    matches_runtime: entry.matchesRuntime === true,
+    note: typeof entry.note === 'string' ? entry.note : '',
+  };
+}
+
+function parseSnapshot(raw: unknown): {
+  checkouts: CheckoutView[];
+  generatedAt: string | null;
+  doesNotEstablish: string[];
+} {
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('invalid checkout inventory: root must be object');
+  }
+  const snapshot = raw as {
+    schemaVersion?: unknown;
+    kind?: unknown;
+    generatedAt?: unknown;
+    checkouts?: unknown;
+    doesNotEstablish?: unknown;
+  };
+  if (snapshot.schemaVersion !== 1 || snapshot.kind !== CONTRACT_KIND) {
+    throw new Error('invalid checkout inventory: kind or schemaVersion mismatch');
+  }
+  if (!Array.isArray(snapshot.checkouts)) {
+    throw new Error('invalid checkout inventory: checkouts must be a list');
+  }
+  const nonClaims = parseStringArray(snapshot.doesNotEstablish);
+  return {
+    checkouts: snapshot.checkouts.map(parseCheckout),
+    generatedAt: typeof snapshot.generatedAt === 'string' ? snapshot.generatedAt : null,
+    doesNotEstablish: nonClaims.length > 0 ? nonClaims : DEFAULT_NON_CLAIMS,
+  };
+}
+
+/** A checkout is "sprawl" when nothing anchors it: no retention, no process, no lease. */
+function isSprawl(checkout: CheckoutView): boolean {
+  return (
+    (checkout.retention === 'orphan' || checkout.retention === 'archivable') &&
+    !checkout.has_process &&
+    !checkout.has_resource_lease
+  );
+}
+
+function emptyData(kind: CheckoutSourceKind, reason: string, sourcePath: string): CheckoutViewData {
+  return {
+    checkouts: [],
+    view_meta: {
+      source_kind: kind,
+      source_path: sourcePath,
+      missing_reason: reason,
+      generated_at: null,
+      freshness_state: 'unknown',
+      checkout_count: 0,
+      orphan_count: 0,
+      archivable_count: 0,
+      retained_count: 0,
+      sprawl_count: 0,
+      does_not_establish: DEFAULT_NON_CLAIMS,
+    },
+  };
+}
+
+function dataFromParsed(
+  parsed: ReturnType<typeof parseSnapshot>,
+  sourceKind: CheckoutSourceKind,
+  sourcePath: string,
+  missingReason: string,
+): CheckoutViewData {
+  // Sort worst retention first so triage-relevant checkouts surface at the top.
+  const order: Record<CheckoutRetention, number> = { orphan: 0, archivable: 1, unknown: 2, retained: 3 };
+  const checkouts = [...parsed.checkouts].sort((a, b) => order[a.retention] - order[b.retention]);
+  return {
+    checkouts,
+    view_meta: {
+      source_kind: sourceKind,
+      source_path: sourcePath,
+      missing_reason: missingReason,
+      generated_at: parsed.generatedAt,
+      freshness_state: freshnessOf(parsed.generatedAt),
+      checkout_count: checkouts.length,
+      orphan_count: checkouts.filter((c) => c.retention === 'orphan').length,
+      archivable_count: checkouts.filter((c) => c.retention === 'archivable').length,
+      retained_count: checkouts.filter((c) => c.retention === 'retained').length,
+      sprawl_count: checkouts.filter(isSprawl).length,
+      does_not_establish: parsed.doesNotEstablish,
+    },
+  };
+}
+
+async function loadSnapshot(path: string): Promise<ReturnType<typeof parseSnapshot>> {
+  return parseSnapshot(JSON.parse(await readFile(path, 'utf-8')) as unknown);
+}
+
+export async function getCheckoutData(): Promise<CheckoutViewData> {
+  const sourcePath = resolve(artifactSnapshotPath());
+  try {
+    return dataFromParsed(await loadSnapshot(sourcePath), 'artifact', sourcePath, 'ok');
+  } catch (error) {
+    const classified = classifyError(error);
+    const envOverride = process.env.LEITSTAND_CHECKOUT_SNAPSHOT_PATH !== undefined;
+    if (envOverride || classified.kind !== 'missing' || !fixtureFallbackEnabled()) {
+      return emptyData(classified.kind, classified.reason, sourcePath);
+    }
+
+    const fallbackPath = resolve(fixtureSnapshotPath());
+    try {
+      return dataFromParsed(
+        await loadSnapshot(fallbackPath),
+        'fixture',
+        fallbackPath,
+        'checkout_inventory_missing_fixture_fallback',
+      );
+    } catch (fallbackError) {
+      const fallbackClassified = classifyError(fallbackError);
+      return emptyData(fallbackClassified.kind, fallbackClassified.reason, fallbackPath);
+    }
+  }
+}

--- a/src/controllers/checkouts.ts
+++ b/src/controllers/checkouts.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises';
-import { join, resolve } from 'node:path';
+import { join, relative, resolve } from 'node:path';
 
 /**
  * Checkout / worktree health controller — Phase "Ausführungs-Achse".
@@ -34,6 +34,7 @@ export interface CheckoutViewData {
   view_meta: {
     source_kind: CheckoutSourceKind;
     source_path: string;
+    source_path_display: string;
     missing_reason: string;
     generated_at: string | null;
     freshness_state: CheckoutFreshness;
@@ -170,12 +171,20 @@ function isSprawl(checkout: CheckoutView): boolean {
   );
 }
 
+
+function displaySourcePath(sourcePath: string): string {
+  const rel = relative(resolve(process.cwd()), resolve(sourcePath));
+  if (rel && !rel.startsWith('..') && !rel.startsWith('/')) return rel;
+  return '<external snapshot>';
+}
+
 function emptyData(kind: CheckoutSourceKind, reason: string, sourcePath: string): CheckoutViewData {
   return {
     checkouts: [],
     view_meta: {
       source_kind: kind,
       source_path: sourcePath,
+      source_path_display: displaySourcePath(sourcePath),
       missing_reason: reason,
       generated_at: null,
       freshness_state: 'unknown',
@@ -203,6 +212,7 @@ function dataFromParsed(
     view_meta: {
       source_kind: sourceKind,
       source_path: sourcePath,
+      source_path_display: displaySourcePath(sourcePath),
       missing_reason: missingReason,
       generated_at: parsed.generatedAt,
       freshness_state: freshnessOf(parsed.generatedAt),

--- a/src/fixtures/bureau-tasks.json
+++ b/src/fixtures/bureau-tasks.json
@@ -1,0 +1,81 @@
+{
+  "schemaVersion": 1,
+  "kind": "leitstand_bureau_task_snapshot",
+  "generatedAt": "2026-07-07T06:30:00Z",
+  "source": "bureau_state_export",
+  "doesNotEstablish": [
+    "task_ownership",
+    "claim_authority",
+    "execution_truth",
+    "dispatch_control",
+    "completion_guarantee"
+  ],
+  "tasks": [
+    {
+      "id": "BUR-RUN-20260707T0612-a1",
+      "title": "grip pr-readiness gate v2",
+      "state": "running",
+      "claimant": "grabowski",
+      "repo": "grabowski",
+      "createdAt": "2026-07-07T06:12:00Z",
+      "updatedAt": "2026-07-07T06:28:00Z",
+      "receiptRef": null,
+      "note": "linked checkout pr81-readiness-fix"
+    },
+    {
+      "id": "BUR-RUN-20260707T0540-b2",
+      "title": "rlens bundle discovery verify",
+      "state": "claimed",
+      "claimant": "grabowski",
+      "repo": "grabowski",
+      "createdAt": "2026-07-07T05:40:00Z",
+      "updatedAt": "2026-07-07T05:41:00Z",
+      "receiptRef": null,
+      "note": "worktree rlens-slice-verify-grabowski"
+    },
+    {
+      "id": "BUR-Q-20260707T0602-c3",
+      "title": "leitstand operator execution observability",
+      "state": "queued",
+      "claimant": null,
+      "repo": "leitstand",
+      "createdAt": "2026-07-07T06:02:00Z",
+      "updatedAt": "2026-07-07T06:02:00Z",
+      "receiptRef": null,
+      "note": "widen observer surface to execution axis"
+    },
+    {
+      "id": "BUR-BLK-20260706T1815-d4",
+      "title": "gui-worker terminal classification",
+      "state": "blocked",
+      "claimant": "grabowski",
+      "repo": "grabowski",
+      "createdAt": "2026-07-06T18:15:43Z",
+      "updatedAt": "2026-07-06T19:02:00Z",
+      "receiptRef": null,
+      "note": "awaiting recovery-gate evidence"
+    },
+    {
+      "id": "BUR-DONE-20260702T1425-e5",
+      "title": "pr50 main receipt",
+      "state": "done",
+      "claimant": "grabowski",
+      "repo": "grabowski",
+      "createdAt": "2026-07-02T14:20:00Z",
+      "updatedAt": "2026-07-02T14:25:00Z",
+      "receiptRef": "receipt:pr50-main-20260702-1425",
+      "note": "receipt archived"
+    },
+    {
+      "id": "BUR-FAIL-20260705T2210-f6",
+      "title": "heimlern metrics cron",
+      "state": "failed",
+      "claimant": "heimlern",
+      "repo": "heimlern",
+      "createdAt": "2026-07-05T22:10:00Z",
+      "updatedAt": "2026-07-05T22:31:00Z",
+      "receiptRef": null,
+      "note": "silent cron failure; no metrics for 3 days"
+    }
+  ]
+}

--- a/src/fixtures/checkout-inventory.json
+++ b/src/fixtures/checkout-inventory.json
@@ -1,0 +1,92 @@
+{
+  "schemaVersion": 1,
+  "kind": "leitstand_checkout_inventory",
+  "generatedAt": "2026-07-07T06:30:00Z",
+  "source": "grabowski_checkout_inventory",
+  "doesNotEstablish": [
+    "checkout_ownership",
+    "cleanup_authority",
+    "branch_deletion",
+    "retention_decision",
+    "process_control"
+  ],
+  "checkouts": [
+    {
+      "path": "/home/alex/repos/.grabowski-worktrees/pr-check-readiness-v2",
+      "repo": "grabowski",
+      "branch": null,
+      "head": "ceab86514eaf",
+      "retention": "retained",
+      "hasProcess": true,
+      "hasResourceLease": true,
+      "matchesRuntime": true,
+      "note": "active runtime-matching worktree"
+    },
+    {
+      "path": "/home/alex/repos/grabowski",
+      "repo": "grabowski",
+      "branch": "fix/reconcile-observe-permission-v1",
+      "head": "09d0f92d48cd",
+      "retention": "retained",
+      "hasProcess": false,
+      "hasResourceLease": false,
+      "matchesRuntime": false,
+      "note": "canonical checkout; does not match deployed runtime"
+    },
+    {
+      "path": "/home/alex/grabowski-workspace/gopt002-validate",
+      "repo": "grabowski",
+      "branch": null,
+      "head": "deb6715a7e2e",
+      "retention": "archivable",
+      "hasProcess": false,
+      "hasResourceLease": false,
+      "matchesRuntime": false,
+      "note": "detached, clean, no owner"
+    },
+    {
+      "path": "/home/alex/grabowski-workspace/checkout-process-scope-v1",
+      "repo": "grabowski",
+      "branch": null,
+      "head": "775f8603b799",
+      "retention": "archivable",
+      "hasProcess": false,
+      "hasResourceLease": false,
+      "matchesRuntime": false,
+      "note": "detached, clean, no owner"
+    },
+    {
+      "path": "/home/alex/repos/.grabowski-worktrees/gopt002-icloud-apply",
+      "repo": "grabowski",
+      "branch": "feat/gopt002-icloud-apply",
+      "head": "01073c37c893",
+      "retention": "orphan",
+      "hasProcess": false,
+      "hasResourceLease": false,
+      "matchesRuntime": false,
+      "note": "no retention owner, no coordination state"
+    },
+    {
+      "path": "/home/alex/repos/.grabowski-worktrees/branch-publish-v1",
+      "repo": "grabowski",
+      "branch": "feat/grip-branch-publish-v1",
+      "head": "6c0de58b029a",
+      "retention": "orphan",
+      "hasProcess": false,
+      "hasResourceLease": false,
+      "matchesRuntime": false,
+      "note": "no retention owner"
+    },
+    {
+      "path": "/home/alex/grabowski-workspace/continuity-bootstrap-v1",
+      "repo": "grabowski",
+      "branch": "feat/continuity-bootstrap-v1",
+      "head": "105f15dce0ba",
+      "retention": "retained",
+      "hasProcess": false,
+      "hasResourceLease": false,
+      "matchesRuntime": false,
+      "note": "owner-retained feature worktree"
+    }
+  ]
+}

--- a/src/fixtures/checkout-inventory.json
+++ b/src/fixtures/checkout-inventory.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "kind": "leitstand_checkout_inventory",
   "generatedAt": "2026-07-07T06:30:00Z",
-  "source": "grabowski_checkout_inventory",
+  "source": "demo_grabowski_checkout_inventory",
   "doesNotEstablish": [
     "checkout_ownership",
     "cleanup_authority",
@@ -12,7 +12,7 @@
   ],
   "checkouts": [
     {
-      "path": "/home/alex/repos/.grabowski-worktrees/pr-check-readiness-v2",
+      "path": "example://grabowski/worktrees/pr-check-readiness-v2",
       "repo": "grabowski",
       "branch": null,
       "head": "ceab86514eaf",
@@ -20,21 +20,21 @@
       "hasProcess": true,
       "hasResourceLease": true,
       "matchesRuntime": true,
-      "note": "active runtime-matching worktree"
+      "note": "synthetic active runtime-matching worktree"
     },
     {
-      "path": "/home/alex/repos/grabowski",
+      "path": "example://grabowski/canonical",
       "repo": "grabowski",
-      "branch": "fix/reconcile-observe-permission-v1",
+      "branch": "fix/example-reconcile-observe-permission-v1",
       "head": "09d0f92d48cd",
       "retention": "retained",
       "hasProcess": false,
       "hasResourceLease": false,
       "matchesRuntime": false,
-      "note": "canonical checkout; does not match deployed runtime"
+      "note": "synthetic canonical checkout; does not match deployed runtime"
     },
     {
-      "path": "/home/alex/grabowski-workspace/gopt002-validate",
+      "path": "example://grabowski/workspace/gopt002-validate",
       "repo": "grabowski",
       "branch": null,
       "head": "deb6715a7e2e",
@@ -42,10 +42,10 @@
       "hasProcess": false,
       "hasResourceLease": false,
       "matchesRuntime": false,
-      "note": "detached, clean, no owner"
+      "note": "synthetic detached, clean, no owner"
     },
     {
-      "path": "/home/alex/grabowski-workspace/checkout-process-scope-v1",
+      "path": "example://grabowski/workspace/checkout-process-scope-v1",
       "repo": "grabowski",
       "branch": null,
       "head": "775f8603b799",
@@ -53,40 +53,40 @@
       "hasProcess": false,
       "hasResourceLease": false,
       "matchesRuntime": false,
-      "note": "detached, clean, no owner"
+      "note": "synthetic detached, clean, no owner"
     },
     {
-      "path": "/home/alex/repos/.grabowski-worktrees/gopt002-icloud-apply",
+      "path": "example://grabowski/worktrees/gopt002-icloud-apply",
       "repo": "grabowski",
-      "branch": "feat/gopt002-icloud-apply",
+      "branch": "feat/example-gopt002-icloud-apply",
       "head": "01073c37c893",
       "retention": "orphan",
       "hasProcess": false,
       "hasResourceLease": false,
       "matchesRuntime": false,
-      "note": "no retention owner, no coordination state"
+      "note": "synthetic no retention owner, no coordination state"
     },
     {
-      "path": "/home/alex/repos/.grabowski-worktrees/branch-publish-v1",
+      "path": "example://grabowski/worktrees/branch-publish-v1",
       "repo": "grabowski",
-      "branch": "feat/grip-branch-publish-v1",
+      "branch": "feat/example-grip-branch-publish-v1",
       "head": "6c0de58b029a",
       "retention": "orphan",
       "hasProcess": false,
       "hasResourceLease": false,
       "matchesRuntime": false,
-      "note": "no retention owner"
+      "note": "synthetic no retention owner"
     },
     {
-      "path": "/home/alex/grabowski-workspace/continuity-bootstrap-v1",
+      "path": "example://grabowski/workspace/continuity-bootstrap-v1",
       "repo": "grabowski",
-      "branch": "feat/continuity-bootstrap-v1",
+      "branch": "feat/example-continuity-bootstrap-v1",
       "head": "105f15dce0ba",
       "retention": "retained",
       "hasProcess": false,
       "hasResourceLease": false,
       "matchesRuntime": false,
-      "note": "owner-retained feature worktree"
+      "note": "synthetic owner-retained feature worktree"
     }
   ]
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,8 @@ import { getReflexionData } from './controllers/reflexion.js';
 import { getDashboardData } from './controllers/dashboard.js';
 import { getEcosystemMapData } from './controllers/ecosystemMap.js';
 import { getRepoBriefData } from './controllers/repoBrief.js';
+import { getBureauData } from './controllers/bureau.js';
+import { getCheckoutData } from './controllers/checkouts.js';
 import { getEventFamily, listEventFamilies } from './utils/eventKind.js';
 import fs from 'fs';
 import { validatePlexerReport } from './validation/validators.js';
@@ -314,6 +316,32 @@ app.get('/repobriefs', async (_req, res) => {
     if (!res.headersSent) {
       console.error('[RepoBriefs] Error:', error);
       res.status(500).send('Error loading RepoBrief data');
+    }
+  }
+});
+
+// Bureau Task Board – Execution axis: read-only Bureau task/claim projection
+app.get('/bureau', async (_req, res) => {
+  try {
+    const data = await getBureauData();
+    res.render('bureau', data);
+  } catch (error) {
+    if (!res.headersSent) {
+      console.error('[Bureau] Error:', error);
+      res.status(500).send('Error loading bureau data');
+    }
+  }
+});
+
+// Checkout Health – Execution axis: read-only Grabowski checkout inventory projection
+app.get('/checkouts', async (_req, res) => {
+  try {
+    const data = await getCheckoutData();
+    res.render('checkouts', data);
+  } catch (error) {
+    if (!res.headersSent) {
+      console.error('[Checkouts] Error:', error);
+      res.status(500).send('Error loading checkout data');
     }
   }
 });

--- a/src/views/bureau.ejs
+++ b/src/views/bureau.ejs
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <title>Bureau Task Board – Leitstand</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0a0e1a; color: #f1f5f9; margin: 0; }
+    nav { position: sticky; top: 0; display: flex; flex-wrap: wrap; gap: 4px; padding: 10px 20px; background: rgba(10,14,26,.92); border-bottom: 1px solid rgba(255,255,255,.08); }
+    nav a { color: #94a3b8; text-decoration: none; padding: 6px 14px; border-radius: 6px; font-size: .82em; }
+    nav a.active, nav a:hover { color: #3b82f6; background: rgba(59,130,246,.1); }
+    nav a:focus-visible { outline: 2px solid #3b82f6; outline-offset: 2px; }
+    nav .title { color: #f1f5f9; font-weight: 700; margin-right: 16px; }
+    main { max-width: 1180px; margin: 0 auto; padding: 42px 24px 80px; }
+    .subtitle, .muted { color: #94a3b8; line-height: 1.55; }
+    .notice, .meta-item, .card { background: rgba(17,24,39,.88); border: 1px solid rgba(255,255,255,.08); border-radius: 14px; padding: 20px 22px; margin-bottom: 18px; }
+    .notice strong { color: #3b82f6; }
+    .meta-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 12px; margin: 22px 0; }
+    .label { color: #64748b; font-size: .72em; text-transform: uppercase; letter-spacing: .08em; margin-bottom: 5px; }
+    .value { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .82em; overflow-wrap: anywhere; }
+    .board { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 14px; }
+    .column { background: rgba(17,24,39,.6); border: 1px solid rgba(255,255,255,.08); border-radius: 12px; padding: 12px; }
+    .column h3 { font-size: .8em; margin: 0 0 10px; display: flex; justify-content: space-between; }
+    .count { color: #64748b; font-weight: 400; }
+    .task { background: rgba(255,255,255,.03); border: 1px solid rgba(255,255,255,.07); border-left-width: 3px; border-radius: 8px; padding: 10px 12px; margin-bottom: 8px; }
+    .task .t-title { font-size: .88em; font-weight: 600; margin-bottom: 4px; }
+    .task .t-meta { font-size: .72em; color: #64748b; font-family: ui-monospace, monospace; overflow-wrap: anywhere; }
+    .task .t-note { font-size: .74em; color: #94a3b8; margin-top: 5px; }
+    .st-queued { border-left-color: #64748b; }
+    .st-claimed { border-left-color: #3b82f6; }
+    .st-running { border-left-color: #22c55e; }
+    .st-blocked { border-left-color: #f59e0b; }
+    .st-done { border-left-color: #16a34a; }
+    .st-failed { border-left-color: #ef4444; }
+    .st-unknown { border-left-color: #475569; }
+    .fresh { color: #22c55e; } .stale { color: #f59e0b; } .fr-unknown { color: #64748b; }
+    .k-missing .value { color: #ef4444; }
+    .k-fixture .value { color: #f59e0b; }
+    code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: #dbeafe; }
+    ul { margin-left: 20px; color: #94a3b8; }
+  </style>
+</head>
+<body>
+  <nav aria-label="Hauptnavigation">
+    <span class="title">Leitstand</span>
+    <a href="/">Home</a>
+    <a href="/bureau" class="active" aria-current="page">Bureau</a>
+    <a href="/checkouts">Checkouts</a>
+    <a href="/repobriefs">RepoBriefs</a>
+    <a href="/anatomy">Anatomie</a>
+    <a href="/timeline">Zeitachse</a>
+    <a href="/insights">Erkenntnisse</a>
+    <a href="/reflexion">Reflexion</a>
+    <a href="/ops">Ops</a>
+  </nav>
+
+  <main>
+    <h1>Bureau Task Board</h1>
+    <p class="subtitle">Read-only Projektion des Bureau-Task-/Claim-Zustands (Ausführungs-Achse). Diese Ansicht zeigt Tasks, Claims und Lifecycle-Zustände; sie besitzt keine Tasks, vergibt keine Claims und führt nichts aus.</p>
+
+    <section class="notice">
+      <strong>View only.</strong> Der Task-Zustand stammt aus einem Snapshot-Artefakt eines separaten Producers. Fällt Leitstand aus, läuft die Ausführungswahrheit ungestört weiter.
+    </section>
+
+    <section class="meta-grid" aria-label="Bureau source metadata">
+      <div class="meta-item <%= view_meta.source_kind === 'artifact' ? '' : view_meta.source_kind === 'fixture' ? 'k-fixture' : 'k-missing' %>"><div class="label">Source state</div><div class="value"><%= view_meta.source_kind %> / <%= view_meta.missing_reason %></div></div>
+      <div class="meta-item"><div class="label">Generated</div><div class="value"><%= view_meta.generated_at || '—' %></div></div>
+      <div class="meta-item"><div class="label">Freshness</div><div class="value <%= view_meta.freshness_state === 'fresh' ? 'fresh' : view_meta.freshness_state === 'stale' ? 'stale' : 'fr-unknown' %>"><%= view_meta.freshness_state %></div></div>
+      <div class="meta-item"><div class="label">Tasks</div><div class="value"><%= view_meta.task_count %></div></div>
+      <div class="meta-item"><div class="label">Offen</div><div class="value"><%= view_meta.open_count %></div></div>
+      <div class="meta-item"><div class="label">Blocked / Failed</div><div class="value"><%= view_meta.blocked_count %> / <%= view_meta.failed_count %></div></div>
+    </section>
+
+    <% if (view_meta.source_kind === 'fixture') { %>
+      <section class="card"><p class="muted">Fixture-Fallback aktiv (<code><%= view_meta.missing_reason %></code>). Dies ist Demo-/Preview-Datenmaterial, kein operativer grüner Status. Pfad: <code><%= view_meta.source_path %></code></p></section>
+    <% } else if (view_meta.source_kind !== 'artifact') { %>
+      <section class="card"><p class="muted">Kein Bureau-Snapshot verfügbar (<code><%= view_meta.missing_reason %></code>). Degradierter Read-only-Zustand, kein grüner Status. Pfad: <code><%= view_meta.source_path %></code></p></section>
+    <% } %>
+
+    <section class="board" aria-label="Task board columns">
+      <% columns.forEach(function(col) { %>
+        <div class="column" data-state="<%= col.state %>">
+          <h3><%= col.label %> <span class="count"><%= col.tasks.length %></span></h3>
+          <% col.tasks.forEach(function(task) { %>
+            <div class="task st-<%= task.state %>" data-task-id="<%= task.id %>">
+              <div class="t-title"><%= task.title %></div>
+              <div class="t-meta"><%= task.id %><% if (task.repo) { %> · <%= task.repo %><% } %><% if (task.claimant) { %> · @<%= task.claimant %><% } %></div>
+              <% if (task.note) { %><div class="t-note"><%= task.note %></div><% } %>
+              <% if (task.receipt_ref) { %><div class="t-meta">receipt: <%= task.receipt_ref %></div><% } %>
+            </div>
+          <% }); %>
+          <% if (col.tasks.length === 0) { %><p class="muted" style="font-size:.75em;">—</p><% } %>
+        </div>
+      <% }); %>
+    </section>
+
+    <section class="card">
+      <h2>Does not establish</h2>
+      <ul>
+        <% view_meta.does_not_establish.forEach(function(item) { %><li><%= item %></li><% }); %>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/src/views/bureau.ejs
+++ b/src/views/bureau.ejs
@@ -72,9 +72,9 @@
     </section>
 
     <% if (view_meta.source_kind === 'fixture') { %>
-      <section class="card"><p class="muted">Fixture-Fallback aktiv (<code><%= view_meta.missing_reason %></code>). Dies ist Demo-/Preview-Datenmaterial, kein operativer grüner Status. Pfad: <code><%= view_meta.source_path %></code></p></section>
+      <section class="card"><p class="muted">Fixture-Fallback aktiv (<code><%= view_meta.missing_reason %></code>). Dies ist Demo-/Preview-Datenmaterial, kein operativer grüner Status. Pfad: <code><%= view_meta.source_path_display %></code></p></section>
     <% } else if (view_meta.source_kind !== 'artifact') { %>
-      <section class="card"><p class="muted">Kein Bureau-Snapshot verfügbar (<code><%= view_meta.missing_reason %></code>). Degradierter Read-only-Zustand, kein grüner Status. Pfad: <code><%= view_meta.source_path %></code></p></section>
+      <section class="card"><p class="muted">Kein Bureau-Snapshot verfügbar (<code><%= view_meta.missing_reason %></code>). Degradierter Read-only-Zustand, kein grüner Status. Pfad: <code><%= view_meta.source_path_display %></code></p></section>
     <% } %>
 
     <section class="board" aria-label="Task board columns">

--- a/src/views/checkouts.ejs
+++ b/src/views/checkouts.ejs
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <title>Checkout Health – Leitstand</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0a0e1a; color: #f1f5f9; margin: 0; }
+    nav { position: sticky; top: 0; display: flex; flex-wrap: wrap; gap: 4px; padding: 10px 20px; background: rgba(10,14,26,.92); border-bottom: 1px solid rgba(255,255,255,.08); }
+    nav a { color: #94a3b8; text-decoration: none; padding: 6px 14px; border-radius: 6px; font-size: .82em; }
+    nav a.active, nav a:hover { color: #3b82f6; background: rgba(59,130,246,.1); }
+    nav a:focus-visible { outline: 2px solid #3b82f6; outline-offset: 2px; }
+    nav .title { color: #f1f5f9; font-weight: 700; margin-right: 16px; }
+    main { max-width: 1180px; margin: 0 auto; padding: 42px 24px 80px; }
+    .subtitle, .muted { color: #94a3b8; line-height: 1.55; }
+    .notice, .meta-item, .card { background: rgba(17,24,39,.88); border: 1px solid rgba(255,255,255,.08); border-radius: 14px; padding: 20px 22px; margin-bottom: 18px; }
+    .notice strong { color: #3b82f6; }
+    .meta-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; margin: 22px 0; }
+    .label { color: #64748b; font-size: .72em; text-transform: uppercase; letter-spacing: .08em; margin-bottom: 5px; }
+    .value { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .82em; overflow-wrap: anywhere; }
+    .table-wrap { overflow-x: auto; }
+    table { border-collapse: collapse; width: 100%; font-size: .82em; }
+    th, td { text-align: left; padding: 9px 12px; border-bottom: 1px solid rgba(255,255,255,.07); vertical-align: top; }
+    th { color: #64748b; font-size: .82em; text-transform: uppercase; letter-spacing: .06em; }
+    td.path { font-family: ui-monospace, monospace; overflow-wrap: anywhere; max-width: 380px; }
+    .pill { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: .9em; border: 1px solid transparent; }
+    .r-orphan { color: #ef4444; border-color: rgba(239,68,68,.3); }
+    .r-archivable { color: #f59e0b; border-color: rgba(245,158,11,.3); }
+    .r-retained { color: #22c55e; border-color: rgba(34,197,94,.3); }
+    .r-unknown { color: #64748b; border-color: rgba(100,116,139,.3); }
+    .flag { color: #94a3b8; font-family: ui-monospace, monospace; }
+    .flag.on { color: #3b82f6; }
+    .fresh { color: #22c55e; } .stale { color: #f59e0b; } .fr-unknown { color: #64748b; }
+    .k-missing .value { color: #ef4444; }
+    .k-fixture .value { color: #f59e0b; }
+    .sprawl-warn { color: #f59e0b; }
+    code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: #dbeafe; }
+    ul { margin-left: 20px; color: #94a3b8; }
+  </style>
+</head>
+<body>
+  <nav aria-label="Hauptnavigation">
+    <span class="title">Leitstand</span>
+    <a href="/">Home</a>
+    <a href="/bureau">Bureau</a>
+    <a href="/checkouts" class="active" aria-current="page">Checkouts</a>
+    <a href="/repobriefs">RepoBriefs</a>
+    <a href="/anatomy">Anatomie</a>
+    <a href="/timeline">Zeitachse</a>
+    <a href="/insights">Erkenntnisse</a>
+    <a href="/reflexion">Reflexion</a>
+    <a href="/ops">Ops</a>
+  </nav>
+
+  <main>
+    <h1>Checkout / Worktree Health</h1>
+    <p class="subtitle">Read-only Projektion des Grabowski-Linked-Checkout-Inventars. Sprawl (viele langlebige, nicht retenierte Worktrees) ist ein Gesundheitssignal — diese Ansicht macht es sichtbar, entscheidet aber nichts und räumt nichts auf.</p>
+
+    <section class="notice">
+      <strong>View only.</strong> Retention-/Cleanup-Entscheidungen gehören Grabowski. Leitstand liest ein Snapshot-Artefakt und stellt es dar.
+    </section>
+
+    <section class="meta-grid" aria-label="Checkout source metadata">
+      <div class="meta-item <%= view_meta.source_kind === 'artifact' ? '' : view_meta.source_kind === 'fixture' ? 'k-fixture' : 'k-missing' %>"><div class="label">Source state</div><div class="value"><%= view_meta.source_kind %> / <%= view_meta.missing_reason %></div></div>
+      <div class="meta-item"><div class="label">Generated</div><div class="value"><%= view_meta.generated_at || '—' %></div></div>
+      <div class="meta-item"><div class="label">Freshness</div><div class="value <%= view_meta.freshness_state === 'fresh' ? 'fresh' : view_meta.freshness_state === 'stale' ? 'stale' : 'fr-unknown' %>"><%= view_meta.freshness_state %></div></div>
+      <div class="meta-item"><div class="label">Checkouts</div><div class="value"><%= view_meta.checkout_count %></div></div>
+      <div class="meta-item"><div class="label">Retained / Archivable / Orphan</div><div class="value"><%= view_meta.retained_count %> / <%= view_meta.archivable_count %> / <%= view_meta.orphan_count %></div></div>
+      <div class="meta-item"><div class="label">Sprawl-Kandidaten</div><div class="value <%= view_meta.sprawl_count > 0 ? 'sprawl-warn' : '' %>"><%= view_meta.sprawl_count %></div></div>
+    </section>
+
+    <% if (view_meta.source_kind === 'fixture') { %>
+      <section class="card"><p class="muted">Fixture-Fallback aktiv (<code><%= view_meta.missing_reason %></code>). Dies ist Demo-/Preview-Datenmaterial, kein operativer grüner Status. Pfad: <code><%= view_meta.source_path %></code></p></section>
+    <% } else if (view_meta.source_kind !== 'artifact') { %>
+      <section class="card"><p class="muted">Kein Checkout-Inventar verfügbar (<code><%= view_meta.missing_reason %></code>). Degradierter Read-only-Zustand, kein grüner Status. Pfad: <code><%= view_meta.source_path %></code></p></section>
+    <% } %>
+
+    <% if (checkouts.length > 0) { %>
+    <section class="card table-wrap">
+      <table>
+        <thead>
+          <tr><th>Retention</th><th>Path</th><th>Repo / Branch</th><th>Head</th><th>Proc</th><th>Lease</th><th>Runtime</th></tr>
+        </thead>
+        <tbody>
+          <% checkouts.forEach(function(c) { %>
+            <tr data-path="<%= c.path %>">
+              <td><span class="pill r-<%= c.retention %>"><%= c.retention %></span></td>
+              <td class="path"><%= c.path %><% if (c.note) { %><div class="muted" style="font-size:.85em;"><%= c.note %></div><% } %></td>
+              <td><%= c.repo || '—' %><% if (c.branch) { %><div class="muted" style="font-size:.85em;"><%= c.branch %></div><% } %></td>
+              <td class="value"><%= c.head || '—' %></td>
+              <td><span class="flag <%= c.has_process ? 'on' : '' %>"><%= c.has_process ? '●' : '○' %></span></td>
+              <td><span class="flag <%= c.has_resource_lease ? 'on' : '' %>"><%= c.has_resource_lease ? '●' : '○' %></span></td>
+              <td><span class="flag <%= c.matches_runtime ? 'on' : '' %>"><%= c.matches_runtime ? '✓' : '·' %></span></td>
+            </tr>
+          <% }); %>
+        </tbody>
+      </table>
+    </section>
+    <% } %>
+
+    <section class="card">
+      <h2>Does not establish</h2>
+      <ul>
+        <% view_meta.does_not_establish.forEach(function(item) { %><li><%= item %></li><% }); %>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/src/views/checkouts.ejs
+++ b/src/views/checkouts.ejs
@@ -70,9 +70,9 @@
     </section>
 
     <% if (view_meta.source_kind === 'fixture') { %>
-      <section class="card"><p class="muted">Fixture-Fallback aktiv (<code><%= view_meta.missing_reason %></code>). Dies ist Demo-/Preview-Datenmaterial, kein operativer grüner Status. Pfad: <code><%= view_meta.source_path %></code></p></section>
+      <section class="card"><p class="muted">Fixture-Fallback aktiv (<code><%= view_meta.missing_reason %></code>). Dies ist Demo-/Preview-Datenmaterial, kein operativer grüner Status. Pfad: <code><%= view_meta.source_path_display %></code></p></section>
     <% } else if (view_meta.source_kind !== 'artifact') { %>
-      <section class="card"><p class="muted">Kein Checkout-Inventar verfügbar (<code><%= view_meta.missing_reason %></code>). Degradierter Read-only-Zustand, kein grüner Status. Pfad: <code><%= view_meta.source_path %></code></p></section>
+      <section class="card"><p class="muted">Kein Checkout-Inventar verfügbar (<code><%= view_meta.missing_reason %></code>). Degradierter Read-only-Zustand, kein grüner Status. Pfad: <code><%= view_meta.source_path_display %></code></p></section>
     <% } %>
 
     <% if (checkouts.length > 0) { %>

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -263,6 +263,8 @@
   <nav aria-label="Hauptnavigation">
     <span class="title">Leitstand</span>
     <a href="/" class="active" aria-current="page">Home</a>
+    <a href="/bureau">Bureau</a>
+    <a href="/checkouts">Checkouts</a>
     <a href="/observatory">Observatorium</a>
     <a href="/ecosystem-map">Ecosystem Map</a>
     <a href="/repobriefs">RepoBriefs</a>
@@ -287,6 +289,15 @@
       <p>
         Read-only Cabinet map source view: zeigt Mermaid-Quellen, Commit, Manifest, Freshness und Boundary-Hinweis.
         <a href="/ecosystem-map">Ecosystem Map öffnen</a>.
+      </p>
+    </section>
+
+    <section class="info-card" aria-labelledby="execution-heading">
+      <h2 id="execution-heading">Ausführungs-Achse (Bureau · Grabowski)</h2>
+      <p>
+        Read-only Projektion des Operator-Ökosystems, das die Ausführungswahrheit erzeugt.
+        Snapshots werden von einem separaten Producer erzeugt; Leitstand rendert sie nur.
+        <a href="/bureau">Bureau Task Board öffnen</a> · <a href="/checkouts">Checkout Health öffnen</a>.
       </p>
     </section>
 

--- a/tests/controllers/bureau.test.ts
+++ b/tests/controllers/bureau.test.ts
@@ -51,6 +51,7 @@ describe('getBureauData', () => {
     const data = await getBureauData();
     expect(data.view_meta.source_kind).toBe('missing');
     expect(data.view_meta.missing_reason).toBe('bureau_snapshot_missing');
+    expect(data.view_meta.source_path_display.startsWith('artifacts/')).toBe(true);
     expect(data.view_meta.source_path.endsWith('/artifacts/bureau-tasks.json')).toBe(true);
   });
 
@@ -60,6 +61,7 @@ describe('getBureauData', () => {
     const data = await getBureauData();
     expect(data.view_meta.source_kind).toBe('fixture');
     expect(data.view_meta.missing_reason).toBe('bureau_snapshot_missing_fixture_fallback');
+    expect(data.view_meta.source_path_display.startsWith('src/fixtures/')).toBe(true);
     expect(data.view_meta.source_path.endsWith('/src/fixtures/bureau-tasks.json')).toBe(true);
   });
 

--- a/tests/controllers/bureau.test.ts
+++ b/tests/controllers/bureau.test.ts
@@ -1,0 +1,120 @@
+import { mkdtemp, writeFile, rm } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { afterEach, describe, expect, it } from 'vitest';
+import { getBureauData } from '../../src/controllers/bureau.js';
+
+const OLD_PATH = process.env.LEITSTAND_BUREAU_SNAPSHOT_PATH;
+const OLD_FIXTURE_FALLBACK = process.env.LEITSTAND_BUREAU_FIXTURE_FALLBACK;
+const OLD_STRICT = process.env.LEITSTAND_STRICT;
+let tempRoots: string[] = [];
+
+afterEach(async () => {
+  if (OLD_PATH === undefined) delete process.env.LEITSTAND_BUREAU_SNAPSHOT_PATH;
+  else process.env.LEITSTAND_BUREAU_SNAPSHOT_PATH = OLD_PATH;
+  if (OLD_FIXTURE_FALLBACK === undefined) delete process.env.LEITSTAND_BUREAU_FIXTURE_FALLBACK;
+  else process.env.LEITSTAND_BUREAU_FIXTURE_FALLBACK = OLD_FIXTURE_FALLBACK;
+  if (OLD_STRICT === undefined) delete process.env.LEITSTAND_STRICT;
+  else process.env.LEITSTAND_STRICT = OLD_STRICT;
+  for (const root of tempRoots) {
+    await rm(root, { recursive: true, force: true });
+  }
+  tempRoots = [];
+});
+
+async function writeSnapshot(generatedAt: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'leitstand-bureau-'));
+  tempRoots.push(root);
+  const path = join(root, 'bureau.json');
+  await writeFile(path, JSON.stringify({
+    schemaVersion: 1,
+    kind: 'leitstand_bureau_task_snapshot',
+    generatedAt,
+    doesNotEstablish: ['task_ownership', 'execution_truth'],
+    tasks: [
+      { id: 'T1', title: 'running one', state: 'running', claimant: 'grabowski', repo: 'grabowski' },
+      { id: 'T2', title: 'queued one', state: 'pending', repo: 'leitstand' },
+      { id: 'T3', title: 'blocked one', state: 'blocked' },
+      { id: 'T4', title: 'failed one', state: 'error', claimant: 'heimlern' },
+      { id: 'T5', title: 'done one', state: 'completed', receiptRef: 'receipt:x' },
+    ],
+  }), 'utf-8');
+  return path;
+}
+
+describe('getBureauData', () => {
+
+  it('checks the artifact path by default and does not silently treat fixtures as artifacts', async () => {
+    delete process.env.LEITSTAND_BUREAU_SNAPSHOT_PATH;
+    delete process.env.LEITSTAND_BUREAU_FIXTURE_FALLBACK;
+    delete process.env.LEITSTAND_STRICT;
+    const data = await getBureauData();
+    expect(data.view_meta.source_kind).toBe('missing');
+    expect(data.view_meta.missing_reason).toBe('bureau_snapshot_missing');
+    expect(data.view_meta.source_path.endsWith('/artifacts/bureau-tasks.json')).toBe(true);
+  });
+
+  it('uses the demo fixture only when fixture fallback is explicit', async () => {
+    delete process.env.LEITSTAND_BUREAU_SNAPSHOT_PATH;
+    process.env.LEITSTAND_BUREAU_FIXTURE_FALLBACK = '1';
+    const data = await getBureauData();
+    expect(data.view_meta.source_kind).toBe('fixture');
+    expect(data.view_meta.missing_reason).toBe('bureau_snapshot_missing_fixture_fallback');
+    expect(data.view_meta.source_path.endsWith('/src/fixtures/bureau-tasks.json')).toBe(true);
+  });
+
+  it('uses the demo fixture when Leitstand is explicitly in non-strict preview mode', async () => {
+    delete process.env.LEITSTAND_BUREAU_SNAPSHOT_PATH;
+    delete process.env.LEITSTAND_BUREAU_FIXTURE_FALLBACK;
+    process.env.LEITSTAND_STRICT = 'false';
+    const data = await getBureauData();
+    expect(data.view_meta.source_kind).toBe('fixture');
+    expect(data.view_meta.missing_reason).toBe('bureau_snapshot_missing_fixture_fallback');
+  });
+  it('groups tasks into lifecycle columns and normalises producer vocab', async () => {
+    process.env.LEITSTAND_BUREAU_SNAPSHOT_PATH = await writeSnapshot('2026-07-07T06:30:00Z');
+    const data = await getBureauData();
+    expect(data.view_meta.source_kind).toBe('artifact');
+    expect(data.view_meta.task_count).toBe(5);
+    // queued+claimed+running+blocked = open
+    expect(data.view_meta.open_count).toBe(3);
+    expect(data.view_meta.blocked_count).toBe(1);
+    expect(data.view_meta.failed_count).toBe(1);
+
+    const byState = Object.fromEntries(data.columns.map((c) => [c.state, c.tasks.length]));
+    expect(byState.queued).toBe(1); // 'pending' → queued
+    expect(byState.running).toBe(1);
+    expect(byState.blocked).toBe(1);
+    expect(byState.failed).toBe(1); // 'error' → failed
+    expect(byState.done).toBe(1); // 'completed' → done
+  });
+
+  it('marks an old snapshot as stale', async () => {
+    process.env.LEITSTAND_BUREAU_SNAPSHOT_PATH = await writeSnapshot('2000-01-01T00:00:00Z');
+    const data = await getBureauData();
+    expect(data.view_meta.freshness_state).toBe('stale');
+  });
+
+  it('reports a missing snapshot as degraded, not green', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'leitstand-bureau-missing-'));
+    tempRoots.push(root);
+    process.env.LEITSTAND_BUREAU_SNAPSHOT_PATH = join(root, 'missing.json');
+    const data = await getBureauData();
+    expect(data.view_meta.source_kind).toBe('missing');
+    expect(data.view_meta.missing_reason).toBe('bureau_snapshot_missing');
+    expect(data.view_meta.task_count).toBe(0);
+    expect(data.tasks).toEqual([]);
+    // Empty state still renders all lifecycle columns.
+    expect(data.columns).toHaveLength(6);
+  });
+
+  it('rejects a snapshot with the wrong contract kind as corrupt', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'leitstand-bureau-wrong-'));
+    tempRoots.push(root);
+    const path = join(root, 'wrong.json');
+    await writeFile(path, JSON.stringify({ schemaVersion: 1, kind: 'something_else', tasks: [] }), 'utf-8');
+    process.env.LEITSTAND_BUREAU_SNAPSHOT_PATH = path;
+    const data = await getBureauData();
+    expect(data.view_meta.source_kind).toBe('corrupt');
+  });
+});

--- a/tests/controllers/checkouts.test.ts
+++ b/tests/controllers/checkouts.test.ts
@@ -1,0 +1,102 @@
+import { mkdtemp, writeFile, rm } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { afterEach, describe, expect, it } from 'vitest';
+import { getCheckoutData } from '../../src/controllers/checkouts.js';
+
+const OLD_PATH = process.env.LEITSTAND_CHECKOUT_SNAPSHOT_PATH;
+const OLD_FIXTURE_FALLBACK = process.env.LEITSTAND_CHECKOUT_FIXTURE_FALLBACK;
+const OLD_STRICT = process.env.LEITSTAND_STRICT;
+let tempRoots: string[] = [];
+
+afterEach(async () => {
+  if (OLD_PATH === undefined) delete process.env.LEITSTAND_CHECKOUT_SNAPSHOT_PATH;
+  else process.env.LEITSTAND_CHECKOUT_SNAPSHOT_PATH = OLD_PATH;
+  if (OLD_FIXTURE_FALLBACK === undefined) delete process.env.LEITSTAND_CHECKOUT_FIXTURE_FALLBACK;
+  else process.env.LEITSTAND_CHECKOUT_FIXTURE_FALLBACK = OLD_FIXTURE_FALLBACK;
+  if (OLD_STRICT === undefined) delete process.env.LEITSTAND_STRICT;
+  else process.env.LEITSTAND_STRICT = OLD_STRICT;
+  for (const root of tempRoots) {
+    await rm(root, { recursive: true, force: true });
+  }
+  tempRoots = [];
+});
+
+async function writeInventory(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'leitstand-checkout-'));
+  tempRoots.push(root);
+  const path = join(root, 'checkouts.json');
+  await writeFile(path, JSON.stringify({
+    schemaVersion: 1,
+    kind: 'leitstand_checkout_inventory',
+    generatedAt: '2026-07-07T06:30:00Z',
+    checkouts: [
+      { path: '/w/retained', retention: 'retained', hasProcess: true, hasResourceLease: true, matchesRuntime: true },
+      { path: '/w/orphan', retention: 'orphaned', hasProcess: false, hasResourceLease: false },
+      { path: '/w/archivable', retention: 'stale', hasProcess: false, hasResourceLease: false },
+      { path: '/w/anchored', retention: 'orphan', hasProcess: true, hasResourceLease: false },
+    ],
+  }), 'utf-8');
+  return path;
+}
+
+describe('getCheckoutData', () => {
+
+  it('checks the artifact path by default and does not silently treat fixtures as artifacts', async () => {
+    delete process.env.LEITSTAND_CHECKOUT_SNAPSHOT_PATH;
+    delete process.env.LEITSTAND_CHECKOUT_FIXTURE_FALLBACK;
+    delete process.env.LEITSTAND_STRICT;
+    const data = await getCheckoutData();
+    expect(data.view_meta.source_kind).toBe('missing');
+    expect(data.view_meta.missing_reason).toBe('checkout_inventory_missing');
+    expect(data.view_meta.source_path.endsWith('/artifacts/checkout-inventory.json')).toBe(true);
+  });
+
+  it('uses the demo fixture only when fixture fallback is explicit', async () => {
+    delete process.env.LEITSTAND_CHECKOUT_SNAPSHOT_PATH;
+    process.env.LEITSTAND_CHECKOUT_FIXTURE_FALLBACK = 'true';
+    const data = await getCheckoutData();
+    expect(data.view_meta.source_kind).toBe('fixture');
+    expect(data.view_meta.missing_reason).toBe('checkout_inventory_missing_fixture_fallback');
+    expect(data.view_meta.source_path.endsWith('/src/fixtures/checkout-inventory.json')).toBe(true);
+  });
+
+  it('uses the demo fixture when Leitstand is explicitly in non-strict preview mode', async () => {
+    delete process.env.LEITSTAND_CHECKOUT_SNAPSHOT_PATH;
+    delete process.env.LEITSTAND_CHECKOUT_FIXTURE_FALLBACK;
+    process.env.LEITSTAND_STRICT = '0';
+    const data = await getCheckoutData();
+    expect(data.view_meta.source_kind).toBe('fixture');
+    expect(data.view_meta.missing_reason).toBe('checkout_inventory_missing_fixture_fallback');
+  });
+  it('counts retention classes and flags true sprawl only', async () => {
+    process.env.LEITSTAND_CHECKOUT_SNAPSHOT_PATH = await writeInventory();
+    const data = await getCheckoutData();
+    expect(data.view_meta.source_kind).toBe('artifact');
+    expect(data.view_meta.checkout_count).toBe(4);
+    expect(data.view_meta.retained_count).toBe(1);
+    expect(data.view_meta.orphan_count).toBe(2); // 'orphaned' and 'orphan' both normalise
+    expect(data.view_meta.archivable_count).toBe(1); // 'stale' → archivable
+    // sprawl = orphan/archivable AND no process AND no lease.
+    // /w/orphan and /w/archivable qualify; /w/anchored has a process so it does not.
+    expect(data.view_meta.sprawl_count).toBe(2);
+  });
+
+  it('sorts worst retention first for triage', async () => {
+    process.env.LEITSTAND_CHECKOUT_SNAPSHOT_PATH = await writeInventory();
+    const data = await getCheckoutData();
+    expect(data.checkouts[0].retention).toBe('orphan');
+    expect(data.checkouts[data.checkouts.length - 1].retention).toBe('retained');
+  });
+
+  it('reports a missing inventory as degraded, not green', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'leitstand-checkout-missing-'));
+    tempRoots.push(root);
+    process.env.LEITSTAND_CHECKOUT_SNAPSHOT_PATH = join(root, 'missing.json');
+    const data = await getCheckoutData();
+    expect(data.view_meta.source_kind).toBe('missing');
+    expect(data.view_meta.missing_reason).toBe('checkout_inventory_missing');
+    expect(data.checkouts).toEqual([]);
+    expect(data.view_meta.sprawl_count).toBe(0);
+  });
+});

--- a/tests/controllers/checkouts.test.ts
+++ b/tests/controllers/checkouts.test.ts
@@ -49,6 +49,7 @@ describe('getCheckoutData', () => {
     const data = await getCheckoutData();
     expect(data.view_meta.source_kind).toBe('missing');
     expect(data.view_meta.missing_reason).toBe('checkout_inventory_missing');
+    expect(data.view_meta.source_path_display.startsWith('artifacts/')).toBe(true);
     expect(data.view_meta.source_path.endsWith('/artifacts/checkout-inventory.json')).toBe(true);
   });
 
@@ -58,6 +59,7 @@ describe('getCheckoutData', () => {
     const data = await getCheckoutData();
     expect(data.view_meta.source_kind).toBe('fixture');
     expect(data.view_meta.missing_reason).toBe('checkout_inventory_missing_fixture_fallback');
+    expect(data.view_meta.source_path_display.startsWith('src/fixtures/')).toBe(true);
     expect(data.view_meta.source_path.endsWith('/src/fixtures/checkout-inventory.json')).toBe(true);
   });
 

--- a/tests/exportOperatorSnapshots.test.ts
+++ b/tests/exportOperatorSnapshots.test.ts
@@ -1,0 +1,87 @@
+import { execFile } from 'node:child_process';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { promisify } from 'node:util';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+const scriptPath = resolve('scripts/export-operator-snapshots.mjs');
+let tempRoots: string[] = [];
+
+afterEach(async () => {
+  for (const root of tempRoots) {
+    await rm(root, { recursive: true, force: true });
+  }
+  tempRoots = [];
+});
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'leitstand-operator-snapshots-'));
+  tempRoots.push(root);
+  return root;
+}
+
+describe('export-operator-snapshots', () => {
+  it('exports canonical Bureau lifecycle states and checkout retention verdicts', async () => {
+    const root = await makeTempRoot();
+    const bureauRawPath = join(root, 'bureau-raw.json');
+    const checkoutRawPath = join(root, 'checkout-raw.json');
+    const outDir = join(root, 'out');
+
+    await writeFile(bureauRawPath, JSON.stringify({
+      tasks: [
+        { id: 'T-open', status: 'open' },
+        { id: 'T-assigned', state: 'assigned' },
+        { id: 'T-active', state: 'active' },
+        { id: 'T-waiting', state: 'waiting' },
+        { id: 'T-complete', status: 'complete' },
+        { id: 'T-error', status: 'error' },
+        { id: 'T-weird', status: 'custom-state' },
+      ],
+    }), 'utf-8');
+
+    await writeFile(checkoutRawPath, JSON.stringify({
+      checkouts: [
+        { path: 'example://retained', retention: { purpose: 'keep' } },
+        { path: 'example://cleanup', cleanup_candidate: true },
+        { path: 'example://stale', retention: 'stale' },
+        { path: 'example://orphaned', retention: 'orphaned' },
+        { path: 'example://implicit-orphan' },
+        { path: 'example://anchored', coordination: { processes: ['pid:1'] } },
+      ],
+    }), 'utf-8');
+
+    await execFileAsync(process.execPath, [
+      scriptPath,
+      '--bureau-raw', bureauRawPath,
+      '--checkout-raw', checkoutRawPath,
+      '--out-dir', outDir,
+    ]);
+
+    const bureauSnapshot = JSON.parse(await readFile(join(outDir, 'bureau-tasks.json'), 'utf-8')) as {
+      tasks: Array<{ id: string; state: string }>;
+    };
+    const checkoutSnapshot = JSON.parse(await readFile(join(outDir, 'checkout-inventory.json'), 'utf-8')) as {
+      checkouts: Array<{ path: string; retention: string }>;
+    };
+
+    expect(Object.fromEntries(bureauSnapshot.tasks.map((task) => [task.id, task.state]))).toEqual({
+      'T-open': 'queued',
+      'T-assigned': 'claimed',
+      'T-active': 'running',
+      'T-waiting': 'blocked',
+      'T-complete': 'done',
+      'T-error': 'failed',
+      'T-weird': 'unknown',
+    });
+    expect(Object.fromEntries(checkoutSnapshot.checkouts.map((checkout) => [checkout.path, checkout.retention]))).toEqual({
+      'example://retained': 'retained',
+      'example://cleanup': 'archivable',
+      'example://stale': 'archivable',
+      'example://orphaned': 'orphan',
+      'example://implicit-orphan': 'orphan',
+      'example://anchored': 'unknown',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds the first Leitstand execution-axis observer surfaces:
- `/bureau` read-only Bureau task/claim lifecycle projection
- `/checkouts` read-only Grabowski checkout/worktree health projection
- producer-side snapshot bridge `scripts/export-operator-snapshots.mjs`
- fixtures, views, controller tests and docs

Implements the first Bureau-registered hardening task from `LOO-V1-T001`:
- default source paths now prefer `artifacts/bureau-tasks.json` and `artifacts/checkout-inventory.json`
- fixture fallback is explicit via `LEITSTAND_BUREAU_FIXTURE_FALLBACK=1`, `LEITSTAND_CHECKOUT_FIXTURE_FALLBACK=1`, or non-strict preview mode `LEITSTAND_STRICT=false|0`
- fixture sources render as `source_kind=fixture`, not as artifacts or green live state
- missing/corrupt snapshots degrade visibly

## Evidence

Local checks:
- `NODE_OPTIONS=--jitless pnpm lint` passed
- `NODE_OPTIONS=--jitless pnpm typecheck` passed
- `NODE_OPTIONS=--jitless pnpm build` passed
- `scripts/ci/observer-invariant-guard.sh` passed
- `scripts/ci/docs-relations-guard.sh` passed
- `scripts/ci/generated-files-guard.sh` passed
- `scripts/ci/check-drift-gates.sh` passed
- direct built-controller smoke passed for default missing artifacts and explicit fixture fallback

Known local limitation:
- direct Vitest execution on the Heim-PC Node 22 runtime still crashes in V8 without `--jitless`; with `--jitless`, Vite/Vitest lacks WebAssembly. CI remains the full test source of truth.

## Boundary

This PR does not make Leitstand a Bureau/Grabowski authority. It adds read-only snapshot rendering only. It does not deploy, restart services, clean worktrees, claim tasks, or mutate external execution state.

## Bureau context

Registered follow-up initiative: `LEITSTAND-OPERATOR-OBSERVABILITY-V1`
Initial task addressed here: `LOO-V1-T001`
