### PR TITLE
fix: align Leitstand navigation parity

### DIFF
--- a/src/views/anatomy.ejs
+++ b/src/views/anatomy.ejs
@@ -331,13 +331,18 @@
   </style>
 </head>
 <body>
-  <nav>
+    <nav aria-label="Hauptnavigation">
     <span class="title">Leitstand</span>
     <a href="/">Home</a>
+    <a href="/bureau">Bureau</a>
+    <a href="/checkouts">Checkouts</a>
     <a href="/observatory">Observatorium</a>
-    <a href="/anatomy" class="active">Anatomie</a>
+    <a href="/ecosystem-map">Ecosystem Map</a>
+    <a href="/repobriefs">RepoBriefs</a>
+    <a href="/anatomy" class="active" aria-current="page">Anatomie</a>
     <a href="/timeline">Zeitachse</a>
     <a href="/insights">Erkenntnisse</a>
+    <a href="/reflexion">Reflexion</a>
     <a href="/ops">Ops</a>
   </nav>
 

--- a/src/views/anatomy.ejs
+++ b/src/views/anatomy.ejs
@@ -331,7 +331,7 @@
   </style>
 </head>
 <body>
-    <nav aria-label="Hauptnavigation">
+  <nav aria-label="Hauptnavigation">
     <span class="title">Leitstand</span>
     <a href="/">Home</a>
     <a href="/bureau">Bureau</a>

--- a/src/views/bureau.ejs
+++ b/src/views/bureau.ejs
@@ -41,11 +41,13 @@
   </style>
 </head>
 <body>
-  <nav aria-label="Hauptnavigation">
+    <nav aria-label="Hauptnavigation">
     <span class="title">Leitstand</span>
     <a href="/">Home</a>
     <a href="/bureau" class="active" aria-current="page">Bureau</a>
     <a href="/checkouts">Checkouts</a>
+    <a href="/observatory">Observatorium</a>
+    <a href="/ecosystem-map">Ecosystem Map</a>
     <a href="/repobriefs">RepoBriefs</a>
     <a href="/anatomy">Anatomie</a>
     <a href="/timeline">Zeitachse</a>

--- a/src/views/bureau.ejs
+++ b/src/views/bureau.ejs
@@ -41,7 +41,7 @@
   </style>
 </head>
 <body>
-    <nav aria-label="Hauptnavigation">
+  <nav aria-label="Hauptnavigation">
     <span class="title">Leitstand</span>
     <a href="/">Home</a>
     <a href="/bureau" class="active" aria-current="page">Bureau</a>

--- a/src/views/checkouts.ejs
+++ b/src/views/checkouts.ejs
@@ -39,7 +39,7 @@
   </style>
 </head>
 <body>
-    <nav aria-label="Hauptnavigation">
+  <nav aria-label="Hauptnavigation">
     <span class="title">Leitstand</span>
     <a href="/">Home</a>
     <a href="/bureau">Bureau</a>

--- a/src/views/checkouts.ejs
+++ b/src/views/checkouts.ejs
@@ -39,11 +39,13 @@
   </style>
 </head>
 <body>
-  <nav aria-label="Hauptnavigation">
+    <nav aria-label="Hauptnavigation">
     <span class="title">Leitstand</span>
     <a href="/">Home</a>
     <a href="/bureau">Bureau</a>
     <a href="/checkouts" class="active" aria-current="page">Checkouts</a>
+    <a href="/observatory">Observatorium</a>
+    <a href="/ecosystem-map">Ecosystem Map</a>
     <a href="/repobriefs">RepoBriefs</a>
     <a href="/anatomy">Anatomie</a>
     <a href="/timeline">Zeitachse</a>

--- a/src/views/ecosystem-map.ejs
+++ b/src/views/ecosystem-map.ejs
@@ -22,7 +22,7 @@
   </style>
 </head>
 <body>
-    <nav aria-label="Hauptnavigation">
+  <nav aria-label="Hauptnavigation">
     <span class="title">Leitstand</span>
     <a href="/">Home</a>
     <a href="/bureau">Bureau</a>

--- a/src/views/ecosystem-map.ejs
+++ b/src/views/ecosystem-map.ejs
@@ -22,10 +22,14 @@
   </style>
 </head>
 <body>
-  <nav aria-label="Hauptnavigation">
+    <nav aria-label="Hauptnavigation">
     <span class="title">Leitstand</span>
     <a href="/">Home</a>
+    <a href="/bureau">Bureau</a>
+    <a href="/checkouts">Checkouts</a>
+    <a href="/observatory">Observatorium</a>
     <a href="/ecosystem-map" class="active" aria-current="page">Ecosystem Map</a>
