### PR TITLE
refactor: consume canonical Systemkatalog map

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Leitstand intentionally tracks `.wgx/profile.yml` as documented in [WGX Leitstan
 
 ## Ecosystem Map View
 
-Leitstand is the right dashboard surface for a future read-only view of the ecosystem map owned by the Heimgewebe-Systemkatalog. The boundary is documented in [Ecosystem Map View Blueprint](docs/blueprints/ecosystem-map-view.md): The Heimgewebe-Systemkatalog owns map semantics; Leitstand may render and display pinned system catalog Mermaid artifacts with freshness metadata.
+Leitstand is the right dashboard surface for a future read-only view of the ecosystem map owned by the Systemkatalog. The boundary is documented in [Ecosystem Map View Blueprint](docs/blueprints/ecosystem-map-view.md): The Systemkatalog owns map semantics; Leitstand may render and display pinned system catalog Mermaid artifacts with freshness metadata.
 
 ## Installation
 

--- a/docs/blueprints/ecosystem-map-view.md
+++ b/docs/blueprints/ecosystem-map-view.md
@@ -6,7 +6,7 @@ doc_type: blueprint
 canonicality: supporting
 owner: leitstand
 summary: >
-  Read-only Leitstand viewer boundary for the Heimgewebe ecosystem map owned by the Heimgewebe-Systemkatalog.
+  Read-only Leitstand viewer boundary for the Heimgewebe ecosystem map owned by the Systemkatalog.
 ---
 
 # Ecosystem Map View Blueprint
@@ -15,17 +15,17 @@ summary: >
 
 Leitstand should provide a dashboard-friendly view of the Heimgewebe ecosystem map without becoming the owner of the map.
 
-The canonical map semantics remain in the Heimgewebe-Systemkatalog. Leitstand may render or display system catalog map artifacts as an observer surface.
+The canonical map semantics remain in the Systemkatalog. Leitstand may render or display system catalog map artifacts as an observer surface.
 
 ## Source Boundary
 
 Canonical sources:
 
-- Heimgewebe-Systemkatalog entry: `../heimgewebe-katalog/index.md` in local operator checkouts, or the GitHub `heimgewebe/heimgewebe-katalog` repository.
-- Readable overview: `rendered/ecosystem-map.mmd` in the Heimgewebe-Systemkatalog.
-- Generated registry projection: `rendered/ecosystem-registry-map.mmd` in the Heimgewebe-Systemkatalog.
-- Map boundary and maintenance rules: `docs/blueprints/ecosystem-map-v0.md` in the Heimgewebe-Systemkatalog.
-- Registry inputs: `registry/ecosystem/nodes.json`, `registry/ecosystem/edges.json`, and `registry/ecosystem/claims.jsonl` in the Heimgewebe-Systemkatalog.
+- Systemkatalog entry: `../systemkatalog/index.md` in local operator checkouts, or the GitHub `heimgewebe/systemkatalog` repository.
+- Canonical generated map: `rendered/ecosystem-registry-map.mmd` in the Systemkatalog.
+- Read-only artifact contract: `catalog/ecosystem-map-artifact-manifest.schema.v1.json` and the generated `rendered/ecosystem-map-artifact-manifest.json`.
+- Map boundary and maintenance rules: `policy/ecosystem-map-view.v1.json` in the Systemkatalog.
+- Registry inputs: `registry/ecosystem/nodes.json`, `registry/ecosystem/edges.json`, and `registry/ecosystem/claims.jsonl` in the Systemkatalog.
 
 Leitstand must not maintain a competing graph, registry, or claim layer.
 
@@ -38,8 +38,8 @@ Allowed:
 - fetch or vendor a pinned system catalog map artifact for display;
 - render Mermaid into an HTML/SVG/dashboard component;
 - show the system catalog commit, source path, and retrieval time;
-- show a freshness or drift warning if the displayed map is not from the current Heimgewebe-Systemkatalog main;
-- link back to the Heimgewebe-Systemkatalog as the canonical source.
+- show a freshness or drift warning if the displayed map is not from the current Systemkatalog main;
+- link back to the Systemkatalog as the canonical source.
 
 Not allowed:
 
@@ -47,7 +47,7 @@ Not allowed:
 - inferring claim truth from a Mermaid edge;
 - treating Leitstand render success as system catalog map validity;
 - dispatching tasks or changing other repos from the map view;
-- silently replacing Heimgewebe-Systemkatalog as the source of map semantics.
+- silently replacing Systemkatalog as the source of map semantics.
 
 ## UI Placement
 
@@ -55,7 +55,7 @@ A future route can use a name such as `/ecosystem-map` or a card in the main das
 
 The page should visibly state:
 
-> View only. Canonical map semantics live in the Heimgewebe-Systemkatalog.
+> View only. Canonical map semantics live in the Systemkatalog.
 
 It should present at least:
 
@@ -73,11 +73,11 @@ This blueprint defines the role split. No UI code is required in this phase.
 
 ### Phase 1 — Static local preview
 
-Render a pinned Heimgewebe-Systemkatalog `.mmd` artifact into a static view. The build must fail closed if the source path is missing or malformed.
+Render the pinned canonical Systemkatalog `.mmd` artifact into a static view. The build must fail closed if the source path is missing or malformed.
 
 ### Phase 2 — Dashboard route
 
-Expose a read-only route in Leitstand. It may display freshness metadata but must not write to the Heimgewebe-Systemkatalog or any other repo.
+Expose a read-only route in Leitstand. It may display freshness metadata but must not write to the Systemkatalog or any other repo.
 
 ### Phase 3 — Freshness signal
 
@@ -85,10 +85,10 @@ Optionally compare the displayed artifact against a system catalog commit or man
 
 ## Organs
 
-- Heimgewebe-Systemkatalog: owns map semantics, registry, generated Mermaid projection, and validation.
+- Systemkatalog: owns map semantics, registry, generated Mermaid projection, and validation.
 - Leitstand: displays a read-only dashboard view and freshness signals.
 - Schauwerk: may create presentation or publishing surfaces from approved sources.
-- heim-pc: points local operators and agents toward the Heimgewebe-Systemkatalog.
+- heim-pc: points local operators and agents toward the Systemkatalog.
 - GitHub and CI: remain primary for repository state and check state.
 
 ## Non-goals

--- a/src/controllers/ecosystemMap.ts
+++ b/src/controllers/ecosystemMap.ts
@@ -1,4 +1,5 @@
 import { readFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
 import { basename, dirname, join, resolve, relative } from 'node:path';
 import {
   loadEcosystemCrossLinks,
@@ -6,7 +7,7 @@ import {
   type EcosystemCrossViewLink,
 } from './ecosystemMapLinks.js';
 
-const MANIFEST_KIND = 'cabinet_ecosystem_map_artifact_manifest';
+const MANIFEST_KIND = 'system_catalog_map_artifact_manifest';
 const DEFAULT_STALE_AFTER_HOURS = 168;
 
 export type EcosystemMapSourceKind = 'artifact' | 'missing' | 'corrupt';
@@ -45,8 +46,7 @@ export interface EcosystemMapArtifactView {
 }
 
 export interface EcosystemMapViewData {
-  overview: EcosystemMapArtifactView | null;
-  registry_projection: EcosystemMapArtifactView | null;
+  map: EcosystemMapArtifactView | null;
   cross_links: EcosystemCrossViewLink[];
   cross_link_meta: {
     source_kind: string;
@@ -107,8 +107,7 @@ function emptyData(
   crossLinks: EcosystemCrossLinkData,
 ): EcosystemMapViewData {
   return {
-    overview: null,
-    registry_projection: null,
+    map: null,
     cross_links: crossLinks.links,
     cross_link_meta: crossLinks.meta,
     view_meta: {
@@ -145,14 +144,17 @@ function parseManifest(raw: unknown): MapManifest {
   if (!manifest.source || typeof manifest.source !== 'object') {
     throw new Error('invalid ecosystem map manifest: source missing');
   }
-  if (manifest.source.repository !== 'heimgewebe/heimgewebe-katalog') {
+  if (manifest.source.repository !== 'heimgewebe/systemkatalog') {
     throw new Error('invalid ecosystem map manifest: source repository mismatch');
   }
   if (!/^[0-9a-f]{40}$/.test(manifest.source.commit || '')) {
     throw new Error('invalid ecosystem map manifest: source commit mismatch');
   }
-  if (!Array.isArray(manifest.artifacts)) {
-    throw new Error('invalid ecosystem map manifest: artifacts missing');
+  if (manifest.contractVersion !== '1') {
+    throw new Error('invalid ecosystem map manifest: contractVersion mismatch');
+  }
+  if (!Array.isArray(manifest.artifacts) || manifest.artifactCount !== manifest.artifacts.length) {
+    throw new Error('invalid ecosystem map manifest: artifacts missing or count mismatch');
   }
   if (!Array.isArray(manifest.doesNotEstablish)) {
     throw new Error('invalid ecosystem map manifest: non-claims missing');
@@ -196,14 +198,26 @@ async function readArtifact(sourceRoot: string, artifact: MapManifestArtifact | 
   if (!artifact) return null;
   const resolvedPath = resolveArtifactPath(sourceRoot, artifact.path);
   try {
-    const content = await readFile(resolvedPath, 'utf-8');
+    const raw = await readFile(resolvedPath);
+    const digest = createHash('sha256').update(raw).digest('hex');
+    if (raw.byteLength !== artifact.bytes || digest !== artifact.sha256) {
+      return {
+        role: artifact.role,
+        path: artifact.path,
+        content_type: artifact.contentType,
+        bytes: artifact.bytes,
+        sha256: artifact.sha256,
+        content: null,
+        missing_reason: 'artifact_integrity_mismatch',
+      };
+    }
     return {
       role: artifact.role,
       path: artifact.path,
       content_type: artifact.contentType,
       bytes: artifact.bytes,
       sha256: artifact.sha256,
-      content,
+      content: raw.toString('utf-8'),
       missing_reason: null,
     };
   } catch {
@@ -228,18 +242,12 @@ export async function getEcosystemMapData(): Promise<EcosystemMapViewData> {
     const manifest = parseManifest(raw);
     const sourceRoot = sourceRootForManifest(manifestPath);
     const freshnessState = freshness(manifest.source.generatedAt, staleAfterHours);
-    const overviewSpec = manifest.artifacts.find((artifact) => artifact.role === 'readable_overview_mermaid');
-    const registrySpec = manifest.artifacts.find((artifact) => artifact.role === 'generated_registry_projection_mermaid');
-    const [overview, registryProjection] = await Promise.all([
-      readArtifact(sourceRoot, overviewSpec),
-      readArtifact(sourceRoot, registrySpec),
-    ]);
-
-    const missingReason = overview?.missing_reason || registryProjection?.missing_reason || 'ok';
+    const mapSpec = manifest.artifacts.find((artifact) => artifact.role === 'canonical_ecosystem_map_mermaid');
+    const map = await readArtifact(sourceRoot, mapSpec);
+    const missingReason = map?.missing_reason || (map ? 'ok' : 'artifact_role_missing');
 
     return {
-      overview,
-      registry_projection: registryProjection,
+      map,
       cross_links: crossLinks.links,
       cross_link_meta: crossLinks.meta,
       view_meta: {

--- a/src/fixtures/ecosystem-map-links.json
+++ b/src/fixtures/ecosystem-map-links.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "kind": "leitstand_ecosystem_map_cross_view_links",
-  "source": "heimgewebe-systemkatalog.ecosystem_map.v0.node_ids",
+  "source": "systemkatalog.ecosystem_map.v1.node_ids",
   "doesNotEstablish": [
     "relation_truth",
     "runtime_dependency",
@@ -23,14 +23,14 @@
       ]
     },
     {
-      "nodeId": "repo:heimgewebe-katalog",
-      "label": "Heimgewebe-Systemkatalog",
+      "nodeId": "repo:systemkatalog",
+      "label": "Systemkatalog",
       "status": "linked",
       "links": [
         {
           "view": "ecosystem-map",
           "href": "/ecosystem-map",
-          "title": "map artifacts owned by the Heimgewebe-Systemkatalog"
+          "title": "map artifacts owned by the Systemkatalog"
         }
       ]
     },

--- a/src/views/ecosystem-map.ejs
+++ b/src/views/ecosystem-map.ejs
@@ -39,10 +39,10 @@
 
   <main>
     <h1>Ecosystem Map</h1>
-    <p class="subtitle">Read-only source view for the Heimgewebe ecosystem map owned by the Heimgewebe-Systemkatalog.</p>
+    <p class="subtitle">Read-only source view for the Heimgewebe ecosystem map owned by the Systemkatalog.</p>
 
     <section class="notice" aria-label="Boundary">
-      <strong>View only.</strong> Canonical map semantics live in the Heimgewebe-Systemkatalog. Leitstand displays pinned artifacts and freshness metadata; it does not edit the map, infer claim truth, dispatch tasks, or prove runtime correctness or merge readiness.
+      <strong>View only.</strong> Canonical map semantics live in the Systemkatalog. Leitstand displays pinned artifacts and freshness metadata; it does not edit the map, infer claim truth, dispatch tasks, or prove runtime correctness or merge readiness.
     </section>
 
     <section class="meta-grid" aria-label="Source metadata">
@@ -78,22 +78,12 @@
     </section>
 
     <section class="panel">
-      <h2>Readable overview</h2>
-      <% if (overview && overview.content) { %>
-        <div class="artifact-meta"><%= overview.path %> · <%= overview.bytes %> bytes · sha256 <%= overview.sha256 %></div>
-        <pre><%= overview.content %></pre>
+      <h2>Canonical ecosystem map</h2>
+      <% if (map && map.content) { %>
+        <div class="artifact-meta"><%= map.path %> · <%= map.bytes %> bytes · sha256 <%= map.sha256 %></div>
+        <pre><%= map.content %></pre>
       <% } else { %>
-        <p class="empty">Overview Mermaid source is not available. Reason: <%= overview ? overview.missing_reason : view_meta.missing_reason %>.</p>
-      <% } %>
-    </section>
-
-    <section class="panel">
-      <h2>Generated registry projection</h2>
-      <% if (registry_projection && registry_projection.content) { %>
-        <div class="artifact-meta"><%= registry_projection.path %> · <%= registry_projection.bytes %> bytes · sha256 <%= registry_projection.sha256 %></div>
-        <pre><%= registry_projection.content %></pre>
-      <% } else { %>
-        <p class="empty">Registry projection Mermaid source is not available. Reason: <%= registry_projection ? registry_projection.missing_reason : view_meta.missing_reason %>.</p>
+        <p class="empty">Canonical Mermaid source is not available. Reason: <%= map ? map.missing_reason : view_meta.missing_reason %>.</p>
       <% } %>
     </section>
 

--- a/tests/controllers/ecosystemMap.test.ts
+++ b/tests/controllers/ecosystemMap.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, mkdir, writeFile, rm } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import { createHash } from 'node:crypto';
 import { afterEach, describe, expect, it } from 'vitest';
 import { getEcosystemMapData } from '../../src/controllers/ecosystemMap.js';
 import { loadEcosystemCrossLinks, resolveEcosystemCrossLink } from '../../src/controllers/ecosystemMapLinks.js';
@@ -31,57 +32,62 @@ afterEach(async () => {
 async function makeFixture(generatedAt = new Date().toISOString()) {
   const root = await mkdtemp(join(tmpdir(), 'leitstand-map-'));
   tempRoots.push(root);
-  const sourceRoot = join(root, 'heimgewebe-katalog');
+  const sourceRoot = join(root, 'systemkatalog');
   await mkdir(join(sourceRoot, 'rendered'), { recursive: true });
-  await writeFile(join(sourceRoot, 'rendered', 'ecosystem-map.mmd'), 'flowchart TD\n  A[Heimgewebe-Systemkatalog]\n', 'utf-8');
-  await writeFile(join(sourceRoot, 'rendered', 'ecosystem-registry-map.mmd'), 'flowchart TD\n  B[Registry]\n', 'utf-8');
+  const mapContent = 'flowchart TD\n  B[Systemkatalog]\n';
+  await writeFile(join(sourceRoot, 'rendered', 'ecosystem-registry-map.mmd'), mapContent, 'utf-8');
   const manifestPath = join(sourceRoot, 'rendered', 'ecosystem-map-artifact-manifest.json');
   const manifest = {
     schemaVersion: 1,
-    kind: 'cabinet_ecosystem_map_artifact_manifest',
+    kind: 'system_catalog_map_artifact_manifest',
     contractVersion: '1',
     source: {
-      repository: 'heimgewebe/heimgewebe-katalog',
+      repository: 'heimgewebe/systemkatalog',
       commit: 'a'.repeat(40),
       generatedAt,
     },
-    artifactCount: 2,
+    artifactCount: 1,
     artifacts: [
       {
-        role: 'readable_overview_mermaid',
-        path: 'rendered/ecosystem-map.mmd',
-        contentType: 'text/mermaid',
-        bytes: 24,
-        sha256: 'b'.repeat(64),
-      },
-      {
-        role: 'generated_registry_projection_mermaid',
+        role: 'canonical_ecosystem_map_mermaid',
         path: 'rendered/ecosystem-registry-map.mmd',
         contentType: 'text/mermaid',
-        bytes: 25,
-        sha256: 'c'.repeat(64),
+        bytes: Buffer.byteLength(mapContent),
+        sha256: createHash('sha256').update(mapContent).digest('hex'),
       },
     ],
     doesNotEstablish: ['claim_truth', 'runtime_correctness', 'merge_readiness'],
   };
   await writeFile(manifestPath, JSON.stringify(manifest), 'utf-8');
-  return { sourceRoot, manifestPath };
+  return { sourceRoot, manifestPath, mapPath: join(sourceRoot, 'rendered', 'ecosystem-registry-map.mmd') };
 }
 
 describe('getEcosystemMapData', () => {
-  it('loads a Heimgewebe system catalog ecosystem map manifest and Mermaid sources read-only', async () => {
+  it('loads the canonical Systemkatalog map artifact read-only', async () => {
     const fixture = await makeFixture();
     process.env.LEITSTAND_ECOSYSTEM_MAP_MANIFEST_PATH = fixture.manifestPath;
 
     const data = await getEcosystemMapData();
 
     expect(data.view_meta.source_kind).toBe('artifact');
-    expect(data.view_meta.source_repository).toBe('heimgewebe/heimgewebe-katalog');
+    expect(data.view_meta.source_repository).toBe('heimgewebe/systemkatalog');
     expect(data.view_meta.source_commit).toBe('a'.repeat(40));
     expect(data.view_meta.source_root).toBe(fixture.sourceRoot);
-    expect(data.overview?.content).toContain('Heimgewebe-Systemkatalog');
-    expect(data.registry_projection?.content).toContain('Registry');
+    expect(data.map?.role).toBe('canonical_ecosystem_map_mermaid');
+    expect(data.map?.content).toContain('Systemkatalog');
     expect(data.view_meta.does_not_establish).toContain('runtime_correctness');
+  });
+
+  it('rejects a map whose bytes no longer match the manifest', async () => {
+    const fixture = await makeFixture();
+    await writeFile(fixture.mapPath, 'tampered map\n', 'utf-8');
+    process.env.LEITSTAND_ECOSYSTEM_MAP_MANIFEST_PATH = fixture.manifestPath;
+
+    const data = await getEcosystemMapData();
+
+    expect(data.view_meta.source_kind).toBe('missing');
+    expect(data.view_meta.missing_reason).toBe('artifact_integrity_mismatch');
+    expect(data.map?.content).toBeNull();
   });
 
   it('reports a missing manifest as a missing source instead of throwing', async () => {
@@ -93,8 +99,7 @@ describe('getEcosystemMapData', () => {
 
     expect(data.view_meta.source_kind).toBe('missing');
     expect(data.view_meta.missing_reason).toBe('manifest_missing');
-    expect(data.overview).toBeNull();
-    expect(data.registry_projection).toBeNull();
+    expect(data.map).toBeNull();
   });
 
   it('marks stale manifests without repairing them', async () => {
@@ -110,7 +115,7 @@ describe('getEcosystemMapData', () => {
 
   it('loads deterministic cross-view links and degrades unknown node IDs', async () => {
     const links = await loadEcosystemCrossLinks();
-    const systemCatalog = resolveEcosystemCrossLink(links, 'repo:heimgewebe-katalog');
+    const systemCatalog = resolveEcosystemCrossLink(links, 'repo:systemkatalog');
     const unknown = resolveEcosystemCrossLink(links, 'repo:unknown');
 
     expect(links.meta.source_kind).toBe('artifact');


### PR DESCRIPTION
## Ziel

Migriert Leitstand vom alten Cabinet-Kartenvertrag auf den neutralen Systemkatalog-Vertrag.

Bureau: `OPERATOR-ECOSYSTEM-REDUNDANCY-V1-T021`.

## Änderung

- Manifest-Kind: `system_catalog_map_artifact_manifest`
- Quelle: `heimgewebe/systemkatalog`
- eine kanonische Rolle: `canonical_ecosystem_map_mermaid`
- eine Kartenansicht statt zweier Aliasansichten
- Knoten-ID: `repo:systemkatalog`
- Größen- und SHA-256-Prüfung vor Anzeige
- aktive Dokumentation auf reale Systemkatalog-Pfade korrigiert

## Prüfung

- 5 Kartenvertragstests grün
- TypeScript-Typprüfung grün
- ESLint grün
- `git diff --check` grün
- vollständige Suite: 340/341 grün; der isoliert reproduzierbare Restfehler betrifft die bestehende Git-Health-Erkennung in verknüpften Worktrees, nicht den Kartenvertrag. GitHub-CI entscheidet im normalen Checkout.