### PR TITLE
Render Systemkatalog map as interactive SVG

### DIFF
--- a/audit/impl-registry.yaml
+++ b/audit/impl-registry.yaml
@@ -56,3 +56,26 @@ implementations:
       - tests/server.test.ts
     supersedes: []
     deprecated_by: []
+
+  - id: impl.controller.ecosystemMapNavigation
+    path: src/controllers/ecosystemMapNavigation.ts
+    impl_type: controller
+    status: active
+    documented_by:
+      - docs/blueprints/ecosystem-map-view.md
+    verified_by:
+      - tests/controllers/ecosystemMapNavigation.test.ts
+    supersedes: []
+    deprecated_by: []
+
+  - id: impl.view.ecosystemMapSvg
+    path: src/public/ecosystem-map.mjs
+    impl_type: view
+    status: active
+    documented_by:
+      - docs/blueprints/ecosystem-map-view.md
+    verified_by:
+      - tests/views/ecosystemMap.test.ts
+      - tests/controllers/ecosystemMapNavigation.test.ts
+    supersedes: []
+    deprecated_by: []

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "date-fns": "^3.0.0",
     "ejs": "^3.1.10",
     "express": "^5.2.1",
+    "mermaid": "11.16.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {
@@ -45,7 +46,7 @@
     "vitest": "^1.0.0"
   },
   "engines": {
-    "node": ">=18.0.0",
+    "node": ">=20.0.0",
     "pnpm": ">=8.0.0"
   },
   "packageManager": "pnpm@9.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       express:
         specifier: ^5.2.1
         version: 5.2.1
+      mermaid:
+        specifier: 11.16.0
+        version: 11.16.0
       zod:
         specifier: ^3.22.4
         version: 3.25.76
@@ -59,6 +62,15 @@ importers:
         version: 1.6.1(@types/node@20.19.27)
 
 packages:
+
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
+  '@braintree/sanitize-url@7.1.2':
+    resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
+  '@chevrotain/types@11.1.2':
+    resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -229,12 +241,21 @@ packages:
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
 
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@3.1.4':
+    resolution: {integrity: sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==}
+
   '@jest/schemas@29.6.3':
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@mermaid-js/parser@1.2.0':
+    resolution: {integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==}
 
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
@@ -392,6 +413,99 @@ packages:
   '@types/cookiejar@2.1.5':
     resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.4':
