### PR TITLE
fix: default Leitstand server binding to loopback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,11 @@
 
 # Server Configuration
 PORT=3000
+# Safe default for direct Node/systemd operation: loopback only.
+# Docker Compose overrides the in-container host explicitly; host exposure is controlled by its ports override.
+LEITSTAND_BIND_HOST=127.0.0.1
+# Wildcard hosts 0.0.0.0 and :: are rejected unless this is explicitly true.
+# LEITSTAND_ALLOW_WIDE_BIND=false
 
 # Strict Mode (enable in production)
 # LEITSTAND_STRICT=1

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -3,6 +3,11 @@
 
 # Server Configuration
 PORT=3000
+# Safe default for direct Node/systemd operation: loopback only.
+# Docker Compose overrides the in-container host explicitly; host exposure is controlled by its ports override.
+LEITSTAND_BIND_HOST=127.0.0.1
+# Wildcard hosts 0.0.0.0 and :: are rejected unless this is explicitly true.
+# LEITSTAND_ALLOW_WIDE_BIND=false
 
 # Strict Mode (enable in production)
 # LEITSTAND_STRICT=1

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -6,6 +6,11 @@ services:
       - "3000"
     env_file:
       - .env
+    environment:
+      # The process must accept traffic from the container network. Host/LAN
+      # exposure remains controlled exclusively by the selected ports override.
+      LEITSTAND_BIND_HOST: "0.0.0.0"
+      LEITSTAND_ALLOW_WIDE_BIND: "true"
     # Volumes removed to ensure production-grade immutability from built image.
     # Bind mounts are for development only.
     restart: unless-stopped