+    <a href="/repobriefs">RepoBriefs</a>
     <a href="/anatomy">Anatomie</a>
     <a href="/timeline">Zeitachse</a>
     <a href="/insights">Erkenntnisse</a>

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -260,7 +260,7 @@
   </style>
 </head>
 <body>
-    <nav aria-label="Hauptnavigation">
+  <nav aria-label="Hauptnavigation">
     <span class="title">Leitstand</span>
     <a href="/" class="active" aria-current="page">Home</a>
     <a href="/bureau">Bureau</a>

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -260,7 +260,7 @@
   </style>
 </head>
 <body>
-  <nav aria-label="Hauptnavigation">
+    <nav aria-label="Hauptnavigation">
     <span class="title">Leitstand</span>
     <a href="/" class="active" aria-current="page">Home</a>
     <a href="/bureau">Bureau</a>

--- a/src/views/insights.ejs
+++ b/src/views/insights.ejs
@@ -586,13 +586,18 @@
   </style>
 </head>
 <body>
-  <nav>
+    <nav aria-label="Hauptnavigation">
     <span class="title">Leitstand</span>
     <a href="/">Home</a>
+    <a href="/bureau">Bureau</a>
+    <a href="/checkouts">Checkouts</a>
     <a href="/observatory">Observatorium</a>
+    <a href="/ecosystem-map">Ecosystem Map</a>
+    <a href="/repobriefs">RepoBriefs</a>
     <a href="/anatomy">Anatomie</a>
     <a href="/timeline">Zeitachse</a>
-    <a href="/insights" class="active">Erkenntnisse</a>
+    <a href="/insights" class="active" aria-current="page">Erkenntnisse</a>
+    <a href="/reflexion">Reflexion</a>
     <a href="/ops">Ops</a>
   </nav>
 

--- a/src/views/insights.ejs
+++ b/src/views/insights.ejs
@@ -586,7 +586,7 @@
   </style>
 </head>
 <body>
-    <nav aria-label="Hauptnavigation">
+  <nav aria-label="Hauptnavigation">
     <span class="title">Leitstand</span>
     <a href="/">Home</a>
     <a href="/bureau">Bureau</a>

--- a/src/views/intent.ejs
+++ b/src/views/intent.ejs
@@ -15,14 +15,19 @@
   </style>
 </head>
 <body>
-  <nav>
+    <nav aria-label="Hauptnavigation">
+    <span class="title">Leitstand</span>
     <a href="/">Home</a>
+    <a href="/bureau">Bureau</a>
+    <a href="/checkouts">Checkouts</a>
     <a href="/observatory">Observatorium</a>
+    <a href="/ecosystem-map">Ecosystem Map</a>
+    <a href="/repobriefs">RepoBriefs</a>
     <a href="/anatomy">Anatomie</a>
     <a href="/timeline">Zeitachse</a>
     <a href="/insights">Erkenntnisse</a>
+    <a href="/reflexion">Reflexion</a>
     <a href="/ops">Ops</a>
-    <a href="/intent">Intent</a>
   </nav>
   <h1>Aktueller Intent</h1>
   <p class="meta">Generated at: <%= data.generated_at %></p>

--- a/src/views/intent.ejs
+++ b/src/views/intent.ejs
@@ -15,7 +15,7 @@
   </style>
 </head>
 <body>
-    <nav aria-label="Hauptnavigation">
+  <nav aria-label="Hauptnavigation">
     <span class="title">Leitstand</span>
     <a href="/">Home</a>
     <a href="/bureau">Bureau</a>

--- a/src/views/observatory.ejs
+++ b/src/views/observatory.ejs
@@ -462,12 +462,18 @@
   </style>
 </head>
 <body>
-  <nav>
+    <nav aria-label="Hauptnavigation">
+    <span class="title">Leitstand</span>
     <a href="/">Home</a>
-    <a href="/observatory">Observatorium</a>
+    <a href="/bureau">Bureau</a>
+    <a href="/checkouts">Checkouts</a>
+    <a href="/observatory" class="active" aria-current="page">Observatorium</a>
+    <a href="/ecosystem-map">Ecosystem Map</a>
+    <a href="/repobriefs">RepoBriefs</a>
     <a href="/anatomy">Anatomie</a>
     <a href="/timeline">Zeitachse</a>
     <a href="/insights">Erkenntnisse</a>
+    <a href="/reflexion">Reflexion</a>
     <a href="/ops">Ops</a>
   </nav>
 

--- a/src/views/observatory.ejs
+++ b/src/views/observatory.ejs
@@ -462,7 +462,7 @@
   </style>
 </head>
 <body>