+    resolution: {integrity: sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+
   '@types/ejs@3.1.5':
     resolution: {integrity: sha512-nv+GSx77ZtXiJzwKdsASqi+YQ5Z7vwHsTP0JY2SiQgjGckkBRKZnk8nIM+7oUZ1VCtuTz0+By4qVR7fqzp/Dfg==}
 
@@ -403,6 +517,9 @@ packages:
 
   '@types/express@5.0.6':
     resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
@@ -436,6 +553,9 @@ packages:
 
   '@types/supertest@6.0.3':
     resolution: {integrity: sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@typescript-eslint/eslint-plugin@6.21.0':
     resolution: {integrity: sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==}
@@ -497,6 +617,9 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@upsetjs/venn.js@2.0.0':
+    resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
   '@vitest/expect@1.6.1':
     resolution: {integrity: sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==}
@@ -635,6 +758,14 @@ packages:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
 
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
   component-emitter@1.3.1:
     resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
 
@@ -663,12 +794,177 @@ packages:
   cookiejar@2.1.4:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
 
+  cose-base@1.0.3:
+    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
+
+  cose-base@2.2.0:
+    resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  cytoscape-cose-bilkent@4.1.0:
+    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape-fcose@2.2.0:
+    resolution: {integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape@3.34.0:
+    resolution: {integrity: sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==}
+    engines: {node: '>=0.10'}
+
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-sankey@0.12.3:
+    resolution: {integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
+
+  dagre-d3-es@7.0.14:
+    resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
+
   date-fns@3.6.0:
     resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
+
+  dayjs@1.11.21:
+    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -685,6 +981,9 @@ packages:
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -708,6 +1007,9 @@ packages:
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
+
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -740,6 +1042,9 @@ packages:
   es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.49.0:
+    resolution: {integrity: sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==}
 
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
@@ -919,6 +1224,9 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
+  hachure-fill@0.5.2:
+    resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -943,6 +1251,10 @@ packages:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
 
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
@@ -955,6 +1267,9 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
@@ -965,6 +1280,13 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -1020,8 +1342,21 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  katex@0.16.47:
+    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
+    hasBin: true
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  khroma@2.1.0:
+    resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
+
+  layout-base@1.0.2:
+    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
+
+  layout-base@2.0.1:
+    resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -1035,6 +1370,9 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
@@ -1043,6 +1381,11 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  marked@16.4.2:
+    resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -1062,6 +1405,9 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  mermaid@11.16.0:
+    resolution: {integrity: sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==}
 
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
@@ -1160,6 +1506,9 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  package-manager-detector@1.7.0:
+    resolution: {integrity: sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -1167,6 +1516,9 @@ packages:
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
+
+  path-data-parser@0.1.0:
+    resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -1209,6 +1561,12 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  points-on-curve@0.2.0:
+    resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
+
+  points-on-path@0.2.1:
+    resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
@@ -1265,10 +1623,16 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
   rollup@4.55.1:
     resolution: {integrity: sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  roughjs@4.6.6:
+    resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
 
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
@@ -1276,6 +1640,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -1360,6 +1727,9 @@ packages:
   strip-literal@2.1.1:
     resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
 
+  stylis@4.4.0:
+    resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
+
   superagent@10.3.0:
     resolution: {integrity: sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==}
     engines: {node: '>=14.18.0'}
@@ -1377,6 +1747,10 @@ packages:
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
 
   tinypool@0.8.4:
     resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
@@ -1399,6 +1773,10 @@ packages:
     engines: {node: '>=16'}
     peerDependencies:
       typescript: '>=4.2.0'
+
+  ts-dedent@2.3.0:
+    resolution: {integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==}
+    engines: {node: '>=6.10'}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -1433,6 +1811,10 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
+    hasBin: true
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -1528,6 +1910,15 @@ packages:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
+
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.7.0
+      tinyexec: 1.2.4
+
+  '@braintree/sanitize-url@7.1.2': {}
+
+  '@chevrotain/types@11.1.2': {}
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -1633,11 +2024,23 @@ snapshots:
 
   '@humanwhocodes/object-schema@2.0.3': {}
 
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@3.1.4':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      import-meta-resolve: 4.2.0
+
   '@jest/schemas@29.6.3':
     dependencies:
       '@sinclair/typebox': 0.27.8
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@mermaid-js/parser@1.2.0':
+    dependencies:
+      '@chevrotain/types': 11.1.2
 
   '@noble/hashes@1.8.0': {}
 
@@ -1745,6 +2148,123 @@ snapshots:
 
   '@types/cookiejar@2.1.5': {}
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.4': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.0
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+
   '@types/ejs@3.1.5': {}
 
   '@types/estree@1.0.8': {}
@@ -1761,6 +2281,8 @@ snapshots:
       '@types/body-parser': 1.19.6
       '@types/express-serve-static-core': 5.1.0
       '@types/serve-static': 2.2.0
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/http-errors@2.0.5': {}
 
@@ -1798,6 +2320,9 @@ snapshots:
     dependencies:
       '@types/methods': 1.1.4
       '@types/superagent': 8.1.9
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.3.3))(eslint@8.57.1)(typescript@5.3.3)':
     dependencies:
@@ -1886,6 +2411,11 @@ snapshots:
       eslint-visitor-keys: 3.4.3
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@upsetjs/venn.js@2.0.0':
+    optionalDependencies:
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   '@vitest/expect@1.6.1':
     dependencies:
@@ -2043,6 +2573,10 @@ snapshots:
     dependencies:
       delayed-stream: 1.0.0
 
+  commander@7.2.0: {}
+
+  commander@8.3.0: {}
+
   component-emitter@1.3.1: {}
 
   concat-map@0.0.1: {}
@@ -2059,13 +2593,207 @@ snapshots:
 
   cookiejar@2.1.4: {}
 
+  cose-base@1.0.3:
+    dependencies:
+      layout-base: 1.0.2
+
+  cose-base@2.2.0:
+    dependencies:
+      layout-base: 2.0.1
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
 
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 1.0.3
+      cytoscape: 3.34.0
+
+  cytoscape-fcose@2.2.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 2.2.0
+      cytoscape: 3.34.0
+
+  cytoscape@3.34.0: {}
+
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
+  d3-ease@3.0.1: {}
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@1.0.9: {}
+
+  d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-sankey@0.12.3:
+    dependencies:
+      d3-array: 2.12.1
+      d3-shape: 1.3.7
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+
+  dagre-d3-es@7.0.14:
+    dependencies:
+      d3: 7.9.0
+      lodash-es: 4.18.1
+
   date-fns@3.6.0: {}
+
+  dayjs@1.11.21: {}
 
   debug@4.4.3:
     dependencies:
@@ -2076,6 +2804,10 @@ snapshots:
       type-detect: 4.1.0
 
   deep-is@0.1.4: {}
+
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
 
   delayed-stream@1.0.0: {}
 
@@ -2095,6 +2827,10 @@ snapshots:
   doctrine@3.0.0:
     dependencies:
       esutils: 2.0.3
+
+  dompurify@3.4.12:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dunder-proto@1.0.1:
     dependencies:
@@ -2124,6 +2860,8 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
+
+  es-toolkit@1.49.0: {}
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -2413,6 +3151,8 @@ snapshots:
 
   graphemer@1.4.0: {}
 
+  hachure-fill@0.5.2: {}
+
   has-flag@4.0.0: {}
 
   has-symbols@1.1.0: {}
@@ -2435,6 +3175,10 @@ snapshots:
 
   human-signals@5.0.0: {}
 
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
@@ -2446,6 +3190,8 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  import-meta-resolve@4.2.0: {}
+
   imurmurhash@0.1.4: {}
 
   inflight@1.0.6:
@@ -2454,6 +3200,10 @@ snapshots:
       wrappy: 1.0.2
 
   inherits@2.0.4: {}
+
+  internmap@1.0.1: {}
+
+  internmap@2.0.3: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -2493,9 +3243,19 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  khroma@2.1.0: {}
+
+  layout-base@1.0.2: {}
+
+  layout-base@2.0.1: {}
 
   levn@0.4.1:
     dependencies:
@@ -2511,6 +3271,8 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash-es@4.18.1: {}
+
   lodash.merge@4.6.2: {}
 
   loupe@2.3.7:
@@ -2521,6 +3283,8 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  marked@16.4.2: {}
+
   math-intrinsics@1.1.0: {}
 
   media-typer@1.1.0: {}
@@ -2530,6 +3294,30 @@ snapshots:
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  mermaid@11.16.0:
+    dependencies:
+      '@braintree/sanitize-url': 7.1.2
+      '@iconify/utils': 3.1.4
+      '@mermaid-js/parser': 1.2.0
+      '@types/d3': 7.4.3
+      '@upsetjs/venn.js': 2.0.0
+      cytoscape: 3.34.0
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.34.0)
+      cytoscape-fcose: 2.2.0(cytoscape@3.34.0)
+      d3: 7.9.0
+      d3-sankey: 0.12.3
+      dagre-d3-es: 7.0.14
+      dayjs: 1.11.21
+      dompurify: 3.4.12
+      es-toolkit: 1.49.0
+      katex: 0.16.47
+      khroma: 2.1.0
+      marked: 16.4.2
+      roughjs: 4.6.6
+      stylis: 4.4.0
+      ts-dedent: 2.3.0
+      uuid: 11.1.1
 
   methods@1.1.2: {}
 
@@ -2620,11 +3408,15 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  package-manager-detector@1.7.0: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
 
   parseurl@1.3.3: {}
+
+  path-data-parser@0.1.0: {}
 
   path-exists@4.0.0: {}
 
@@ -2653,6 +3445,13 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.8.0
       pathe: 2.0.3
+
+  points-on-curve@0.2.0: {}
+
+  points-on-path@0.2.1:
+    dependencies:
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
 
   postcss@8.5.6:
     dependencies:
@@ -2702,6 +3501,8 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
+  robust-predicates@3.0.3: {}
+
   rollup@4.55.1:
     dependencies:
       '@types/estree': 1.0.8
@@ -2733,6 +3534,13 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.55.1
       fsevents: 2.3.3
 
+  roughjs@4.6.6:
+    dependencies:
+      hachure-fill: 0.5.2
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+      points-on-path: 0.2.1
+
   router@2.2.0:
     dependencies:
       debug: 4.4.3
@@ -2746,6 +3554,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rw@1.3.3: {}
 
   safer-buffer@2.1.2: {}
 
@@ -2838,6 +3648,8 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
+  stylis@4.4.0: {}
+
   superagent@10.3.0:
     dependencies:
       component-emitter: 1.3.1
@@ -2868,6 +3680,8 @@ snapshots:
 
   tinybench@2.9.0: {}
 
+  tinyexec@1.2.4: {}
+
   tinypool@0.8.4: {}
 
   tinyspy@2.2.1: {}
@@ -2881,6 +3695,8 @@ snapshots:
   ts-api-utils@1.4.3(typescript@5.3.3):
     dependencies:
       typescript: 5.3.3
+
+  ts-dedent@2.3.0: {}
 
   type-check@0.4.0:
     dependencies:
@@ -2907,6 +3723,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  uuid@11.1.1: {}
 
   vary@1.1.2: {}
 

--- a/src/controllers/ecosystemMapNavigation.ts
+++ b/src/controllers/ecosystemMapNavigation.ts
@@ -1,0 +1,109 @@
+import type { EcosystemCrossViewLink } from './ecosystemMapLinks.js';
+
+export type EcosystemMapNavigationTargetKind = 'leitstand' | 'systemkatalog';
+
+export interface EcosystemMapNodeNavigation {
+  mermaid_id: string;
+  node_id: string;
+  label: string;
+  href: string;
+  title: string;
+  target_kind: EcosystemMapNavigationTargetKind;
+  source_href: string;
+}
+
+interface MermaidNodeIdentity {
+  mermaidId: string;
+  nodeId: string;
+  label: string;
+  line: number;
+}
+
+const NODE_DEFINITION = /^\s*([A-Za-z][A-Za-z0-9_]*)\["([^"\n]*?)<br\s*\/?\s*>id:\s*([^<"\n]+)<br\s*\/?\s*>/;
+const SOURCE_COMMIT = /^[0-9a-f]{40}$/;
+const SOURCE_REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+
+function encodeRepository(repository: string): string {
+  return repository.split('/').map(encodeURIComponent).join('/');
+}
+
+function encodeArtifactPath(path: string): string {
+  return path.split('/').map(encodeURIComponent).join('/');
+}
+
+function canonicalSourceHref(
+  repository: string,
+  commit: string,
+  artifactPath: string,
+  line: number,
+): string {
+  if (!SOURCE_REPOSITORY.test(repository) || !SOURCE_COMMIT.test(commit)) {
+    throw new Error('invalid Systemkatalog source identity');
+  }
+  if (!artifactPath || artifactPath.startsWith('/') || artifactPath.split('/').includes('..')) {
+    throw new Error('invalid Systemkatalog artifact path');
+  }
+  return `https://github.com/${encodeRepository(repository)}/blob/${commit}/${encodeArtifactPath(artifactPath)}?plain=1#L${line}`;
+}
+
+export function extractMermaidNodeIdentities(content: string): MermaidNodeIdentity[] {
+  const identities: MermaidNodeIdentity[] = [];
+  const seenMermaidIds = new Set<string>();
+  const seenNodeIds = new Set<string>();
+
+  for (const [index, line] of content.split('\n').entries()) {
+    const match = NODE_DEFINITION.exec(line);
+    if (!match) continue;
+
+    const [, mermaidId, labelValue, nodeIdValue] = match;
+    const label = labelValue.trim();
+    const nodeId = nodeIdValue.trim();
+    if (!label || !nodeId || seenMermaidIds.has(mermaidId) || seenNodeIds.has(nodeId)) continue;
+
+    seenMermaidIds.add(mermaidId);
+    seenNodeIds.add(nodeId);
+    identities.push({ mermaidId, nodeId, label, line: index + 1 });
+  }
+
+  return identities;
+}
+
+export function buildEcosystemMapNavigation(
+  mapContent: string,
+  crossLinks: EcosystemCrossViewLink[],
+  sourceRepository: string,
+  sourceCommit: string,
+  mapPath: string,
+): EcosystemMapNodeNavigation[] {
+  const linkByNodeId = new Map(crossLinks.map((link) => [link.node_id, link]));
+
+  return extractMermaidNodeIdentities(mapContent).map((identity) => {
+    const sourceHref = canonicalSourceHref(
+      sourceRepository,
+      sourceCommit,
+      mapPath,
+      identity.line,
+    );
+    const mapped = linkByNodeId.get(identity.nodeId);
+    const target = mapped?.status === 'linked' ? mapped.links[0] : undefined;
+
+    return {
+      mermaid_id: identity.mermaidId,
+      node_id: identity.nodeId,
+      label: identity.label,
+      href: target?.href || sourceHref,
+      title: target?.title || `${identity.label} im kanonischen Systemkatalog öffnen`,
+      target_kind: target ? 'leitstand' : 'systemkatalog',
+      source_href: sourceHref,
+    };
+  });
+}
+
+export function serializeEcosystemMapNavigation(navigation: EcosystemMapNodeNavigation[]): string {
+  return JSON.stringify(navigation)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}

--- a/src/public/ecosystem-map.mjs
+++ b/src/public/ecosystem-map.mjs
@@ -1,0 +1,100 @@
+import mermaid from '/vendor/mermaid/mermaid.esm.min.mjs';
+
+const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
+
+function findRenderedNode(svgRoot, mermaidId) {
+  return [...svgRoot.querySelectorAll('g.node')].find((node) => (
+    node.getAttribute('data-id') === mermaidId
+    || node.id === mermaidId
+    || node.id.includes(`-${mermaidId}-`)
+  ));
+}
+
+function addAccessibleTitle(node, title) {
+  let titleElement = [...node.children].find((child) => child.tagName.toLowerCase() === 'title');
+  if (!titleElement) {
+    titleElement = document.createElementNS(SVG_NAMESPACE, 'title');
+    node.prepend(titleElement);
+  }
+  titleElement.textContent = title;
+}
+
+function navigateTo(href) {
+  window.location.assign(href);
+}
+
+function bindNodeNavigation(svgRoot, navigation) {
+  let linkedNodes = 0;
+
+  for (const target of navigation) {
+    const node = findRenderedNode(svgRoot, target.mermaid_id);
+    if (!node) continue;
+
+    node.classList.add('navigable-node');
+    node.setAttribute('tabindex', '0');
+    node.setAttribute('role', 'link');
+    node.setAttribute('aria-label', `${target.label}: ${target.title}`);
+    node.dataset.navigationHref = target.href;
+    node.dataset.navigationKind = target.target_kind;
+    addAccessibleTitle(node, target.title);
+
+    node.addEventListener('click', () => navigateTo(target.href));
+    node.addEventListener('keydown', (event) => {
+      if (event.key !== 'Enter' && event.key !== ' ') return;
+      event.preventDefault();
+      navigateTo(target.href);
+    });
+    linkedNodes += 1;
+  }
+
+  return linkedNodes;
+}
+
+async function renderEcosystemMap() {
+  const canvas = document.querySelector('[data-ecosystem-map-canvas]');
+  const source = document.querySelector('[data-ecosystem-map-source]');
+  const navigationData = document.querySelector('[data-ecosystem-map-navigation]');
+  const status = document.querySelector('[data-ecosystem-map-render-status]');
+  const sourceDetails = document.querySelector('[data-ecosystem-map-source-details]');
+
+  if (!canvas || !source || !navigationData || !status) return;
+
+  const navigation = JSON.parse(navigationData.textContent || '[]');
+  const definition = source.textContent || '';
+  if (!definition.trim()) {
+    status.textContent = 'Keine Mermaid-Quelle verfügbar.';
+    status.dataset.state = 'error';
+    return;
+  }
+
+  mermaid.initialize({
+    startOnLoad: false,
+    securityLevel: 'strict',
+    theme: 'dark',
+    flowchart: {
+      htmlLabels: true,
+      useMaxWidth: true,
+    },
+  });
+
+  try {
+    const renderId = `ecosystem-map-svg-${Date.now()}`;
+    const { svg, bindFunctions } = await mermaid.render(renderId, definition);
+    canvas.innerHTML = svg;
+    bindFunctions?.(canvas);
+
+    const linkedNodes = bindNodeNavigation(canvas, navigation);
+    status.textContent = `SVG gerendert · ${linkedNodes} von ${navigation.length} Knoten verlinkt`;
+    status.dataset.state = linkedNodes === navigation.length ? 'ready' : 'warning';
+    canvas.dataset.renderState = 'ready';
+  } catch (error) {
+    console.error('[EcosystemMap] Mermaid render failed:', error);
+    canvas.replaceChildren();
+    canvas.dataset.renderState = 'error';
+    status.textContent = 'SVG-Rendering fehlgeschlagen. Die geprüfte Mermaid-Quelle bleibt unten lesbar.';
+    status.dataset.state = 'error';
+    if (sourceDetails) sourceDetails.open = true;
+  }
+}
+
+void renderEcosystemMap();

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,6 +14,10 @@ import { getTimelineData } from './controllers/timeline.js';
 import { getReflexionData } from './controllers/reflexion.js';
 import { getDashboardData } from './controllers/dashboard.js';
 import { getEcosystemMapData } from './controllers/ecosystemMap.js';
+import {
+  buildEcosystemMapNavigation,
+  serializeEcosystemMapNavigation,
+} from './controllers/ecosystemMapNavigation.js';
 import { getRepoBriefData } from './controllers/repoBrief.js';
 import { getBureauData } from './controllers/bureau.js';
 import { getCheckoutData } from './controllers/checkouts.js';
@@ -81,6 +85,19 @@ app.set('view engine', 'ejs');
 // We point to src/views for the MVP to avoid build complexity of copying assets
 // This assumes the process is run from the root of the repo
 app.set('views', join(process.cwd(), 'src', 'views'));
+
+// Release-local, read-only browser assets. Mermaid is served from the lockfile-bound
+// dependency tree; the map view never depends on a third-party CDN.
+app.use('/assets', express.static(join(process.cwd(), 'src', 'public'), {
+  fallthrough: false,
+  index: false,
+  maxAge: '1h',
+}));
+app.use('/vendor/mermaid', express.static(join(process.cwd(), 'node_modules', 'mermaid', 'dist'), {
+  fallthrough: false,
+  index: false,
+  maxAge: '1h',
+}));
 
 app.post('/events', async (req, res) => {
   // 1. Authorization
@@ -368,7 +385,21 @@ app.get('/checkouts', async (_req, res) => {
 app.get('/ecosystem-map', async (_req, res) => {
   try {
     const data = await getEcosystemMapData();
-    res.render('ecosystem-map', data);
+    const navigation = data.map?.content
+      && data.view_meta.source_repository
+      && data.view_meta.source_commit
+      ? buildEcosystemMapNavigation(
+        data.map.content,
+        data.cross_links,
+        data.view_meta.source_repository,
+        data.view_meta.source_commit,
+        data.map.path,
+      )
+      : [];
+    res.render('ecosystem-map', {
+      ...data,
+      node_navigation_json: serializeEcosystemMapNavigation(navigation),
+    });
   } catch (error) {
     if (!res.headersSent) {
       console.error('[EcosystemMap] Error:', error);

--- a/src/views/ecosystem-map.ejs
+++ b/src/views/ecosystem-map.ejs
@@ -1,24 +1,48 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-  <title>Ecosystem Map – Leitstand</title>
+  <title>Ökosystemkarte – Leitstand</title>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <style>
     body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0a0e1a; color: #f1f5f9; margin: 0; }
-    nav { position: sticky; top: 0; display: flex; gap: 4px; padding: 10px 20px; background: rgba(10, 14, 26, 0.92); border-bottom: 1px solid rgba(255,255,255,.08); }
-    nav a { color: #94a3b8; text-decoration: none; padding: 6px 14px; border-radius: 6px; font-size: .82em; }
+    a { color: #60a5fa; }
+    nav { position: sticky; top: 0; z-index: 10; display: flex; gap: 4px; padding: 10px 20px; overflow-x: auto; background: rgba(10, 14, 26, 0.96); border-bottom: 1px solid rgba(255,255,255,.08); }
+    nav a { color: #94a3b8; text-decoration: none; padding: 6px 14px; border-radius: 6px; font-size: .82em; white-space: nowrap; }
     nav a.active, nav a:hover { color: #3b82f6; background: rgba(59,130,246,.1); }
-    nav .title { color: #f1f5f9; font-weight: 700; margin-right: 16px; }
-    main { max-width: 1180px; margin: 0 auto; padding: 42px 24px 80px; }
+    nav .title { color: #f1f5f9; font-weight: 700; margin-right: 16px; padding: 6px 0; white-space: nowrap; }
+    main { max-width: 1440px; margin: 0 auto; padding: 42px 24px 80px; }
     h1 { font-size: 1.9em; margin-bottom: 10px; }
-    .subtitle, .empty, .artifact-meta, li { color: #94a3b8; line-height: 1.55; }
+    h2 { margin-top: 0; }
+    .subtitle, .empty, .artifact-meta, li, summary { color: #94a3b8; line-height: 1.55; }
     .notice, .panel, .meta-item { background: rgba(17,24,39,.88); border: 1px solid rgba(255,255,255,.08); border-radius: 14px; padding: 20px 22px; margin-bottom: 18px; }
     .notice strong { color: #3b82f6; }
     .meta-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; margin-bottom: 22px; }
     .label { color: #64748b; font-size: .72em; text-transform: uppercase; letter-spacing: .08em; margin-bottom: 5px; }
     .value { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .82em; overflow-wrap: anywhere; }
+    .map-header { display: flex; flex-wrap: wrap; align-items: baseline; justify-content: space-between; gap: 10px 18px; margin-bottom: 14px; }
+    .render-status { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .78em; color: #94a3b8; }
+    .render-status[data-state="ready"] { color: #86efac; }
+    .render-status[data-state="warning"] { color: #fde68a; }
+    .render-status[data-state="error"] { color: #fca5a5; }
+    .map-canvas { min-height: 420px; overflow: auto; padding: 18px; background: rgba(2,6,23,.72); border: 1px solid rgba(255,255,255,.08); border-radius: 12px; }
+    .map-canvas[data-render-state="loading"] { display: grid; place-items: center; color: #64748b; }
+    .map-canvas svg { display: block; min-width: 980px; width: 100%; height: auto; margin: 0 auto; }
+    .map-canvas g.node.navigable-node { cursor: pointer; }
+    .map-canvas g.node.navigable-node:hover > rect,
+    .map-canvas g.node.navigable-node:hover > polygon,
+    .map-canvas g.node.navigable-node:focus > rect,
+    .map-canvas g.node.navigable-node:focus > polygon { stroke: #60a5fa !important; stroke-width: 3px !important; }
+    .map-canvas g.node.navigable-node:focus { outline: none; }
+    details { margin-top: 16px; }
+    summary { cursor: pointer; }
     pre { background: rgba(2,6,23,.72); color: #dbeafe; border: 1px solid rgba(255,255,255,.08); border-radius: 10px; padding: 16px; overflow: auto; font-size: .78em; line-height: 1.45; max-height: 520px; }
+    .link-note { margin: 0 0 14px; color: #94a3b8; line-height: 1.5; }
+    @media (max-width: 720px) {
+      main { padding: 28px 14px 60px; }
+      .notice, .panel, .meta-item { padding: 16px; }
+      .map-canvas { padding: 10px; min-height: 360px; }
+    }
   </style>
 </head>
 <body>
@@ -28,7 +52,7 @@
     <a href="/bureau">Bureau</a>
     <a href="/checkouts">Checkouts</a>
     <a href="/observatory">Observatorium</a>
-    <a href="/ecosystem-map" class="active" aria-current="page">Ecosystem Map</a>
+    <a href="/ecosystem-map" class="active" aria-current="page">Ökosystemkarte</a>
     <a href="/repobriefs">RepoBriefs</a>
     <a href="/anatomy">Anatomie</a>
     <a href="/timeline">Zeitachse</a>
@@ -38,38 +62,68 @@
   </nav>
 
   <main>
-    <h1>Ecosystem Map</h1>
-    <p class="subtitle">Read-only source view for the Heimgewebe ecosystem map owned by the Systemkatalog.</p>
+    <h1>Ökosystemkarte</h1>
+    <p class="subtitle">Grafische, ausschließlich lesende Projektion der vom Systemkatalog verantworteten Ökosystemsemantik.</p>
 
-    <section class="notice" aria-label="Boundary">
-      <strong>View only.</strong> Canonical map semantics live in the Systemkatalog. Leitstand displays pinned artifacts and freshness metadata; it does not edit the map, infer claim truth, dispatch tasks, or prove runtime correctness or merge readiness.
+    <section class="notice" aria-label="Zuständigkeitsgrenze">
+      <strong>Nur Ansicht.</strong> Der Systemkatalog besitzt Systeme, Beziehungen und Bedeutungen. Leitstand rendert das geprüfte, commit- und hashgebundene Artefakt als SVG. Er bearbeitet die Karte nicht, leitet keine neue Wahrheit ab und löst keine Aufgaben oder Änderungen aus.
     </section>
 
-    <section class="meta-grid" aria-label="Source metadata">
-      <div class="meta-item"><div class="label">Source state</div><div class="value"><%= view_meta.source_kind %> / <%= view_meta.missing_reason %></div></div>
+    <section class="meta-grid" aria-label="Quellenmetadaten">
+      <div class="meta-item"><div class="label">Quellzustand</div><div class="value"><%= view_meta.source_kind %> / <%= view_meta.missing_reason %></div></div>
       <div class="meta-item"><div class="label">Manifest</div><div class="value"><%= view_meta.manifest_path %></div></div>
-      <div class="meta-item"><div class="label">Source root</div><div class="value"><%= view_meta.source_root || '—' %></div></div>
+      <div class="meta-item"><div class="label">Quellwurzel</div><div class="value"><%= view_meta.source_root || '—' %></div></div>
       <div class="meta-item"><div class="label">Repository</div><div class="value"><%= view_meta.source_repository || '—' %></div></div>
-      <div class="meta-item"><div class="label">Commit</div><div class="value"><%= view_meta.source_commit || '—' %></div></div>
-      <div class="meta-item"><div class="label">Freshness</div><div class="value"><%= view_meta.freshness_state %><% if (view_meta.data_age_minutes !== null) { %> · <%= view_meta.data_age_minutes %> min<% } %></div></div>
+      <div class="meta-item">
+        <div class="label">Commit</div>
+        <div class="value">
+          <% if (view_meta.source_repository && view_meta.source_commit) { %>
+            <a href="https://github.com/<%= view_meta.source_repository %>/tree/<%= view_meta.source_commit %>"><%= view_meta.source_commit %></a>
+          <% } else { %>—<% } %>
+        </div>
+      </div>
+      <div class="meta-item"><div class="label">Frische</div><div class="value"><%= view_meta.freshness_state %><% if (view_meta.data_age_minutes !== null) { %> · <%= view_meta.data_age_minutes %> min<% } %></div></div>
     </section>
 
-    <section class="panel" aria-label="Cross-view identity mapping">
-      <h2>Cross-view links</h2>
-      <p class="artifact-meta">Contract: <%= cross_link_meta.source_kind %> / <%= cross_link_meta.missing_reason %> · <%= cross_link_meta.source_path %></p>
+    <section class="panel" aria-labelledby="canonical-map-heading">
+      <div class="map-header">
+        <h2 id="canonical-map-heading">Kanonische Karte</h2>
+        <div class="render-status" data-ecosystem-map-render-status data-state="loading">SVG wird lokal gerendert …</div>
+      </div>
+      <% if (map && map.content) { %>
+        <p class="artifact-meta">
+          <a href="https://github.com/<%= view_meta.source_repository %>/blob/<%= view_meta.source_commit %>/<%= map.path %>"><%= map.path %></a>
+          · <%= map.bytes %> Bytes · sha256 <%= map.sha256 %>
+        </p>
+        <p class="link-note">Knoten mit einer passenden Leitstand-Ansicht öffnen diese Ansicht. Alle übrigen Knoten führen zur exakten Definitionszeile im gebundenen Systemkatalog-Commit. Tastatur: Tab, dann Enter oder Leertaste.</p>
+        <div class="map-canvas" data-ecosystem-map-canvas data-render-state="loading" aria-live="polite">Karte wird vorbereitet …</div>
+        <pre hidden data-ecosystem-map-source><%= map.content %></pre>
+        <script type="application/json" data-ecosystem-map-navigation><%- node_navigation_json %></script>
+        <details data-ecosystem-map-source-details>
+          <summary>Geprüfte Mermaid-Quelle anzeigen</summary>
+          <pre><%= map.content %></pre>
+        </details>
+      <% } else { %>
+        <p class="empty">Die kanonische Mermaid-Quelle ist nicht verfügbar. Grund: <%= map ? map.missing_reason : view_meta.missing_reason %>.</p>
+      <% } %>
+    </section>
+
+    <section class="panel" aria-label="Spezifische Leitstand-Verknüpfungen">
+      <h2>Spezifische Ansichten</h2>
+      <p class="artifact-meta">Vertrag: <%= cross_link_meta.source_kind %> / <%= cross_link_meta.missing_reason %> · <%= cross_link_meta.source_path %></p>
       <% if (cross_links.length === 0) { %>
-        <p class="empty">No cross-view mapping contract is available. Unknown nodes remain unlinked.</p>
+        <p class="empty">Kein Cross-View-Vertrag verfügbar. Die Kartenknoten verweisen weiterhin auf ihren exakten Systemkatalog-Ursprung.</p>
       <% } else { %>
         <ul>
           <% for (const link of cross_links) { %>
             <li>
-              <strong><%= link.node_id %></strong> — <%= link.label %> — <%= link.status %>
+              <strong><%= link.label %></strong> (<%= link.node_id %>)
               <% if (link.links.length > 0) { %>
                 <% for (const target of link.links) { %>
                   · <a href="<%= target.href %>"><%= target.title %></a>
                 <% } %>
               <% } else { %>
-                · <%= link.reason || 'unmapped' %>
+                · <%= link.reason || 'nicht zugeordnet' %>
               <% } %>
             </li>
           <% } %>
@@ -78,17 +132,7 @@
     </section>
 
     <section class="panel">
-      <h2>Canonical ecosystem map</h2>
-      <% if (map && map.content) { %>
-        <div class="artifact-meta"><%= map.path %> · <%= map.bytes %> bytes · sha256 <%= map.sha256 %></div>
-        <pre><%= map.content %></pre>
-      <% } else { %>
-        <p class="empty">Canonical Mermaid source is not available. Reason: <%= map ? map.missing_reason : view_meta.missing_reason %>.</p>
-      <% } %>
-    </section>
-
-    <section class="panel">
-      <h2>Does not establish</h2>
+      <h2>Belegt ausdrücklich nicht</h2>
       <ul>
         <% for (const item of view_meta.does_not_establish) { %>
           <li><%= item %></li>
@@ -96,5 +140,6 @@
       </ul>
     </section>
   </main>
+  <script type="module" src="/assets/ecosystem-map.mjs"></script>
 </body>
 </html>

--- a/tests/controllers/ecosystemMapNavigation.test.ts
+++ b/tests/controllers/ecosystemMapNavigation.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildEcosystemMapNavigation,
+  extractMermaidNodeIdentities,
+  serializeEcosystemMapNavigation,
+} from '../../src/controllers/ecosystemMapNavigation.js';
+import type { EcosystemCrossViewLink } from '../../src/controllers/ecosystemMapLinks.js';
+
+const COMMIT = 'a'.repeat(40);
+const MAP = [
+  'flowchart TD',
+  '  repo_bureau["Bureau<br/>id: repo:bureau<br/>repository<br/>task cadence"]',
+  '  repo_systemkatalog["Systemkatalog<br/>id: repo:systemkatalog<br/>repository<br/>catalog"]',
+  '  service_github["GitHub<br/>id: service:github<br/>service<br/>repository state"]',
+  '  repo_bureau --> repo_systemkatalog',
+].join('\n');
+
+const LINKS: EcosystemCrossViewLink[] = [
+  {
+    node_id: 'repo:bureau',
+    label: 'Bureau',
+    status: 'linked',
+    reason: null,
+    links: [{ view: 'bureau', href: '/bureau', title: 'Bureau task view' }],
+  },
+];
+
+describe('ecosystem map node navigation', () => {
+  it('extracts stable node IDs and source lines from the generated Mermaid map', () => {
+    expect(extractMermaidNodeIdentities(MAP)).toEqual([
+      { mermaidId: 'repo_bureau', nodeId: 'repo:bureau', label: 'Bureau', line: 2 },
+      { mermaidId: 'repo_systemkatalog', nodeId: 'repo:systemkatalog', label: 'Systemkatalog', line: 3 },
+      { mermaidId: 'service_github', nodeId: 'service:github', label: 'GitHub', line: 4 },
+    ]);
+  });
+
+  it('uses explicit Leitstand mappings and exact commit-bound Systemkatalog fallbacks', () => {
+    const navigation = buildEcosystemMapNavigation(
+      MAP,
+      LINKS,
+      'heimgewebe/systemkatalog',
+      COMMIT,
+      'rendered/ecosystem-registry-map.mmd',
+    );
+
+    expect(navigation).toHaveLength(3);
+    expect(navigation[0]).toMatchObject({
+      node_id: 'repo:bureau',
+      href: '/bureau',
+      target_kind: 'leitstand',
+    });
+    expect(navigation[1]).toMatchObject({
+      node_id: 'repo:systemkatalog',
+      target_kind: 'systemkatalog',
+      href: `https://github.com/heimgewebe/systemkatalog/blob/${COMMIT}/rendered/ecosystem-registry-map.mmd?plain=1#L3`,
+    });
+    expect(navigation[2].source_href).toContain(`/${COMMIT}/rendered/ecosystem-registry-map.mmd?plain=1#L4`);
+  });
+
+  it('serializes navigation without allowing an inline script terminator', () => {
+    const navigation = buildEcosystemMapNavigation(
+      MAP,
+      [{
+        ...LINKS[0],
+        links: [{ view: 'bureau', href: '/bureau', title: '</script><script>alert(1)</script>' }],
+      }],
+      'heimgewebe/systemkatalog',
+      COMMIT,
+      'rendered/ecosystem-registry-map.mmd',
+    );
+    const serialized = serializeEcosystemMapNavigation(navigation);
+
+    expect(serialized).not.toContain('</script>');
+    expect(JSON.parse(serialized)[0].title).toBe('</script><script>alert(1)</script>');
+  });
+
+  it('rejects invalid source identities rather than creating an unbound fallback', () => {
+    expect(() => buildEcosystemMapNavigation(
+      MAP,
+      [],
+      'heimgewebe/systemkatalog',
+      'main',
+      'rendered/ecosystem-registry-map.mmd',
+    )).toThrow('invalid Systemkatalog source identity');
+  });
+});

--- a/tests/views/ecosystemMap.test.ts
+++ b/tests/views/ecosystemMap.test.ts
@@ -1,0 +1,67 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import ejs from 'ejs';
+import { describe, expect, it } from 'vitest';
+
+describe('ecosystem-map view', () => {
+  it('renders a local read-only SVG canvas while preserving source identity and freshness', async () => {
+    const commit = 'a'.repeat(40);
+    const html = await ejs.renderFile(
+      join(process.cwd(), 'src/views/ecosystem-map.ejs'),
+      {
+        map: {
+          path: 'rendered/ecosystem-registry-map.mmd',
+          bytes: 42,
+          sha256: 'b'.repeat(64),
+          content: 'flowchart TD\n  repo_bureau["Bureau"]\n',
+          missing_reason: null,
+        },
+        cross_links: [],
+        cross_link_meta: {
+          source_kind: 'artifact',
+          source_path: '/tmp/cross-links.json',
+          missing_reason: 'ok',
+          does_not_establish: [],
+        },
+        view_meta: {
+          source_kind: 'artifact',
+          missing_reason: 'ok',
+          manifest_path: '/tmp/manifest.json',
+          source_root: '/tmp/systemkatalog',
+          source_repository: 'heimgewebe/systemkatalog',
+          source_commit: commit,
+          generated_at: '2026-07-14T00:00:00Z',
+          data_age_minutes: 12,
+          freshness_state: 'fresh',
+          stale_after_hours: 168,
+          does_not_establish: ['runtime_correctness'],
+        },
+        node_navigation_json: '[{"mermaid_id":"repo_bureau","href":"/bureau"}]',
+      },
+      { async: true, localsName: 'locals' },
+    );
+
+    expect(html).toContain('data-ecosystem-map-canvas');
+    expect(html).toContain('data-ecosystem-map-source');
+    expect(html).toContain('data-ecosystem-map-navigation');
+    expect(html).toContain('/assets/ecosystem-map.mjs');
+    expect(html).toContain(commit);
+    expect(html).toContain('fresh · 12 min');
+    expect(html).not.toContain('cdn.jsdelivr');
+    expect(html).not.toContain('<form');
+    expect(html).not.toContain('contenteditable');
+  });
+
+  it('uses the lockfile-local Mermaid module with strict rendering and no remote fetch', async () => {
+    const browserModule = await readFile(
+      join(process.cwd(), 'src/public/ecosystem-map.mjs'),
+      'utf-8',
+    );
+
+    expect(browserModule).toContain("from '/vendor/mermaid/mermaid.esm.min.mjs'");
+    expect(browserModule).toContain("securityLevel: 'strict'");
+    expect(browserModule).toContain("setAttribute('role', 'link')");
+    expect(browserModule).not.toContain('fetch(');
+    expect(browserModule).not.toContain('contenteditable');
+  });
+});


### PR DESCRIPTION
## Zweck

Leitstand rendert das commit- und hashgebundene Mermaid-Artefakt des Systemkatalogs als lokale, ausschließlich lesende SVG-Ansicht.

## Änderung

- Mermaid 11.16.0 lokal und lockfile-gebunden ausliefern; kein CDN
- Quellencommit, Frische, Artefaktpfad und SHA-256 sichtbar lassen
- alle kanonischen Kartenknoten tastaturzugänglich verlinken
- bekannte Knoten in passende Leitstand-Ansichten führen
- übrige Knoten zur exakten Definitionszeile im gebundenen Systemkatalog-Commit führen
- geprüfte Mermaid-Quelle als Fallback erhalten
- keine Bearbeitungs- oder Schreibschnittstelle hinzufügen
- Mindestlaufzeit auf Node 20 anheben; Docker und CI verwenden bereits Node 20, Produktion Node 22

## Prüfung

- unabhängiger normaler Clone: 44 Testdateien, 348/348 Tests grün
- Typecheck, Lint, Build und Repository-Gates grün
- echter Headless-Chrome-Smoke: SVG ready, 37/37 Knoten navigierbar
- `pnpm audit --prod --audit-level high`: keine zusätzlichen hohen Befunde gegenüber main

## Grenzen

Leitstand bleibt Projektion. Der Systemkatalog besitzt weiterhin Systeme, Beziehungen und Bedeutungen.