--- a/docs/runbooks/leitstand.md
+++ b/docs/runbooks/leitstand.md
@@ -58,7 +58,9 @@ The vendored files must be committed to the repository. The build process (`buil
 
 ## Deployment & Zugriff
 
-Der Leitstand wird via Docker Compose deployt und lauscht standardmäßig auf **localhost:3000** (sicherer Default).
+Der Leitstand lauscht bei direktem Node-/systemd-Betrieb standardmäßig auf **127.0.0.1:3000** (sicherer Default). Der Node-Server setzt diesen Host explizit über `LEITSTAND_BIND_HOST`; ein fehlender Host darf nicht implizit zu einer Wildcard-Bindung führen. Ein konkretes LAN-IP-Literal ist zulässig. `0.0.0.0` oder `::` werden nur zusammen mit `LEITSTAND_ALLOW_WIDE_BIND=true` akzeptiert.
+
+Im Docker-Betrieb bindet der Prozess innerhalb des isolierten Container-Netzes bewusst an `0.0.0.0` und setzt die Bestätigung explizit. Die tatsächliche Host-Exposition bleibt ausschließlich in den Compose-Overrides: `docker-compose.loopback.yml` publiziert auf `127.0.0.1`, `docker-compose.lan.yml` nur auf die ausdrücklich gesetzte `LEITSTAND_BIND_IP`.
 
 ### Standard Update & Start
 Der einzige empfohlene Einstiegspunkt für Updates und Neustarts ist das `scripts/leitstand-up` Skript.

--- a/docs/runbooks/ops.runbook.leitstand-gateway.updates.md
+++ b/docs/runbooks/ops.runbook.leitstand-gateway.updates.md
@@ -10,9 +10,9 @@ summary: >
 
 # ops.runbook.leitstand-gateway.updates
 
-Stand: 2026-02-03
+Stand: 2026-07-11
 Dokumentklasse: OPERATIV · PROZEDURAL
-Scope: Heimserver-only (Updates für compose.gateway.yml Stack)
+Scope: Leitstand-Gateway sowie direkter Node-/systemd- und Docker-Compose-Betrieb
 Owner: ops / Heimserver
 
 ## 1) Zweck
@@ -21,11 +21,16 @@ Dieses Runbook definiert die sichere Sequenz für Updates des Leitstand-Gateways
 Grundsatz:
 - Keine Auto-Updates by default.
 - Updates sind bewusst, manuell ausgelöst und auditierbar.
+- Direkter Node-/systemd-Betrieb bindet standardmäßig an `127.0.0.1`.
+- Wildcard-Bindungen (`0.0.0.0`, `::`) benötigen `LEITSTAND_ALLOW_WIDE_BIND=true`.
+- Docker darf intern bewusst an `0.0.0.0` binden; die Host-Exposition wird ausschließlich durch den gewählten Compose-Override begrenzt.
 
 ## 2) Voraussetzungen
-- Zugriff auf Heimserver via WireGuard oder LAN.
-- Pfad: `/opt/heimgewebe/gateway/`
-- Dateien: `compose.gateway.yml`, `Caddyfile` vorhanden.
+- Zugriff auf den Zielhost über den vorgesehenen privaten Administrationspfad.
+- Gateway-Pfad, falls verwendet: `/opt/heimgewebe/gateway/`.
+- Direkter Heim-PC-Pfad, falls verwendet: kanonischer Leitstand-Checkout und `leitstand.service`.
+- Vorherigen Unit-/Compose-Stand, laufenden Commit, Listener und letzte Logs als Rollbackbeleg sichern.
+- Kein Update, solange der Zielpfad dirty, der Rollbackstand unklar oder Port 3000 einem fremden Prozess zugeordnet ist.
 
 ## 3) Pfade
 Wähle den Pfad passend zu deiner Deployment-Strategie:
@@ -56,6 +61,42 @@ ss -lntp | grep -E ':(80|443)\b' || true
 # 4. Firewall Cage Check
 sudo iptables -S DOCKER-USER
 ```
+
+
+### 4.1a Bindungs-Preflight
+
+Vor einer Änderung den aktuellen Prozess und die Netzgrenze erfassen:
+
+```bash
+systemctl --user show leitstand.service \
+  -p ActiveState -p SubState -p MainPID -p FragmentPath --no-pager
+systemctl --user cat leitstand.service
+ss -lntp 'sport = :3000'
+curl -fsS --max-time 10 http://127.0.0.1:3000/health
+```
+
+Erwartung für direkten Node-/systemd-Betrieb nach dem Update:
+
+- `LEITSTAND_BIND_HOST=127.0.0.1` ist explizit gesetzt oder der sichere Default greift;
+- der Listener ist `127.0.0.1:3000`, nicht `*:3000`, `0.0.0.0:3000` oder `[::]:3000`;
+- ein absichtlicher konkreter LAN-IP-Bind ist dokumentiert;
+- eine Wildcard ist nur mit der separaten Bestätigung zulässig.
+
+Für Docker zusätzlich beide Renderverträge prüfen:
+
+```bash
+docker compose -f deploy/docker-compose.yml \
+  -f deploy/docker-compose.loopback.yml config
+
+LEITSTAND_BIND_IP=<konkrete-LAN-IP> \
+  docker compose -f deploy/docker-compose.yml \
+  -f deploy/docker-compose.lan.yml config
+```
+
+Die Container-Umgebung darf intern `LEITSTAND_BIND_HOST=0.0.0.0` und
+`LEITSTAND_ALLOW_WIDE_BIND=true` setzen. Der Loopback-Override muss den
+Hostport auf `127.0.0.1` begrenzen; der LAN-Override darf nur die ausdrücklich
+gesetzte IP publizieren.
 
 ### 4.2 Update (Execution)
 
@@ -103,23 +144,43 @@ curl -I https://leitstand.heimgewebe.home.arpa/health
 docker compose ps
 # Optional bei Problemen:
 # docker compose logs --tail=100 --no-color
+
+# 4. Netzgrenze des direkten Dienstes
+ss -lntp 'sport = :3000'
+# Erwartet im sicheren Standardpfad ausschließlich 127.0.0.1:3000.
+# Wildcard-Treffer sind ein fehlgeschlagener Postflight.
 ```
 
 ### 4.4 Rollback (Emergency)
-Wenn Postflight fehlschlägt.
+Wenn Postflight fehlschlägt, nur den betroffenen Leitstand-Dienst auf den zuvor
+gesicherten Stand zurücksetzen. Kein pauschales `docker compose down`, kein
+Prune und keine Datenlöschung.
+
+Direkter systemd-Betrieb:
+
+```bash
+# Vorher gesicherte Unit beziehungsweise Environment-Zeilen wiederherstellen.
+systemctl --user daemon-reload
+systemctl --user restart leitstand.service
+systemctl --user is-active leitstand.service
+ss -lntp 'sport = :3000'
+curl -fsS --max-time 10 http://127.0.0.1:3000/health
+```
+
+Docker-Betrieb:
 
 ```bash
 cd /opt/heimgewebe/gateway/
-
-# Option A: Zurück zu vorherigen Tags (Pinning in compose.yml erforderlich)
-# nano compose.gateway.yml -> fix tags
-# docker compose up -d
-
-# Option B: Hard Reset (Downtime)
-docker compose down
-# Start mit explizit funktionierenden Versionen
-# docker compose up -d
+# Vorherige, digest- oder versionsgebundene Leitstand-Referenz wieder einsetzen.
+# Nur den Leitstand-Service neu erzeugen; abhängige Daten-/Gateway-Dienste bleiben stehen.
+docker compose up -d --no-deps --force-recreate leitstand
+docker compose ps leitstand
+docker compose logs --tail=100 --no-color leitstand
 ```
+
+Schlägt auch der Rollback-Postflight fehl, keine weiteren automatischen
+Versuche starten. Vorherige Logs, Unit-/Compose-Datei, Commit und Listenerbeleg
+erhalten und den Dienst als blockiert melden.
 
 ## 5) Fehlerbilder (Troubleshooting)
 - **DNS bricht:** `getent hosts` liefert nichts -> Prüfe `/etc/hosts` oder FritzBox.

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,10 +1,39 @@
 import { z } from 'zod';
+import { isIP } from 'node:net';
 import { resolve, dirname, join } from 'path';
 import { readJsonFile } from './utils/fs.js';
 
 /**
+ * Robust boolean parser for environment variables.
+ * Handles 'true', '1', 'yes', 'on' (case-insensitive).
+ */
+function isTruthy(val?: string): boolean {
+    if (!val) return false;
+    return ['true', '1', 'yes', 'on'].includes(val.toLowerCase());
+}
+
+function isWildcardBindHost(host: string): boolean {
+    return host === '0.0.0.0' || host === '::';
+}
+
+/**
  * Schema for runtime environment variables
  */
+const BindEnvSchema = z.object({
+  LEITSTAND_BIND_HOST: z.string()
+    .refine((value) => isIP(value) !== 0, { message: 'Must be an IPv4 or IPv6 literal' })
+    .default('127.0.0.1'),
+  LEITSTAND_ALLOW_WIDE_BIND: z.string().optional(),
+}).superRefine((env, ctx) => {
+  if (isWildcardBindHost(env.LEITSTAND_BIND_HOST) && !isTruthy(env.LEITSTAND_ALLOW_WIDE_BIND)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['LEITSTAND_BIND_HOST'],
+      message: 'Wildcard binding requires LEITSTAND_ALLOW_WIDE_BIND=true',
+    });
+  }
+});
+
 const EnvSchema = z.object({
   PORT: z.coerce.number().int().positive().default(3000),
   NODE_ENV: z.string().default('development'),
@@ -34,9 +63,30 @@ const EnvSchema = z.object({
 });
 
 type EnvType = z.infer<typeof EnvSchema>;
+type BindEnvType = z.infer<typeof BindEnvSchema>;
 
-// Memoization cache
+// Memoization caches
 let cachedEnv: EnvType | null = null;
+let cachedBindEnv: BindEnvType | null = null;
+
+const parsedBindEnv = (): BindEnvType => {
+    if (cachedBindEnv) {
+        return cachedBindEnv;
+    }
+
+    const parsed = BindEnvSchema.safeParse(process.env);
+    if (!parsed.success) {
+        console.warn('Invalid bind environment variables:', parsed.error.format());
+        cachedBindEnv = {
+            LEITSTAND_BIND_HOST: '127.0.0.1',
+            LEITSTAND_ALLOW_WIDE_BIND: undefined,
+        };
+        return cachedBindEnv;
+    }
+
+    cachedBindEnv = parsed.data;
+    return parsed.data;
+};
 
 const parsedEnv = (): EnvType => {
     if (cachedEnv) {
@@ -78,19 +128,12 @@ const parsedEnv = (): EnvType => {
  */
 export const resetEnvConfig = () => {
     cachedEnv = null;
+    cachedBindEnv = null;
 };
-
-/**
- * Robust boolean parser for environment variables.
- * Handles 'true', '1', 'yes', 'on' (case-insensitive).
- */
-function isTruthy(val?: string): boolean {
-    if (!val) return false;
-    return ['true', '1', 'yes', 'on'].includes(val.toLowerCase());
-}
 
 export const envConfig = {
     get PORT() { return parsedEnv().PORT; },
+    get bindHost() { return parsedBindEnv().LEITSTAND_BIND_HOST; },
     get NODE_ENV() { return parsedEnv().NODE_ENV; },
     get OBSERVATORY_URL() { return parsedEnv().OBSERVATORY_URL; },
     get token() { return parsedEnv().LEITSTAND_EVENTS_TOKEN; },

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,6 +22,7 @@ import { getEventFamily, listEventFamilies } from './utils/eventKind.js';
 import fs from 'fs';
 import { validatePlexerReport } from './validation/validators.js';
 import { randomBytes } from 'crypto';
+import { Server } from 'node:http';
 
 const execPromise = promisify(exec);
 
@@ -70,7 +71,8 @@ async function enqueueMetaUpdate(updateFn: (meta: Record<string, unknown>) => Re
 }
 
 const app: Express = express();
-const port = envConfig.PORT;
+const defaultPort = envConfig.PORT;
+const defaultBindHost = envConfig.bindHost;
 
 app.use(express.json());
 
@@ -499,10 +501,24 @@ try {
   isDirectRun = false;
 }
 
-if (isDirectRun) {
-  app.listen(port, () => {
-    console.log(`Leitstand server running at http://localhost:${port}`);
+export interface StartServerOptions {
+  port?: number;
+  bindHost?: string;
+  log?: boolean;
+}
+
+export function startServer(options: StartServerOptions = {}): Server {
+  const port = options.port ?? defaultPort;
+  const bindHost = options.bindHost ?? defaultBindHost;
+  return app.listen(port, bindHost, () => {
+    if (options.log === false) return;
+    const displayHost = bindHost.includes(':') ? `[${bindHost}]` : bindHost;
+    console.log(`Leitstand server running at http://${displayHost}:${port}`);
   });
+}
+
+if (isDirectRun) {
+  startServer();
 }
 
 /**

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -56,6 +56,52 @@ describe('config', () => {
       expect(warnSpy).toHaveBeenCalled();
     });
 
+    describe('LEITSTAND_BIND_HOST', () => {
+      it('defaults to IPv4 loopback', () => {
+        resetEnvConfig();
+        expect(envConfig.bindHost).toBe('127.0.0.1');
+      });
+
+      it('accepts an explicit LAN IP literal', () => {
+        vi.stubEnv('LEITSTAND_BIND_HOST', '192.168.178.10');
+        resetEnvConfig();
+        expect(envConfig.bindHost).toBe('192.168.178.10');
+      });
+
+      it('accepts IPv6 loopback', () => {
+        vi.stubEnv('LEITSTAND_BIND_HOST', '::1');
+        resetEnvConfig();
+        expect(envConfig.bindHost).toBe('::1');
+      });
+
+      it('rejects hostnames and falls back to loopback', () => {
+        vi.stubEnv('PORT', '4001');
+        vi.stubEnv('NODE_ENV', 'production');
+        vi.stubEnv('LEITSTAND_BIND_HOST', 'leitstand.local');
+        resetEnvConfig();
+        expect(envConfig.bindHost).toBe('127.0.0.1');
+        expect(envConfig.PORT).toBe(4001);
+        expect(envConfig.NODE_ENV).toBe('production');
+        expect(envConfig.isStrict).toBe(true);
+        expect(warnSpy).toHaveBeenCalled();
+      });
+
+      it.each(['0.0.0.0', '::'])('rejects wildcard %s without acknowledgement', (host) => {
+        vi.stubEnv('LEITSTAND_BIND_HOST', host);
+        resetEnvConfig();
+        expect(envConfig.bindHost).toBe('127.0.0.1');
+        expect(warnSpy).toHaveBeenCalled();
+      });
+
+      it.each(['0.0.0.0', '::'])('accepts wildcard %s only with explicit acknowledgement', (host) => {
+        vi.stubEnv('LEITSTAND_BIND_HOST', host);
+        vi.stubEnv('LEITSTAND_ALLOW_WIDE_BIND', 'true');
+        resetEnvConfig();
+        expect(envConfig.bindHost).toBe(host);
+        expect(warnSpy).not.toHaveBeenCalled();
+      });
+    });
+
     describe('LEITSTAND_ACS_URL', () => {
       // Ops Viewer specific config tests
       it('should accept valid HTTP/HTTPS URLs', () => {

--- a/tests/deployBinding.test.ts
+++ b/tests/deployBinding.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+function read(relativePath: string): string {
+  return readFileSync(join(process.cwd(), relativePath), 'utf-8');
+}
+
+describe('Docker binding contract', () => {
+  it('acknowledges the required in-container wildcard explicitly', () => {
+    const compose = read('deploy/docker-compose.yml');
+    expect(compose).toContain('LEITSTAND_BIND_HOST: "0.0.0.0"');
+    expect(compose).toContain('LEITSTAND_ALLOW_WIDE_BIND: "true"');
+  });
+
+  it('keeps host publication loopback-first and LAN publication explicit', () => {
+    expect(read('deploy/docker-compose.loopback.yml')).toContain('127.0.0.1:3000:3000');
+    expect(read('deploy/docker-compose.lan.yml')).toContain('${LEITSTAND_BIND_IP:?set LEITSTAND_BIND_IP}:3000:3000');
+  });
+});

--- a/tests/serverBind.test.ts
+++ b/tests/serverBind.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import type { AddressInfo } from 'node:net';
+import type { Server } from 'node:http';
+import { startServer } from '../src/server.js';
+
+function waitForListening(server: Server): Promise<void> {
+  if (server.listening) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    server.once('listening', resolve);
+    server.once('error', reject);
+  });
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+  });
+}
+
+describe('startServer binding', () => {
+  let server: Server | undefined;
+
+  afterEach(async () => {
+    if (server?.listening) await closeServer(server);
+    server = undefined;
+  });
+
+  it('binds the explicit loopback host instead of an implicit wildcard', async () => {
+    server = startServer({ port: 0, bindHost: '127.0.0.1', log: false });
+    await waitForListening(server);
+    const address = server.address() as AddressInfo;
+    expect(address.address).toBe('127.0.0.1');
+    expect(address.family).toBe('IPv4');
+    expect(address.port).toBeGreaterThan(0);
+  });
+
+  it('supports explicit IPv6 loopback', async () => {
+    server = startServer({ port: 0, bindHost: '::1', log: false });
+    try {
+      await waitForListening(server);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'EAFNOSUPPORT') return;
+      throw error;
+    }
+    const address = server.address() as AddressInfo;
+    expect(address.address).toBe('::1');
+    expect(address.family).toBe('IPv6');
+  });
+});


### PR DESCRIPTION
Task: OPERATOR-PC-HYGIENE-V1-T004

Fixes the live contract drift where the direct systemd/Node runtime listened on *:3000 although the runbook described a loopback-first default.

Contract:
- direct Node/systemd default: 127.0.0.1
- bind host must be an IP literal
- 0.0.0.0 and :: require LEITSTAND_ALLOW_WIDE_BIND=true
- invalid bind configuration falls back only the bind surface, not NODE_ENV/strict/other production settings
- Docker acknowledges its required in-container wildcard explicitly while host publication remains controlled by loopback/LAN Compose overrides

Validation:
- TypeScript typecheck PASS
- ESLint PASS
- 25 focused config/server/deploy binding tests PASS
- build PASS
- real startServer listener proof bound 127.0.0.1 on an ephemeral test port
- Docker loopback and explicit-LAN render contracts PASS
- self-review PASS after fixing Docker reachability and environment-fallback coupling

Known local full-suite noise under host Node 22 is unrelated and pre-existing; GitHub CI is authoritative for the repository runtime matrix.