### PR TITLE
docs: define Leitstand static mirror boundary

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,11 +3,12 @@
 # It acts strictly as a "Mode B" public mirror/preview.
 # It does NOT represent the canonical Mode A internal runtime.
 # Consequently, dynamic endpoints (/events, /ops) are not available here.
+# GitHub Pages is intentionally manual-only. Cloudflare Pages is the primary
+# static preview path; GitHub Pages must not keep main red when the repository
+# has no enabled Pages environment.
 name: Deploy to Pages
 
 on:
-  push:
-    branches: ["main"]
   workflow_dispatch:
 
 permissions:

--- a/docs/decisions/static-mirror-boundary.md
+++ b/docs/decisions/static-mirror-boundary.md
@@ -1,0 +1,52 @@
+---
+id: docs.decisions.static-mirror-boundary
+title: Leitstand Static Mirror Boundary
+status: active
+doc_type: decision
+canonicality: canonical
+summary: >
+  Defines the supported route set and GitHub Pages boundary for Leitstand Mode B static mirrors.
+---
+
+# Leitstand Static Mirror Boundary
+
+## Decision
+
+Leitstand Mode B is a **public static mirror / preview**, not the canonical runtime.
+
+The current static build supports exactly these routes:
+
+- `/`
+- `/observatory`
+- `/intent`
+
+`pnpm build:static` emits `dist/site/_static-boundary.json` with this supported route set and the explicitly dynamic-only routes.
+
+## Dynamic-only routes
+
+These routes are intentionally not part of the current static mirror:
+
+- `/events` — runtime ingestion endpoint.
+- `/ops` — runtime ACS viewer and optional job fallback.
+- `/bureau` — execution-axis snapshot view, runtime-rendered in Mode A until static artifact parity is implemented.
+- `/checkouts` — checkout inventory view, runtime-rendered in Mode A until static artifact parity is implemented.
+- `/ecosystem-map` — Cabinet artifact projection, runtime-rendered until static artifact parity is implemented.
+- `/repobriefs` — RepoBrief bundle index view, runtime-rendered until static artifact parity is implemented.
+- `/anatomy`, `/insights`, `/timeline`, `/reflexion` — controller-backed views with runtime/time-window semantics or artifact freshness contracts not yet represented by the static build.
+
+## GitHub Pages boundary
+
+GitHub Pages is **manual-only**. The workflow remains available for explicit Mode B smoke runs, but it is not triggered on every `main` push.
+
+Cloudflare Pages remains the primary static preview surface. A missing or disabled GitHub Pages environment must not keep `main` red.
+
+## Non-claims
+
+This decision does not establish:
+
+- canonical runtime availability;
+- `/events` ingestion availability;
+- `/ops` runtime or ACS fallback behavior;
+- Bureau task truth;
+- Grabowski checkout truth;
+- route parity between Mode A and Mode B.

--- a/docs/deploy-cloudflare.md
+++ b/docs/deploy-cloudflare.md
@@ -11,7 +11,7 @@ summary: >
 # Deploying Leitstand to Cloudflare Pages
 
 > **Deployment Mode: B (Public Static Mirror)**
-> This mode acts purely as a static read-only mirror. Dynamic endpoints (`/events`, `/ops` fallbacks) are inactive.
+> This mode acts purely as a static read-only mirror. Dynamic endpoints (`/events`, `/ops` fallbacks) are inactive. The supported static routes are `/`, `/observatory` and `/intent`; `dist/site/_static-boundary.json` records the exact route boundary.
 
 Leitstand relies on a deterministic build process where data artifacts are fetched *before* the static site generation.
 
