### PR TITLE
feat: add runtime health receipt

### DIFF
--- a/docs/runbooks/operator-snapshots.md
+++ b/docs/runbooks/operator-snapshots.md
@@ -83,6 +83,8 @@ The controller thresholds are encoded in:
 - `src/controllers/bureau.ts` — 6 hour stale threshold.
 - `src/controllers/checkouts.ts` — 24 hour stale threshold.
 
+The runtime health receipt at `/health` is intentionally stricter: it warns when either operator snapshot is older than 20 minutes. The running service uses this tighter threshold to detect bridge/timer drift early; the human-facing boards remain renderable for longer.
+
 A stale snapshot remains renderable, but it is not a green status. Operators should refresh the raw producer export and rerun the bridge before treating the view as current.
 
 ## Failure semantics

--- a/docs/runtime.contract.md
+++ b/docs/runtime.contract.md
@@ -36,8 +36,12 @@ Der Leitstand ist ausschließlich unter folgendem FQDN erreichbar:
 Der Dienst gilt als gesund ("grün"), wenn:
 
 - **HTTP Status:** 200 OK auf `/` und `/health`
+- **Health Receipt:** `/health` liefert `kind=leitstand_runtime_health_receipt` und `status=ok`
+- **Snapshots:** Bureau- und Checkout-Snapshots sind vorhanden und nach Runtime-Schwelle frisch
 - **Host:** Kein Mixed Content (HTTPS-Only Policy)
 - **Zugriff:** Direkter IP-Zugriff ist nicht Teil des Contracts; Zugriff erfolgt per FQDN Host-Match via Reverse Proxy.
+
+`/health` ist eine read-only In-Process-Fläche. Sie belegt, dass der aktuelle Node-Prozess antwortet und seine lokalen Snapshots/Git-Daten lesen kann. Sie belegt nicht DNS-Korrektheit, Caddyfile-Persistenz, Task-Wahrheit oder externe Erreichbarkeit; diese Punkte müssen durch Gateway-/DNS-Smokes belegt werden.
 
 ## 5. Deployment-Status
 

