### PR TITLE
chore: migrate system catalog source identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Leitstand intentionally tracks `.wgx/profile.yml` as documented in [WGX Leitstan
 
 ## Ecosystem Map View
 
-Leitstand is the right dashboard surface for a future read-only view of the Cabinet-owned ecosystem map. The boundary is documented in [Ecosystem Map View Blueprint](docs/blueprints/ecosystem-map-view.md): Cabinet owns map semantics; Leitstand may render and display pinned Cabinet Mermaid artifacts with freshness metadata.
+Leitstand is the right dashboard surface for a future read-only view of the ecosystem map owned by the Heimgewebe-Systemkatalog. The boundary is documented in [Ecosystem Map View Blueprint](docs/blueprints/ecosystem-map-view.md): The Heimgewebe-Systemkatalog owns map semantics; Leitstand may render and display pinned system catalog Mermaid artifacts with freshness metadata.
 
 ## Installation
 

--- a/docs/blueprints/ecosystem-map-view.md
+++ b/docs/blueprints/ecosystem-map-view.md
@@ -6,7 +6,7 @@ doc_type: blueprint
 canonicality: supporting
 owner: leitstand
 summary: >
-  Read-only Leitstand viewer boundary for the Cabinet-owned Heimgewebe ecosystem map.
+  Read-only Leitstand viewer boundary for the Heimgewebe ecosystem map owned by the Heimgewebe-Systemkatalog.
 ---
 
 # Ecosystem Map View Blueprint
@@ -15,17 +15,17 @@ summary: >
 
 Leitstand should provide a dashboard-friendly view of the Heimgewebe ecosystem map without becoming the owner of the map.
 
-The canonical map semantics remain in Cabinet. Leitstand may render or display Cabinet map artifacts as an observer surface.
+The canonical map semantics remain in the Heimgewebe-Systemkatalog. Leitstand may render or display system catalog map artifacts as an observer surface.
 
 ## Source Boundary
 
 Canonical sources:
 
-- Cabinet entry: `../cabinet/index.md` in local operator checkouts, or the GitHub `heimgewebe/cabinet` repository.
-- Readable overview: `rendered/ecosystem-map.mmd` in Cabinet.
-- Generated registry projection: `rendered/ecosystem-registry-map.mmd` in Cabinet.
-- Map boundary and maintenance rules: `docs/blueprints/ecosystem-map-v0.md` in Cabinet.
-- Registry inputs: `registry/ecosystem/nodes.json`, `registry/ecosystem/edges.json`, and `registry/ecosystem/claims.jsonl` in Cabinet.
+- Heimgewebe-Systemkatalog entry: `../heimgewebe-katalog/index.md` in local operator checkouts, or the GitHub `heimgewebe/heimgewebe-katalog` repository.
+- Readable overview: `rendered/ecosystem-map.mmd` in the Heimgewebe-Systemkatalog.
+- Generated registry projection: `rendered/ecosystem-registry-map.mmd` in the Heimgewebe-Systemkatalog.
+- Map boundary and maintenance rules: `docs/blueprints/ecosystem-map-v0.md` in the Heimgewebe-Systemkatalog.
+- Registry inputs: `registry/ecosystem/nodes.json`, `registry/ecosystem/edges.json`, and `registry/ecosystem/claims.jsonl` in the Heimgewebe-Systemkatalog.
 
 Leitstand must not maintain a competing graph, registry, or claim layer.
 
@@ -35,19 +35,19 @@ The first implementation should be read-only.
 
 Allowed:
 
-- fetch or vendor a pinned Cabinet map artifact for display;
+- fetch or vendor a pinned system catalog map artifact for display;
 - render Mermaid into an HTML/SVG/dashboard component;
-- show the Cabinet commit, source path, and retrieval time;
-- show a freshness or drift warning if the displayed map is not from the current Cabinet main;
-- link back to Cabinet as the canonical source.
+- show the system catalog commit, source path, and retrieval time;
+- show a freshness or drift warning if the displayed map is not from the current Heimgewebe-Systemkatalog main;
+- link back to the Heimgewebe-Systemkatalog as the canonical source.
 
 Not allowed:
 
-- editing Cabinet map content from Leitstand;
+- editing system catalog map content from Leitstand;
 - inferring claim truth from a Mermaid edge;
-- treating Leitstand render success as Cabinet map validity;
+- treating Leitstand render success as system catalog map validity;
 - dispatching tasks or changing other repos from the map view;
-- silently replacing Cabinet as the source of map semantics.
+- silently replacing Heimgewebe-Systemkatalog as the source of map semantics.
 
 ## UI Placement
 
@@ -55,13 +55,13 @@ A future route can use a name such as `/ecosystem-map` or a card in the main das
 
 The page should visibly state:
 
-> View only. Canonical map semantics live in Cabinet.
+> View only. Canonical map semantics live in the Heimgewebe-Systemkatalog.
 
 It should present at least:
 
 1. readable overview map;
 2. generated registry projection;
-3. Cabinet source links;
+3. system catalog source links;
 4. source commit or retrieval metadata;
 5. boundary note explaining that the map is an orientation aid, not proof of runtime correctness or merge readiness.
 
@@ -73,28 +73,28 @@ This blueprint defines the role split. No UI code is required in this phase.
 
 ### Phase 1 — Static local preview
 
-Render a pinned Cabinet `.mmd` artifact into a static view. The build must fail closed if the source path is missing or malformed.
+Render a pinned Heimgewebe-Systemkatalog `.mmd` artifact into a static view. The build must fail closed if the source path is missing or malformed.
 
 ### Phase 2 — Dashboard route
 
-Expose a read-only route in Leitstand. It may display freshness metadata but must not write to Cabinet or any other repo.
+Expose a read-only route in Leitstand. It may display freshness metadata but must not write to the Heimgewebe-Systemkatalog or any other repo.
 
 ### Phase 3 — Freshness signal
 
-Optionally compare the displayed artifact against a Cabinet commit or manifest. A stale map should be flagged, not auto-repaired.
+Optionally compare the displayed artifact against a system catalog commit or manifest. A stale map should be flagged, not auto-repaired.
 
 ## Organs
 
-- Cabinet: owns map semantics, registry, generated Mermaid projection, and validation.
+- Heimgewebe-Systemkatalog: owns map semantics, registry, generated Mermaid projection, and validation.
 - Leitstand: displays a read-only dashboard view and freshness signals.
 - Schauwerk: may create presentation or publishing surfaces from approved sources.
-- heim-pc: points local operators and agents toward Cabinet.
+- heim-pc: points local operators and agents toward the Heimgewebe-Systemkatalog.
 - GitHub and CI: remain primary for repository state and check state.
 
 ## Non-goals
 
 - no map editing in Leitstand;
-- no Cabinet registry duplication;
+- no system catalog registry duplication;
 - no task dispatch from the map view;
 - no runtime truth claims;
 - no merge-readiness claims;

--- a/docs/decisions/static-mirror-boundary.md
+++ b/docs/decisions/static-mirror-boundary.md
@@ -30,7 +30,7 @@ These routes are intentionally not part of the current static mirror:
 - `/ops` — runtime ACS viewer and optional job fallback.
 - `/bureau` — execution-axis snapshot view, runtime-rendered in Mode A until static artifact parity is implemented.
 - `/checkouts` — checkout inventory view, runtime-rendered in Mode A until static artifact parity is implemented.
-- `/ecosystem-map` — Cabinet artifact projection, runtime-rendered until static artifact parity is implemented.
+- `/ecosystem-map` — system catalog artifact projection, runtime-rendered until static artifact parity is implemented.
 - `/repobriefs` — RepoBrief bundle index view, runtime-rendered until static artifact parity is implemented.
 - `/anatomy`, `/insights`, `/timeline`, `/reflexion` — controller-backed views with runtime/time-window semantics or artifact freshness contracts not yet represented by the static build.
 

--- a/scripts/build-static.mjs
+++ b/scripts/build-static.mjs
@@ -18,7 +18,7 @@ const STATIC_MIRROR_DYNAMIC_ONLY_ROUTES = [
   { route: "/ops", reason: "runtime ACS viewer and optional job fallback" },
   { route: "/bureau", reason: "execution-axis snapshot view remains runtime-rendered in Mode A" },
   { route: "/checkouts", reason: "checkout inventory view remains runtime-rendered in Mode A" },
-  { route: "/ecosystem-map", reason: "Cabinet artifact projection is runtime-rendered until static artifact parity is implemented" },
+  { route: "/ecosystem-map", reason: "system catalog artifact projection is runtime-rendered until static artifact parity is implemented" },
   { route: "/repobriefs", reason: "RepoBrief bundle index view is runtime-rendered until static artifact parity is implemented" },
   { route: "/anatomy", reason: "controller-backed structure view is runtime-rendered until static artifact parity is implemented" },
   { route: "/insights", reason: "controller-backed insights view is runtime-rendered until static artifact parity is implemented" },

--- a/src/controllers/ecosystemMap.ts
+++ b/src/controllers/ecosystemMap.ts
@@ -145,7 +145,7 @@ function parseManifest(raw: unknown): MapManifest {
   if (!manifest.source || typeof manifest.source !== 'object') {
     throw new Error('invalid ecosystem map manifest: source missing');
   }
-  if (manifest.source.repository !== 'heimgewebe/cabinet') {
+  if (manifest.source.repository !== 'heimgewebe/heimgewebe-katalog') {
     throw new Error('invalid ecosystem map manifest: source repository mismatch');
   }
   if (!/^[0-9a-f]{40}$/.test(manifest.source.commit || '')) {

--- a/src/fixtures/ecosystem-map-links.json
+++ b/src/fixtures/ecosystem-map-links.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "kind": "leitstand_ecosystem_map_cross_view_links",
-  "source": "cabinet.ecosystem_map.v0.node_ids",
+  "source": "heimgewebe-systemkatalog.ecosystem_map.v0.node_ids",
   "doesNotEstablish": [
     "relation_truth",
     "runtime_dependency",
@@ -18,19 +18,19 @@
         {
           "view": "ecosystem-map",
           "href": "/ecosystem-map",
-          "title": "Cabinet map source view"
+          "title": "system catalog map source view"
         }
       ]
     },
     {
-      "nodeId": "repo:cabinet",
-      "label": "Cabinet",
+      "nodeId": "repo:heimgewebe-katalog",
+      "label": "Heimgewebe-Systemkatalog",
       "status": "linked",
       "links": [
         {
           "view": "ecosystem-map",
           "href": "/ecosystem-map",
-          "title": "Cabinet-owned map artifacts"
+          "title": "map artifacts owned by the Heimgewebe-Systemkatalog"
         }
       ]
     },

--- a/src/views/ecosystem-map.ejs
+++ b/src/views/ecosystem-map.ejs
@@ -39,10 +39,10 @@
 
   <main>
     <h1>Ecosystem Map</h1>
-    <p class="subtitle">Read-only source view for the Cabinet-owned Heimgewebe ecosystem map.</p>
+    <p class="subtitle">Read-only source view for the Heimgewebe ecosystem map owned by the Heimgewebe-Systemkatalog.</p>
 
     <section class="notice" aria-label="Boundary">
-      <strong>View only.</strong> Canonical map semantics live in Cabinet. Leitstand displays pinned artifacts and freshness metadata; it does not edit the map, infer claim truth, dispatch tasks, or prove runtime correctness or merge readiness.
+      <strong>View only.</strong> Canonical map semantics live in the Heimgewebe-Systemkatalog. Leitstand displays pinned artifacts and freshness metadata; it does not edit the map, infer claim truth, dispatch tasks, or prove runtime correctness or merge readiness.
     </section>
 
     <section class="meta-grid" aria-label="Source metadata">

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -287,7 +287,7 @@
     <section class="info-card" aria-labelledby="ecosystem-map-heading">
       <h2 id="ecosystem-map-heading">Ecosystem Map</h2>
       <p>
-        Read-only Cabinet map source view: zeigt Mermaid-Quellen, Commit, Manifest, Freshness und Boundary-Hinweis.
+        Read-only system catalog map source view: zeigt Mermaid-Quellen, Commit, Manifest, Freshness und Boundary-Hinweis.
         <a href="/ecosystem-map">Ecosystem Map öffnen</a>.
       </p>
     </section>

--- a/tests/controllers/ecosystemMap.test.ts
+++ b/tests/controllers/ecosystemMap.test.ts
@@ -31,9 +31,9 @@ afterEach(async () => {
 async function makeFixture(generatedAt = new Date().toISOString()) {
   const root = await mkdtemp(join(tmpdir(), 'leitstand-map-'));
   tempRoots.push(root);
-  const sourceRoot = join(root, 'cabinet');
+  const sourceRoot = join(root, 'heimgewebe-katalog');
   await mkdir(join(sourceRoot, 'rendered'), { recursive: true });
-  await writeFile(join(sourceRoot, 'rendered', 'ecosystem-map.mmd'), 'flowchart TD\n  A[Cabinet]\n', 'utf-8');
+  await writeFile(join(sourceRoot, 'rendered', 'ecosystem-map.mmd'), 'flowchart TD\n  A[Heimgewebe-Systemkatalog]\n', 'utf-8');
   await writeFile(join(sourceRoot, 'rendered', 'ecosystem-registry-map.mmd'), 'flowchart TD\n  B[Registry]\n', 'utf-8');
   const manifestPath = join(sourceRoot, 'rendered', 'ecosystem-map-artifact-manifest.json');
   const manifest = {
@@ -41,7 +41,7 @@ async function makeFixture(generatedAt = new Date().toISOString()) {
     kind: 'cabinet_ecosystem_map_artifact_manifest',
     contractVersion: '1',
     source: {
-      repository: 'heimgewebe/cabinet',
+      repository: 'heimgewebe/heimgewebe-katalog',
       commit: 'a'.repeat(40),
       generatedAt,
     },
@@ -69,17 +69,17 @@ async function makeFixture(generatedAt = new Date().toISOString()) {
 }
 
 describe('getEcosystemMapData', () => {
-  it('loads a Cabinet ecosystem map manifest and Mermaid sources read-only', async () => {
+  it('loads a Heimgewebe system catalog ecosystem map manifest and Mermaid sources read-only', async () => {
     const fixture = await makeFixture();
     process.env.LEITSTAND_ECOSYSTEM_MAP_MANIFEST_PATH = fixture.manifestPath;
 
     const data = await getEcosystemMapData();
 
     expect(data.view_meta.source_kind).toBe('artifact');
-    expect(data.view_meta.source_repository).toBe('heimgewebe/cabinet');
+    expect(data.view_meta.source_repository).toBe('heimgewebe/heimgewebe-katalog');
     expect(data.view_meta.source_commit).toBe('a'.repeat(40));
     expect(data.view_meta.source_root).toBe(fixture.sourceRoot);
-    expect(data.overview?.content).toContain('Cabinet');
+    expect(data.overview?.content).toContain('Heimgewebe-Systemkatalog');
     expect(data.registry_projection?.content).toContain('Registry');
     expect(data.view_meta.does_not_establish).toContain('runtime_correctness');
   });
@@ -110,12 +110,12 @@ describe('getEcosystemMapData', () => {
 
   it('loads deterministic cross-view links and degrades unknown node IDs', async () => {
     const links = await loadEcosystemCrossLinks();
-    const cabinet = resolveEcosystemCrossLink(links, 'repo:cabinet');
+    const systemCatalog = resolveEcosystemCrossLink(links, 'repo:heimgewebe-katalog');
     const unknown = resolveEcosystemCrossLink(links, 'repo:unknown');
 
     expect(links.meta.source_kind).toBe('artifact');
-    expect(cabinet.status).toBe('linked');
-    expect(cabinet.links[0].href).toBe('/ecosystem-map');
+    expect(systemCatalog.status).toBe('linked');
+    expect(systemCatalog.links[0].href).toBe('/ecosystem-map');
     expect(unknown.status).toBe('unmapped');
     expect(unknown.reason).toBe('node_id_not_in_cross_view_contract');
   });


### PR DESCRIPTION
## Ergebnis
- akzeptiert nur noch `heimgewebe/heimgewebe-katalog` als aktive Kartenquelle
- migriert den Cross-View-Knoten von `repo:cabinet` zu `repo:heimgewebe-katalog`
- aktualisiert UI, Blueprint und Tests
- lässt datierte Pilotberichte unverändert

## Validierung
- TypeScript typecheck: PASS
- ESLint: PASS
- Vitest im eigenständigen Clone: 341/341 PASS
- Diff SHA-256: `cdfb625d730fed79b261ba1d162bf6580f87501497a90ad98c7e5b51973f3b3c`
- Vollständiger Diff: https://gist.github.com/alexdermohr/f83a5c884cb566ea36709fe6e1a919dd