@@ -34,7 +34,7 @@ The build command must explicitly fetch both artifacts before generating the sta
 pnpm build:cf
 ```
 
-This command runs `fetch:observatory` and `fetch:insights` (populating the `artifacts/` directory) followed by `build:static`.
+This command runs `fetch:observatory` and `fetch:insights` (populating the `artifacts/` directory) followed by `build:static`. The static build emits `dist/site/_static-boundary.json`; it is the machine-readable contract for the route set.
 
 ## Strict Mode Behavior
 
@@ -51,3 +51,7 @@ A `_meta.json` file is also generated in `artifacts/` to provide a forensic trai
 
 1.  **Strict Mode without Fetch**: Setting `LEITSTAND_STRICT=1` but running only `pnpm build:static` (skipping fetch). This will cause the build to fail because artifacts are missing. **Always use `pnpm build:cf`**.
 2.  **Missing URLs**: If `OBSERVATORY_URL` or `INSIGHTS_DAILY_URL` are not set, the fetch step will fallback to defaults (GitHub Releases), which might not be desired for private setups.
+
+## GitHub Pages Boundary
+
+GitHub Pages is intentionally manual-only in this repository. The workflow exists as an optional smoke for Mode B output, not as the primary public mirror and not as evidence of Mode A runtime health. Main pushes must not depend on a repository-level Pages environment being enabled.

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,7 @@ Tools that enforce the rules automatically.
 ## 4. Architecture Decisions & Blueprints
 
 - [WGX Leitstand Decision](decisions/wgx-leitstand.md)
+- [Static Mirror Boundary Decision](decisions/static-mirror-boundary.md)
 - [Leitstand Manifest Blueprint](blueprints/leitstand_manifest.md)
 - [Leitstand Visualization Blueprint](blueprints/leitstand_visualization.md)
 - [Ecosystem Map View Blueprint](blueprints/ecosystem-map-view.md)
@@ -65,7 +66,8 @@ Each Leitstand deployment instance operates in exactly one of two explicit modes
 
 **Mode B — Public Static Mirror / Preview**
 - Scope: optional, read-only public mirror or PR preview.
-- Topology: static host (Cloudflare Pages, GitHub Pages).
-- Features: static build only. No active runtime, no `/events` ingestion, no `/ops` dynamic fallbacks.
+- Topology: static host. Cloudflare Pages is the primary preview path; GitHub Pages is manual-only.
+- Supported routes: `/`, `/observatory`, `/intent`; the build emits `dist/site/_static-boundary.json` with the exact route contract.
+- Dynamic-only routes: `/events`, `/ops`, `/bureau`, `/checkouts`, `/ecosystem-map`, `/repobriefs`, `/anatomy`, `/insights`, `/timeline`, `/reflexion`.
 - Nature: derived projection of Mode A; may be stale and is not an operational source of truth.
-- Documentation: [Cloudflare Deployment](deploy-cloudflare.md), [../.github/workflows/pages.yml](../.github/workflows/pages.yml)
+- Documentation: [Static Mirror Boundary Decision](decisions/static-mirror-boundary.md), [Cloudflare Deployment](deploy-cloudflare.md), [../.github/workflows/pages.yml](../.github/workflows/pages.yml)

--- a/scripts/build-static.mjs
+++ b/scripts/build-static.mjs
@@ -6,6 +6,61 @@ const ROOT = process.cwd();
 const VIEWS = join(ROOT, "src", "views");
 const OUT = join(ROOT, "dist", "site");
 
+
+const STATIC_MIRROR_SUPPORTED_ROUTES = [
+  { route: "/", output: "index.html", view: "index", reason: "static landing page" },
+  { route: "/observatory", output: "observatory/index.html", view: "observatory", reason: "static observatory projection" },
+  { route: "/intent", output: "intent/index.html", view: "intent", reason: "fixture-backed static intent page" },
+];
+
+const STATIC_MIRROR_DYNAMIC_ONLY_ROUTES = [
+  { route: "/events", reason: "runtime ingestion endpoint" },
+  { route: "/ops", reason: "runtime ACS viewer and optional job fallback" },
+  { route: "/bureau", reason: "execution-axis snapshot view remains runtime-rendered in Mode A" },
+  { route: "/checkouts", reason: "checkout inventory view remains runtime-rendered in Mode A" },
+  { route: "/ecosystem-map", reason: "Cabinet artifact projection is runtime-rendered until static artifact parity is implemented" },
+  { route: "/repobriefs", reason: "RepoBrief bundle index view is runtime-rendered until static artifact parity is implemented" },
+  { route: "/anatomy", reason: "controller-backed structure view is runtime-rendered until static artifact parity is implemented" },
+  { route: "/insights", reason: "controller-backed insights view is runtime-rendered until static artifact parity is implemented" },
+  { route: "/timeline", reason: "time-windowed Chronik view is runtime-rendered" },
+  { route: "/reflexion", reason: "controller-backed reflexion view is runtime-rendered until static artifact parity is implemented" },
+];
+
+function buildTimestamp() {
+  const rawEpoch = process.env.SOURCE_DATE_EPOCH;
+  if (rawEpoch && /^\d+$/.test(rawEpoch)) {
+    return new Date(Number(rawEpoch) * 1000).toISOString();
+  }
+  return new Date().toISOString();
+}
+
+async function writeStaticBoundaryManifest() {
+  await writeFile(
+    join(OUT, "_static-boundary.json"),
+    JSON.stringify(
+      {
+        schemaVersion: 1,
+        kind: "leitstand_static_mirror_boundary",
+        generatedAt: buildTimestamp(),
+        deploymentMode: "Mode B — Public Static Mirror / Preview",
+        supportedRoutes: STATIC_MIRROR_SUPPORTED_ROUTES,
+        dynamicOnlyRoutes: STATIC_MIRROR_DYNAMIC_ONLY_ROUTES,
+        doesNotEstablish: [
+          "canonical_runtime_availability",
+          "events_ingestion",
+          "ops_runtime_fallback",
+          "bureau_snapshot_truth",
+          "grabowski_checkout_truth",
+          "route_parity_with_mode_a",
+        ],
+      },
+      null,
+      2,
+    ) + "\n",
+    "utf-8",
+  );
+}
+
 class EmptyFileError extends Error {
   code = 'EMPTY_FILE';
   constructor(message) {
@@ -344,6 +399,8 @@ async function main() {
 
   await mkdir(join(OUT, "intent"), { recursive: true });
   await renderTo(join(OUT, "intent", "index.html"), "intent", { data: intentData });
+
+  await writeStaticBoundaryManifest();
 
   console.log("Static site generated at:", OUT);
 }


### PR DESCRIPTION
## Summary

Implements `LOO-V1-T006` by making the Mode B static mirror boundary explicit:

- documents the static mirror route decision in `docs/decisions/static-mirror-boundary.md`
- records the supported static route set in `dist/site/_static-boundary.json` during `build:static`
- keeps `/`, `/observatory`, and `/intent` as the supported static routes
- explicitly marks `/events`, `/ops`, `/bureau`, `/checkouts`, `/ecosystem-map`, `/repobriefs`, `/anatomy`, `/insights`, `/timeline`, and `/reflexion` as dynamic-only for now
- changes GitHub Pages to manual-only so a missing/disabled Pages environment cannot keep `main` red
- documents Cloudflare Pages as the primary static preview path

## Evidence

Local checks:
- `NODE_OPTIONS=--jitless pnpm lint` passed
- `NODE_OPTIONS=--jitless pnpm typecheck` passed
- `NODE_OPTIONS=--jitless pnpm build` passed
- `SOURCE_DATE_EPOCH=0 LEITSTAND_STRICT=0 NODE_OPTIONS=--jitless pnpm build:static` passed
- static output contains `index.html`, `observatory/index.html`, `intent/index.html`, `_static-boundary.json`
- `_static-boundary.json` sanity check passed
- GitHub Pages trigger check passed: no `branches: ["main"]`, `workflow_dispatch:` present
- `python3 scripts/ai_context/validate_ai_context.py --file .ai-context.yml` passed
- `bash scripts/ci/observer-invariant-guard.sh` passed
- `bash scripts/ci/docs-relations-guard.sh` passed
- `bash scripts/ci/generated-files-guard.sh` passed
- `bash scripts/ci/check-drift-gates.sh` passed

## Boundary

This does not deploy runtime, enable GitHub Pages, establish route parity with Mode A, or establish Bureau/Grabowski snapshot truth.