-    <nav aria-label="Hauptnavigation">
+  <nav aria-label="Hauptnavigation">
     <span class="title">Leitstand</span>
     <a href="/">Home</a>
     <a href="/bureau">Bureau</a>

--- a/src/views/ops.ejs
+++ b/src/views/ops.ejs
@@ -242,14 +242,19 @@
   </style>
 </head>
 <body>
-  <nav>
-    <strong class="nav-title" style="font-weight: 700; font-size: 0.9em; color: var(--text-primary); margin-right: 16px;">Leitstand</strong>
+    <nav aria-label="Hauptnavigation">
+    <span class="title">Leitstand</span>
     <a href="/">Home</a>
+    <a href="/bureau">Bureau</a>
+    <a href="/checkouts">Checkouts</a>
     <a href="/observatory">Observatorium</a>
+    <a href="/ecosystem-map">Ecosystem Map</a>
+    <a href="/repobriefs">RepoBriefs</a>
     <a href="/anatomy">Anatomie</a>
     <a href="/timeline">Zeitachse</a>
     <a href="/insights">Erkenntnisse</a>
-    <a href="/ops" class="active">Ops</a>
+    <a href="/reflexion">Reflexion</a>
+    <a href="/ops" class="active" aria-current="page">Ops</a>
   </nav>
 
   <div class="main-wrapper">

--- a/src/views/ops.ejs
+++ b/src/views/ops.ejs
@@ -242,7 +242,7 @@
   </style>
 </head>
 <body>
-    <nav aria-label="Hauptnavigation">
+  <nav aria-label="Hauptnavigation">
     <span class="title">Leitstand</span>
     <a href="/">Home</a>
     <a href="/bureau">Bureau</a>

--- a/src/views/reflexion.ejs
+++ b/src/views/reflexion.ejs
@@ -310,14 +310,18 @@
   </style>
 </head>
 <body>
-  <nav>
+    <nav aria-label="Hauptnavigation">
     <span class="title">Leitstand</span>
     <a href="/">Home</a>
+    <a href="/bureau">Bureau</a>
+    <a href="/checkouts">Checkouts</a>
     <a href="/observatory">Observatorium</a>
+    <a href="/ecosystem-map">Ecosystem Map</a>
+    <a href="/repobriefs">RepoBriefs</a>
     <a href="/anatomy">Anatomie</a>
     <a href="/timeline">Zeitachse</a>
     <a href="/insights">Erkenntnisse</a>
-    <a href="/reflexion" class="active">Reflexion</a>
+    <a href="/reflexion" class="active" aria-current="page">Reflexion</a>
     <a href="/ops">Ops</a>
   </nav>
 

--- a/src/views/reflexion.ejs
+++ b/src/views/reflexion.ejs
@@ -310,7 +310,7 @@
   </style>
 </head>
 <body>
-    <nav aria-label="Hauptnavigation">
+  <nav aria-label="Hauptnavigation">
     <span class="title">Leitstand</span>
     <a href="/">Home</a>
     <a href="/bureau">Bureau</a>

--- a/src/views/repobriefs.ejs
+++ b/src/views/repobriefs.ejs
@@ -25,9 +25,12 @@
   </style>
 </head>
 <body>
-  <nav aria-label="Hauptnavigation">
+    <nav aria-label="Hauptnavigation">
     <span class="title">Leitstand</span>
     <a href="/">Home</a>
+    <a href="/bureau">Bureau</a>
+    <a href="/checkouts">Checkouts</a>
+    <a href="/observatory">Observatorium</a>
     <a href="/ecosystem-map">Ecosystem Map</a>
     <a href="/repobriefs" class="active" aria-current="page">RepoBriefs</a>
     <a href="/anatomy">Anatomie</a>

--- a/src/views/repobriefs.ejs
+++ b/src/views/repobriefs.ejs
@@ -25,7 +25,7 @@
   </style>
 </head>
 <body>
-    <nav aria-label="Hauptnavigation">
+  <nav aria-label="Hauptnavigation">
     <span class="title">Leitstand</span>
     <a href="/">Home</a>
     <a href="/bureau">Bureau</a>

--- a/src/views/timeline.ejs
+++ b/src/views/timeline.ejs
@@ -371,7 +371,7 @@
   </style>
 </head>
 <body>
-    <nav aria-label="Hauptnavigation">
+  <nav aria-label="Hauptnavigation">
     <span class="title">Leitstand</span>
     <a href="/">Home</a>
     <a href="/bureau">Bureau</a>

--- a/src/views/timeline.ejs
+++ b/src/views/timeline.ejs
@@ -371,13 +371,18 @@
   </style>
 </head>
 <body>