--- a/src/runtimeHealth.ts
+++ b/src/runtimeHealth.ts
@@ -1,0 +1,326 @@
+import { readFile, stat } from 'node:fs/promises';
+import { join, relative, resolve } from 'node:path';
+
+export type RuntimeHealthStatus = 'ok' | 'warn' | 'fail';
+export type RuntimeHealthCheckStatus = RuntimeHealthStatus | 'unknown';
+
+type SnapshotKind = 'bureau_tasks' | 'checkout_inventory';
+
+export interface RuntimeHealthCheck {
+  status: RuntimeHealthCheckStatus;
+  reason: string;
+}
+
+export interface RuntimeHealthSnapshot {
+  status: RuntimeHealthCheckStatus;
+  reason: string;
+  path: string;
+  path_display: string;
+  exists: boolean;
+  generated_at: string | null;
+  mtime: string | null;
+  age_seconds: number | null;
+  stale_after_seconds: number;
+  kind: string | null;
+  record_count: number | null;
+}
+
+export interface RuntimeHealthReceipt {
+  schemaVersion: 1;
+  kind: 'leitstand_runtime_health_receipt';
+  generatedAt: string;
+  status: RuntimeHealthStatus;
+  runtime: {
+    pid: number;
+    uptime_seconds: number;
+    node_version: string;
+    cwd: string;
+  };
+  git: {
+    status: RuntimeHealthCheckStatus;
+    reason: string;
+    head: string | null;
+    branch: string | null;
+    source_path: string;
+    source_path_display: string;
+  };
+  snapshots: Record<SnapshotKind, RuntimeHealthSnapshot>;
+  checks: Record<string, RuntimeHealthCheck>;
+  ingress: {
+    canonical_url: string;
+    status: 'not_checked';
+    reason: string;
+  };
+  doesNotEstablish: string[];
+}
+
+export interface RuntimeHealthOptions {
+  cwd?: string;
+  now?: Date;
+  bureauSnapshotPath?: string;
+  checkoutSnapshotPath?: string;
+  staleAfterMs?: number;
+}
+
+const SNAPSHOT_STALE_AFTER_MS = 20 * 60 * 1000;
+const GIT_HEAD_RE = /^[0-9a-f]{40}$/;
+
+const DOES_NOT_ESTABLISH = [
+  'external_ingress_reachable',
+  'dns_correctness',
+  'caddyfile_persistence',
+  'bureau_task_truth',
+  'checkout_cleanup_authority',
+  'operator_action_authority',
+];
+
+function displayPath(cwd: string, path: string): string {
+  const rel = relative(resolve(cwd), resolve(path));
+  if (rel && !rel.startsWith('..') && !rel.startsWith('/')) return rel;
+  return '<external path>';
+}
+
+function snapshotPathFromEnv(kind: SnapshotKind, cwd: string): string {
+  if (kind === 'bureau_tasks') {
+    return process.env.LEITSTAND_BUREAU_SNAPSHOT_PATH || join(cwd, 'artifacts', 'bureau-tasks.json');
+  }
+  return process.env.LEITSTAND_CHECKOUT_SNAPSHOT_PATH || join(cwd, 'artifacts', 'checkout-inventory.json');
+}
+
+function snapshotRecordCount(kind: SnapshotKind, raw: unknown): number | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const snapshot = raw as { tasks?: unknown; checkouts?: unknown };
+  if (kind === 'bureau_tasks') return Array.isArray(snapshot.tasks) ? snapshot.tasks.length : null;
+  return Array.isArray(snapshot.checkouts) ? snapshot.checkouts.length : null;
+}
+
+function snapshotGeneratedAt(raw: unknown): string | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const snapshot = raw as { generatedAt?: unknown; generated_at?: unknown };
+  if (typeof snapshot.generatedAt === 'string') return snapshot.generatedAt;
+  if (typeof snapshot.generated_at === 'string') return snapshot.generated_at;
+  return null;
+}
+
+function snapshotKind(raw: unknown): string | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const snapshot = raw as { kind?: unknown };
+  return typeof snapshot.kind === 'string' ? snapshot.kind : null;
+}
+
+function expectedSnapshotKind(kind: SnapshotKind): string {
+  if (kind === 'bureau_tasks') return 'leitstand_bureau_task_snapshot';
+  return 'leitstand_checkout_inventory';
+}
+
+function msAge(now: Date, generatedAt: string | null, mtimeMs: number): number | null {
+  const sourceMs = generatedAt ? Date.parse(generatedAt) : mtimeMs;
+  if (!Number.isFinite(sourceMs)) return null;
+  return Math.max(0, now.getTime() - sourceMs);
+}
+
+async function readSnapshotHealth(
+  kind: SnapshotKind,
+  path: string,
+  cwd: string,
+  now: Date,
+  staleAfterMs: number,
+): Promise<RuntimeHealthSnapshot> {
+  const resolvedPath = resolve(path);
+  const base = {
+    path: resolvedPath,
+    path_display: displayPath(cwd, resolvedPath),
+    stale_after_seconds: Math.round(staleAfterMs / 1000),
+  };
+
+  try {
+    const fileStat = await stat(resolvedPath);
+    const text = await readFile(resolvedPath, 'utf-8');
+    const parsed = JSON.parse(text) as unknown;
+    const generatedAt = snapshotGeneratedAt(parsed);
+    const ageMs = msAge(now, generatedAt, fileStat.mtimeMs);
+    const recordCount = snapshotRecordCount(kind, parsed);
+    const kindValue = snapshotKind(parsed);
+
+    if (kindValue !== expectedSnapshotKind(kind) || recordCount === null) {
+      return {
+        ...base,
+        status: 'fail',
+        reason: 'snapshot_contract_mismatch',
+        exists: true,
+        generated_at: generatedAt,
+        mtime: fileStat.mtime.toISOString(),
+        age_seconds: ageMs === null ? null : Math.round(ageMs / 1000),
+        kind: kindValue,
+        record_count: recordCount,
+      };
+    }
+
+    if (ageMs === null) {
+      return {
+        ...base,
+        status: 'warn',
+        reason: 'snapshot_timestamp_unparseable',
+        exists: true,
+        generated_at: generatedAt,
+        mtime: fileStat.mtime.toISOString(),
+        age_seconds: null,
+        kind: kindValue,
+        record_count: recordCount,
+      };
+    }
+
+    return {
+      ...base,
+      status: ageMs <= staleAfterMs ? 'ok' : 'warn',
+      reason: ageMs <= staleAfterMs ? 'snapshot_fresh' : 'snapshot_stale',
+      exists: true,
+      generated_at: generatedAt,
+      mtime: fileStat.mtime.toISOString(),
+      age_seconds: Math.round(ageMs / 1000),
+      kind: kindValue,
+      record_count: recordCount,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+    const missing = message.includes('enoent') || message.includes('no such file');
+    const invalidJson = message.includes('json') || message.includes('unexpected');
+    let mtime: string | null = null;
+    if (!missing) {
+      try {
+        mtime = (await stat(resolvedPath)).mtime.toISOString();
+      } catch {
+        mtime = null;
+      }
+    }
+    return {
+      ...base,
+      status: 'fail',
+      reason: missing ? 'snapshot_missing' : invalidJson ? 'snapshot_json_invalid' : 'snapshot_unreadable',
+      exists: !missing,
+      generated_at: null,
+      mtime,
+      age_seconds: null,
+      kind: null,
+      record_count: null,
+    };
+  }
+}
+
+function parseGitdirFile(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith('gitdir:')) return null;
+  return trimmed.slice('gitdir:'.length).trim();
+}
+
+async function resolveGitDir(cwd: string): Promise<string> {
+  const dotGitPath = join(cwd, '.git');
+  try {
+    const dotGitStat = await stat(dotGitPath);
+    if (dotGitStat.isDirectory()) return dotGitPath;
+  } catch {
+    return dotGitPath;
+  }
+
+  const gitdir = parseGitdirFile(await readFile(dotGitPath, 'utf-8'));
+  if (!gitdir) return dotGitPath;
+  return resolve(cwd, gitdir);
+}
+
+async function readGitHealth(cwd: string): Promise<RuntimeHealthReceipt['git']> {
+  const gitDir = await resolveGitDir(cwd);
+  const headPath = join(gitDir, 'HEAD');
+  const base = {
+    source_path: headPath,
+    source_path_display: displayPath(cwd, headPath),
+  };
+
+  try {
+    const rawHead = (await readFile(headPath, 'utf-8')).trim();
+    if (rawHead.startsWith('ref:')) {
+      const ref = rawHead.slice('ref:'.length).trim();
+      const refPath = join(gitDir, ref);
+      const head = (await readFile(refPath, 'utf-8')).trim();
+      const branch = ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref;
+      return {
+        ...base,
+        status: GIT_HEAD_RE.test(head) ? 'ok' : 'warn',
+        reason: GIT_HEAD_RE.test(head) ? 'git_head_resolved' : 'git_head_unexpected_format',
+        head,
+        branch,
+      };
+    }
+
+    return {
+      ...base,
+      status: GIT_HEAD_RE.test(rawHead) ? 'ok' : 'warn',
+      reason: GIT_HEAD_RE.test(rawHead) ? 'git_detached_head_resolved' : 'git_head_unexpected_format',
+      head: rawHead || null,
+      branch: null,
+    };
+  } catch {
+    return {
+      ...base,
+      status: 'warn',
+      reason: 'git_head_unavailable',
+      head: null,
+      branch: null,
+    };
+  }
+}
+
+function summarizeStatus(checks: RuntimeHealthCheckStatus[]): RuntimeHealthStatus {
+  if (checks.includes('fail')) return 'fail';
+  if (checks.includes('warn') || checks.includes('unknown')) return 'warn';
+  return 'ok';
+}
+
+function checkFromSnapshot(snapshot: RuntimeHealthSnapshot): RuntimeHealthCheck {
+  return { status: snapshot.status, reason: snapshot.reason };
+}
+
+export async function getRuntimeHealthData(options: RuntimeHealthOptions = {}): Promise<RuntimeHealthReceipt> {
+  const cwd = resolve(options.cwd || process.cwd());
+  const now = options.now || new Date();
+  const staleAfterMs = options.staleAfterMs ?? SNAPSHOT_STALE_AFTER_MS;
+  const bureauPath = options.bureauSnapshotPath || snapshotPathFromEnv('bureau_tasks', cwd);
+  const checkoutPath = options.checkoutSnapshotPath || snapshotPathFromEnv('checkout_inventory', cwd);
+
+  const [git, bureauSnapshot, checkoutSnapshot] = await Promise.all([
+    readGitHealth(cwd),
+    readSnapshotHealth('bureau_tasks', bureauPath, cwd, now, staleAfterMs),
+    readSnapshotHealth('checkout_inventory', checkoutPath, cwd, now, staleAfterMs),
+  ]);
+
+  const checks: RuntimeHealthReceipt['checks'] = {
+    server_process: { status: 'ok', reason: 'health_endpoint_served_by_current_process' },
+    git_head: { status: git.status, reason: git.reason },
+    bureau_snapshot: checkFromSnapshot(bureauSnapshot),
+    checkout_snapshot: checkFromSnapshot(checkoutSnapshot),
+  };
+
+  return {
+    schemaVersion: 1,
+    kind: 'leitstand_runtime_health_receipt',
+    generatedAt: now.toISOString(),
+    status: summarizeStatus(Object.values(checks).map((check) => check.status)),
+    runtime: {
+      pid: process.pid,
+      uptime_seconds: Math.round(process.uptime()),
+      node_version: process.version,
+      cwd,
+    },
+    git,
+    snapshots: {
+      bureau_tasks: bureauSnapshot,
+      checkout_inventory: checkoutSnapshot,
+    },
+    checks,
+    ingress: {
+      canonical_url: 'https://leitstand.heimgewebe.home.arpa/',
+      status: 'not_checked',
+      reason: 'in_process_health_receipt_does_not_probe_dns_or_caddy',
+    },
+    doesNotEstablish: DOES_NOT_ESTABLISH,
+  };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,6 +17,7 @@ import { getEcosystemMapData } from './controllers/ecosystemMap.js';
 import { getRepoBriefData } from './controllers/repoBrief.js';
 import { getBureauData } from './controllers/bureau.js';
 import { getCheckoutData } from './controllers/checkouts.js';
+import { getRuntimeHealthData } from './runtimeHealth.js';
 import { getEventFamily, listEventFamilies } from './utils/eventKind.js';
 import fs from 'fs';
 import { validatePlexerReport } from './validation/validators.js';
@@ -291,6 +292,22 @@ app.get('/ops', (_req, res) => {
     allowJobFallback: envConfig.allowJobFallback,
     acsViewerToken: envConfig.acsViewerToken
   });
+});
+
+// Runtime Health Receipt – read-only in-process proof surface for service and snapshot freshness.
+app.get('/health', async (_req, res) => {
+  try {
+    const data = await getRuntimeHealthData();
+    res.status(data.status === 'fail' ? 503 : 200).send(data);
+  } catch (error) {
+    console.error('[Health] Error:', error);
+    res.status(500).send({
+      schemaVersion: 1,
+      kind: 'leitstand_runtime_health_receipt',
+      status: 'fail',
+      reason: 'runtime_health_unexpected_error',
+    });
+  }
 });
 
 app.get('/', async (_req, res) => {

--- a/tests/runtimeHealth.test.ts
+++ b/tests/runtimeHealth.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { getRuntimeHealthData } from '../src/runtimeHealth.js';
+
+describe('runtime health receipt', () => {
+  let testDir: string;
+  let artifactsDir: string;
+  const now = new Date('2026-07-08T18:00:00.000Z');
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'leitstand-runtime-health-'));
+    artifactsDir = join(testDir, 'artifacts');
+    await mkdir(artifactsDir, { recursive: true });
+    await mkdir(join(testDir, '.git', 'refs', 'heads'), { recursive: true });
+    await writeFile(join(testDir, '.git', 'HEAD'), 'ref: refs/heads/main\n', 'utf-8');
+    await writeFile(join(testDir, '.git', 'refs', 'heads', 'main'), `${'a'.repeat(40)}\n`, 'utf-8');
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  async function writeSnapshots(generatedAt: string): Promise<void> {
+    await writeFile(
+      join(artifactsDir, 'bureau-tasks.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        kind: 'leitstand_bureau_task_snapshot',
+        generatedAt,
+        tasks: [{ id: 'T1', title: 'Task one', state: 'queued' }],
+      }),
+      'utf-8',
+    );
+    await writeFile(
+      join(artifactsDir, 'checkout-inventory.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        kind: 'leitstand_checkout_inventory',
+        generatedAt,
+        checkouts: [{ path: '/tmp/repo', retention: 'retained' }],
+      }),
+      'utf-8',
+    );
+  }
+
+  it('reports ok when git and operator snapshots are fresh', async () => {
+    await writeSnapshots('2026-07-08T17:55:00.000Z');
+
+    const receipt = await getRuntimeHealthData({ cwd: testDir, now, staleAfterMs: 20 * 60 * 1000 });
+
+    expect(receipt.status).toBe('ok');
+    expect(receipt.kind).toBe('leitstand_runtime_health_receipt');
+    expect(receipt.git.head).toBe('a'.repeat(40));
+    expect(receipt.git.branch).toBe('main');
+    expect(receipt.snapshots.bureau_tasks.status).toBe('ok');
+    expect(receipt.snapshots.bureau_tasks.record_count).toBe(1);
+    expect(receipt.snapshots.checkout_inventory.status).toBe('ok');
+    expect(receipt.ingress.status).toBe('not_checked');
+    expect(receipt.doesNotEstablish).toContain('dns_correctness');
+  });
+
+  it('warns when snapshots are stale', async () => {
+    await writeSnapshots('2026-07-08T17:00:00.000Z');
+
+    const receipt = await getRuntimeHealthData({ cwd: testDir, now, staleAfterMs: 20 * 60 * 1000 });
+
+    expect(receipt.status).toBe('warn');
+    expect(receipt.snapshots.bureau_tasks.status).toBe('warn');
+    expect(receipt.snapshots.bureau_tasks.reason).toBe('snapshot_stale');
+    expect(receipt.snapshots.checkout_inventory.status).toBe('warn');
+  });
+
+
+  it('fails when a snapshot has the wrong contract kind', async () => {
+    await writeFile(
+      join(artifactsDir, 'bureau-tasks.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        kind: 'wrong_kind',
+        generatedAt: '2026-07-08T17:55:00.000Z',
+        tasks: [],
+      }),
+      'utf-8',
+    );
+    await writeFile(
+      join(artifactsDir, 'checkout-inventory.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        kind: 'leitstand_checkout_inventory',
+        generatedAt: '2026-07-08T17:55:00.000Z',
+        checkouts: [],
+      }),
+      'utf-8',
+    );
+
+    const receipt = await getRuntimeHealthData({ cwd: testDir, now, staleAfterMs: 20 * 60 * 1000 });
+
+    expect(receipt.status).toBe('fail');
+    expect(receipt.snapshots.bureau_tasks.status).toBe('fail');
+    expect(receipt.snapshots.bureau_tasks.reason).toBe('snapshot_contract_mismatch');
+    expect(receipt.snapshots.bureau_tasks.exists).toBe(true);
+  });
+
+  it('fails when a required snapshot is missing', async () => {
+    await writeFile(
+      join(artifactsDir, 'checkout-inventory.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        kind: 'leitstand_checkout_inventory',
+        generatedAt: '2026-07-08T17:55:00.000Z',
+        checkouts: [],
+      }),
+      'utf-8',
+    );
+
+    const receipt = await getRuntimeHealthData({ cwd: testDir, now, staleAfterMs: 20 * 60 * 1000 });
+
+    expect(receipt.status).toBe('fail');
+    expect(receipt.snapshots.bureau_tasks.status).toBe('fail');
+    expect(receipt.snapshots.bureau_tasks.reason).toBe('snapshot_missing');
+  });
+});