-  <nav>
+    <nav aria-label="Hauptnavigation">
     <span class="title">Leitstand</span>
     <a href="/">Home</a>
+    <a href="/bureau">Bureau</a>
+    <a href="/checkouts">Checkouts</a>
     <a href="/observatory">Observatorium</a>
+    <a href="/ecosystem-map">Ecosystem Map</a>
+    <a href="/repobriefs">RepoBriefs</a>
     <a href="/anatomy">Anatomie</a>
-    <a href="/timeline" class="active">Zeitachse</a>
+    <a href="/timeline" class="active" aria-current="page">Zeitachse</a>
     <a href="/insights">Erkenntnisse</a>
+    <a href="/reflexion">Reflexion</a>
     <a href="/ops">Ops</a>
   </nav>
 

--- a/tests/views/navigation.test.ts
+++ b/tests/views/navigation.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const canonicalRoutes = [
+  '/',
+  '/bureau',
+  '/checkouts',
+  '/observatory',
+  '/ecosystem-map',
+  '/repobriefs',
+  '/anatomy',
+  '/timeline',
+  '/insights',
+  '/reflexion',
+  '/ops',
+];
+
+const navViews: Array<{ file: string; active?: string }> = [
+  { file: 'index.ejs', active: '/' },
+  { file: 'bureau.ejs', active: '/bureau' },
+  { file: 'checkouts.ejs', active: '/checkouts' },
+  { file: 'observatory.ejs', active: '/observatory' },
+  { file: 'ecosystem-map.ejs', active: '/ecosystem-map' },
+  { file: 'repobriefs.ejs', active: '/repobriefs' },
+  { file: 'anatomy.ejs', active: '/anatomy' },
+  { file: 'timeline.ejs', active: '/timeline' },
+  { file: 'insights.ejs', active: '/insights' },
+  { file: 'reflexion.ejs', active: '/reflexion' },
+  { file: 'ops.ejs', active: '/ops' },
+  { file: 'intent.ejs' },
+];
+
+function readView(file: string): string {
+  return readFileSync(join(process.cwd(), 'src', 'views', file), 'utf-8');
+}
+
+function navBlock(html: string): string {
+  const match = html.match(/<nav[^>]*aria-label="Hauptnavigation"[^>]*>[\s\S]*?<\/nav>/);
+  if (!match) throw new Error('missing canonical navigation block');
+  return match[0];
+}
+
+describe('canonical navigation parity', () => {
+  it.each(navViews)('$file exposes the canonical read-only route set', ({ file }) => {
+    const nav = navBlock(readView(file));
+    for (const route of canonicalRoutes) {
+      expect(nav).toContain(`href="${route}"`);
+    }
+  });
+
+  it.each(navViews.filter((view) => view.active))('$file marks only its active route', ({ file, active }) => {
+    const nav = navBlock(readView(file));
+    const activeMatches = [...nav.matchAll(/<a href="([^"]+)" class="active" aria-current="page">/g)].map((match) => match[1]);
+    expect(activeMatches).toEqual([active]);
+  });
+
+  it('canonical navigation contains links only and no action forms', () => {
+    for (const view of navViews) {
+      const nav = navBlock(readView(view.file));
+      expect(nav).not.toContain('<form');
+      expect(nav).not.toContain('method="post"');
+      expect(nav).not.toContain('data-action');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Implements `LOO-V1-T004` navigation parity:

- all nav-bearing Leitstand views now expose the same canonical read-only route set
- `/bureau` and `/checkouts` are reachable from older primary views
- active page marker uses a single active route with `aria-current="page"`
- navigation blocks contain links only, no forms or action hooks
- adds `tests/views/navigation.test.ts` to guard route parity and active-state behavior

## Evidence

Local checks:
- plain Node nav parity smoke passed
- `NODE_OPTIONS=--jitless pnpm lint` passed
- `NODE_OPTIONS=--jitless pnpm typecheck` passed
- `NODE_OPTIONS=--jitless pnpm build` passed
- `python3 scripts/ai_context/validate_ai_context.py --file .ai-context.yml` passed
- `bash scripts/ci/observer-invariant-guard.sh` passed
- `bash scripts/ci/docs-relations-guard.sh` passed
- `bash scripts/ci/generated-files-guard.sh` passed
- `bash scripts/ci/check-drift-gates.sh` passed

Known local limitation:
- full Vitest remains delegated to CI because the Heim-PC local Node/V8 runtime crashes without `--jitless`, while Vitest/Vite needs WebAssembly.

## Boundary

This PR changes navigation only. It does not add POST actions, task dispatch, checkout cleanup, runtime mutation, or deployment behavior.