--- a/tests/serverHealth.test.ts
+++ b/tests/serverHealth.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import request from 'supertest';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { app } from '../src/server.js';
+
+describe('GET /health', () => {
+  let testDir: string;
+  let bureauSnapshotPath: string;
+  let checkoutSnapshotPath: string;
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'leitstand-server-health-'));
+    await mkdir(testDir, { recursive: true });
+    bureauSnapshotPath = join(testDir, 'bureau-tasks.json');
+    checkoutSnapshotPath = join(testDir, 'checkout-inventory.json');
+    const generatedAt = new Date().toISOString();
+    await writeFile(
+      bureauSnapshotPath,
+      JSON.stringify({
+        schemaVersion: 1,
+        kind: 'leitstand_bureau_task_snapshot',
+        generatedAt,
+        tasks: [],
+      }),
+      'utf-8',
+    );
+    await writeFile(
+      checkoutSnapshotPath,
+      JSON.stringify({
+        schemaVersion: 1,
+        kind: 'leitstand_checkout_inventory',
+        generatedAt,
+        checkouts: [],
+      }),
+      'utf-8',
+    );
+    vi.stubEnv('LEITSTAND_BUREAU_SNAPSHOT_PATH', bureauSnapshotPath);
+    vi.stubEnv('LEITSTAND_CHECKOUT_SNAPSHOT_PATH', checkoutSnapshotPath);
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it('returns a read-only runtime health receipt', async () => {
+    const response = await request(app).get('/health');
+
+    expect(response.status).toBe(200);
+    expect(response.body.kind).toBe('leitstand_runtime_health_receipt');
+    expect(response.body.status).toBe('ok');
+    expect(response.body.checks.server_process.status).toBe('ok');
+    expect(response.body.snapshots.bureau_tasks.path).toBe(bureauSnapshotPath);
+    expect(response.body.snapshots.checkout_inventory.path).toBe(checkoutSnapshotPath);
+    expect(response.body.ingress.status).toBe('not_checked');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a read-only runtime health receipt at `/health` for the canonical dynamic Leitstand runtime.

The receipt reports:

- current Node process metadata;
- Git branch/head resolution;
- Bureau task snapshot presence, contract shape and freshness;
- Grabowski checkout inventory presence, contract shape and freshness;
- explicit non-claims for DNS, Caddyfile persistence, task truth and action authority.

## Boundary

`/health` is intentionally in-process and read-only. It does not probe DNS/Caddy, does not call Bureau or Grabowski, and does not mutate local or remote state.

## Validation

Local validation on heim-pc:

- `NODE_OPTIONS=--jitless pnpm typecheck` ✅
- `NODE_OPTIONS=--jitless pnpm lint` ✅
- `NODE_OPTIONS=--jitless pnpm build` ✅
- `NODE_OPTIONS=--jitless pnpm run check:vendor-contracts` ✅
- `bash scripts/ci/repo-structure-guard.sh` ✅
- `bash scripts/ci/docs-relations-guard.sh` ✅
- `bash scripts/ci/generated-files-guard.sh` ✅
- `bash scripts/ci/check-drift-gates.sh` ✅
- `bash scripts/ci/check-runbook-invariants.sh` ✅
- `bash scripts/ci/observer-invariant-guard.sh` ✅
- `python3 scripts/ai_context/validate_ai_context.py --file .ai-context.yml` ✅
- `/health` endpoint smoke on local port 3108 ✅

Local Vitest note: heim-pc Node 22 crashes without `--jitless`; with `--jitless`, Vite/Vitest cannot start because WebAssembly is disabled. GitHub CI uses Node 20 and must be treated as the Vitest source of truth for this PR.

## Self-review

Self-review evidence was produced locally before commit:

- Base head: `7416c7360de3e1550383161c6c9d756727c6c854`
- Pre-commit diff SHA-256: `b5eab038ba02a5577823bf7076f31bc7aa290592ece4782f4b659a803bc82899`
- Self-review SHA-256: `85139fd2c66ddb199601b2b827128923afc3b0675cfc4131ccef0ce4436fd146`

Do not merge until GitHub CI has run the full Vitest suite successfully.
