### PR TITLE
fix: Systemkatalog-Kartenfrische korrekt belegen

### DIFF
--- a/src/controllers/ecosystemMap.ts
+++ b/src/controllers/ecosystemMap.ts
@@ -1,6 +1,7 @@
-import { readFile } from 'node:fs/promises';
+import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { basename, dirname, join, resolve, relative } from 'node:path';
+import { readFile } from 'node:fs/promises';
+import { basename, dirname, join, relative, resolve } from 'node:path';
 import {
   loadEcosystemCrossLinks,
   type EcosystemCrossLinkData,
@@ -8,10 +9,52 @@ import {
 } from './ecosystemMapLinks.js';
 
 const MANIFEST_KIND = 'system_catalog_map_artifact_manifest';
+const MANIFEST_SCHEMA_PATH = 'catalog/ecosystem-map-artifact-manifest.schema.v1.json';
+const MANIFEST_MODE = 'read_only_projection_source';
 const DEFAULT_STALE_AFTER_HOURS = 168;
+const GIT_TIMEOUT_MS = 2_500;
+const MAX_GIT_OUTPUT_BYTES = 1_000_000;
+
+const ARTIFACT_CONTRACT = [
+  {
+    role: 'canonical_ecosystem_map_mermaid',
+    path: 'rendered/ecosystem-registry-map.mmd',
+    contentType: 'text/mermaid',
+  },
+  {
+    role: 'rendered_catalog_markdown',
+    path: 'rendered/system-catalog.md',
+    contentType: 'text/markdown',
+  },
+  {
+    role: 'registry_nodes',
+    path: 'registry/ecosystem/nodes.json',
+    contentType: 'application/json',
+  },
+  {
+    role: 'registry_edges',
+    path: 'registry/ecosystem/edges.json',
+    contentType: 'application/json',
+  },
+  {
+    role: 'authority_matrix',
+    path: 'registry/ecosystem/authority-matrix.v1.json',
+    contentType: 'application/json',
+  },
+] as const;
+
+const DOES_NOT_ESTABLISH_CONTRACT = [
+  'claim_truth',
+  'runtime_correctness',
+  'merge_readiness',
+  'system_catalog_registry_correctness',
+  'consumer_view_correctness',
+  'render_success_validates_map',
+] as const;
 
 export type EcosystemMapSourceKind = 'artifact' | 'missing' | 'corrupt';
 export type EcosystemMapFreshness = 'fresh' | 'stale' | 'unknown';
+export type EcosystemMapAlignment = 'exact' | 'compatible' | 'drifted' | 'unverifiable';
 
 interface MapManifestArtifact {
   role: string;
@@ -25,6 +68,8 @@ interface MapManifest {
   schemaVersion: number;
   kind: string;
   contractVersion: string;
+  schemaPath: string;
+  mode: string;
   source: {
     repository: string;
     commit: string;
@@ -33,6 +78,28 @@ interface MapManifest {
   artifactCount: number;
   artifacts: MapManifestArtifact[];
   doesNotEstablish: string[];
+}
+
+interface GitCommandResult {
+  code: number | null;
+  stdout: Buffer;
+  stderr: string;
+  timedOut: boolean;
+  outputOverflow: boolean;
+}
+
+interface ArtifactInspection {
+  artifact: MapManifestArtifact;
+  view: EcosystemMapArtifactView;
+  matches: boolean;
+}
+
+interface AlignmentInspection {
+  state: EcosystemMapAlignment;
+  reason: string;
+  sourceHead: string | null;
+  commitsAhead: number | null;
+  verifiedArtifactCount: number;
 }
 
 export interface EcosystemMapArtifactView {
@@ -61,9 +128,15 @@ export interface EcosystemMapViewData {
     source_root: string | null;
     source_repository: string | null;
     source_commit: string | null;
+    source_head: string | null;
+    commits_ahead: number | null;
+    alignment_state: EcosystemMapAlignment;
+    alignment_reason: string;
+    verified_artifact_count: number;
     generated_at: string | null;
     data_age_minutes: number | null;
     freshness_state: EcosystemMapFreshness;
+    freshness_reason: string;
     stale_after_hours: number;
     does_not_establish: string[];
   };
@@ -117,9 +190,15 @@ function emptyData(
       source_root: null,
       source_repository: null,
       source_commit: null,
+      source_head: null,
+      commits_ahead: null,
+      alignment_state: 'unverifiable',
+      alignment_reason: reason,
+      verified_artifact_count: 0,
       generated_at: null,
       data_age_minutes: null,
       freshness_state: 'unknown',
+      freshness_reason: reason,
       stale_after_hours: configuredStaleAfterHours(),
       does_not_establish: [
         'claim_truth',
@@ -130,39 +209,109 @@ function emptyData(
   };
 }
 
-function parseManifest(raw: unknown): MapManifest {
-  if (!raw || typeof raw !== 'object') {
-    throw new Error('invalid ecosystem map manifest: root must be object');
-  }
-  const manifest = raw as Partial<MapManifest>;
-  if (manifest.schemaVersion !== 1) {
-    throw new Error('invalid ecosystem map manifest: schemaVersion must be 1');
-  }
-  if (manifest.kind !== MANIFEST_KIND) {
-    throw new Error('invalid ecosystem map manifest: kind mismatch');
-  }
-  if (!manifest.source || typeof manifest.source !== 'object') {
-    throw new Error('invalid ecosystem map manifest: source missing');
-  }
-  if (manifest.source.repository !== 'heimgewebe/systemkatalog') {
-    throw new Error('invalid ecosystem map manifest: source repository mismatch');
-  }
-  if (!/^[0-9a-f]{40}$/.test(manifest.source.commit || '')) {
-    throw new Error('invalid ecosystem map manifest: source commit mismatch');
-  }
-  if (manifest.contractVersion !== '1') {
-    throw new Error('invalid ecosystem map manifest: contractVersion mismatch');
-  }
-  if (!Array.isArray(manifest.artifacts) || manifest.artifactCount !== manifest.artifacts.length) {
-    throw new Error('invalid ecosystem map manifest: artifacts missing or count mismatch');
-  }
-  if (!Array.isArray(manifest.doesNotEstablish)) {
-    throw new Error('invalid ecosystem map manifest: non-claims missing');
-  }
-  return manifest as MapManifest;
+function hasExactKeys(value: Record<string, unknown>, expected: readonly string[]): boolean {
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  return actual.length === wanted.length && actual.every((key, index) => key === wanted[index]);
 }
 
-function freshness(generatedAt: string | null, staleAfterHours: number): {
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function parseManifest(raw: unknown): MapManifest {
+  if (!isRecord(raw)) {
+    throw new Error('invalid ecosystem map manifest: root must be object');
+  }
+  if (!hasExactKeys(raw, [
+    'schemaVersion',
+    'kind',
+    'contractVersion',
+    'schemaPath',
+    'mode',
+    'source',
+    'artifactCount',
+    'artifacts',
+    'doesNotEstablish',
+  ])) {
+    throw new Error('invalid ecosystem map manifest: fields mismatch');
+  }
+  if (raw.schemaVersion !== 1 || raw.kind !== MANIFEST_KIND) {
+    throw new Error('invalid ecosystem map manifest: identity mismatch');
+  }
+  if (raw.contractVersion !== '1' || raw.schemaPath !== MANIFEST_SCHEMA_PATH) {
+    throw new Error('invalid ecosystem map manifest: contract binding mismatch');
+  }
+  if (raw.mode !== MANIFEST_MODE) {
+    throw new Error('invalid ecosystem map manifest: mode mismatch');
+  }
+  if (!isRecord(raw.source) || !hasExactKeys(raw.source, ['repository', 'commit', 'generatedAt'])) {
+    throw new Error('invalid ecosystem map manifest: source fields mismatch');
+  }
+  if (raw.source.repository !== 'heimgewebe/systemkatalog') {
+    throw new Error('invalid ecosystem map manifest: source repository mismatch');
+  }
+  if (typeof raw.source.commit !== 'string' || !/^[0-9a-f]{40}$/.test(raw.source.commit)) {
+    throw new Error('invalid ecosystem map manifest: source commit mismatch');
+  }
+  if (typeof raw.source.generatedAt !== 'string' || Number.isNaN(new Date(raw.source.generatedAt).getTime())) {
+    throw new Error('invalid ecosystem map manifest: generatedAt mismatch');
+  }
+  if (!Array.isArray(raw.artifacts) || raw.artifactCount !== ARTIFACT_CONTRACT.length || raw.artifacts.length !== ARTIFACT_CONTRACT.length) {
+    throw new Error('invalid ecosystem map manifest: artifacts missing or count mismatch');
+  }
+
+  const artifacts = raw.artifacts.map((item, index): MapManifestArtifact => {
+    if (!isRecord(item) || !hasExactKeys(item, ['role', 'path', 'contentType', 'bytes', 'sha256'])) {
+      throw new Error(`invalid ecosystem map manifest: artifact fields mismatch at ${index}`);
+    }
+    const expected = ARTIFACT_CONTRACT[index];
+    if (item.role !== expected.role || item.path !== expected.path || item.contentType !== expected.contentType) {
+      throw new Error(`invalid ecosystem map manifest: artifact contract mismatch at ${index}`);
+    }
+    if (!Number.isInteger(item.bytes) || (item.bytes as number) < 1) {
+      throw new Error(`invalid ecosystem map manifest: artifact bytes mismatch at ${index}`);
+    }
+    if (typeof item.sha256 !== 'string' || !/^[0-9a-f]{64}$/.test(item.sha256)) {
+      throw new Error(`invalid ecosystem map manifest: artifact sha256 mismatch at ${index}`);
+    }
+    return {
+      role: expected.role,
+      path: expected.path,
+      contentType: expected.contentType,
+      bytes: item.bytes as number,
+      sha256: item.sha256,
+    };
+  });
+
+  if (!Array.isArray(raw.doesNotEstablish)
+    || raw.doesNotEstablish.length !== DOES_NOT_ESTABLISH_CONTRACT.length
+    || raw.doesNotEstablish.some((item, index) => item !== DOES_NOT_ESTABLISH_CONTRACT[index])) {
+    throw new Error('invalid ecosystem map manifest: non-claims mismatch');
+  }
+
+  const sourceRepository = raw.source.repository as string;
+  const sourceCommit = raw.source.commit as string;
+  const generatedAt = raw.source.generatedAt as string;
+
+  return {
+    schemaVersion: 1,
+    kind: MANIFEST_KIND,
+    contractVersion: '1',
+    schemaPath: MANIFEST_SCHEMA_PATH,
+    mode: MANIFEST_MODE,
+    source: {
+      repository: sourceRepository,
+      commit: sourceCommit,
+      generatedAt,
+    },
+    artifactCount: ARTIFACT_CONTRACT.length,
+    artifacts,
+    doesNotEstablish: [...DOES_NOT_ESTABLISH_CONTRACT],
+  };
+}
+
+function ageFreshness(generatedAt: string | null, staleAfterHours: number): {
   generated_at: string | null;
   data_age_minutes: number | null;
   freshness_state: EcosystemMapFreshness;
@@ -174,7 +323,7 @@ function freshness(generatedAt: string | null, staleAfterHours: number): {
   if (Number.isNaN(generatedMs)) {
     return { generated_at: generatedAt, data_age_minutes: null, freshness_state: 'unknown' };
   }
-  const ageMinutes = Math.max(0, Math.floor((Date.now() - generatedMs) / 60000));
+  const ageMinutes = Math.max(0, Math.floor((Date.now() - generatedMs) / 60_000));
   return {
     generated_at: new Date(generatedMs).toISOString(),
     data_age_minutes: ageMinutes,
@@ -183,54 +332,258 @@ function freshness(generatedAt: string | null, staleAfterHours: number): {
 }
 
 function resolveArtifactPath(sourceRoot: string, artifactPath: string): string {
-  if (artifactPath.startsWith('/') || artifactPath.includes('..')) {
-    throw new Error('invalid ecosystem map manifest: artifact path escapes source root');
-  }
   const resolved = resolve(sourceRoot, artifactPath);
   const rel = relative(sourceRoot, resolved);
-  if (rel.startsWith('..') || rel === '') {
+  if (artifactPath.startsWith('/') || rel.startsWith('..') || rel === '') {
     throw new Error('invalid ecosystem map manifest: artifact path escapes source root');
   }
   return resolved;
 }
 
-async function readArtifact(sourceRoot: string, artifact: MapManifestArtifact | undefined): Promise<EcosystemMapArtifactView | null> {
-  if (!artifact) return null;
+function digestMatches(raw: Buffer, artifact: MapManifestArtifact): boolean {
+  return raw.byteLength === artifact.bytes
+    && createHash('sha256').update(raw).digest('hex') === artifact.sha256;
+}
+
+async function inspectCurrentArtifact(sourceRoot: string, artifact: MapManifestArtifact): Promise<ArtifactInspection> {
   const resolvedPath = resolveArtifactPath(sourceRoot, artifact.path);
   try {
     const raw = await readFile(resolvedPath);
-    const digest = createHash('sha256').update(raw).digest('hex');
-    if (raw.byteLength !== artifact.bytes || digest !== artifact.sha256) {
-      return {
+    const matches = digestMatches(raw, artifact);
+    return {
+      artifact,
+      matches,
+      view: {
+        role: artifact.role,
+        path: artifact.path,
+        content_type: artifact.contentType,
+        bytes: artifact.bytes,
+        sha256: artifact.sha256,
+        content: matches ? raw.toString('utf-8') : null,
+        missing_reason: matches ? null : 'artifact_integrity_mismatch',
+      },
+    };
+  } catch {
+    return {
+      artifact,
+      matches: false,
+      view: {
         role: artifact.role,
         path: artifact.path,
         content_type: artifact.contentType,
         bytes: artifact.bytes,
         sha256: artifact.sha256,
         content: null,
-        missing_reason: 'artifact_integrity_mismatch',
-      };
-    }
-    return {
-      role: artifact.role,
-      path: artifact.path,
-      content_type: artifact.contentType,
-      bytes: artifact.bytes,
-      sha256: artifact.sha256,
-      content: raw.toString('utf-8'),
-      missing_reason: null,
-    };
-  } catch {
-    return {
-      role: artifact.role,
-      path: artifact.path,
-      content_type: artifact.contentType,
-      bytes: artifact.bytes,
-      sha256: artifact.sha256,
-      content: null,
-      missing_reason: 'artifact_missing',
+        missing_reason: 'artifact_missing',
+      },
     };
   }
+}
+
+function runGit(sourceRoot: string, args: string[]): Promise<GitCommandResult> {
+  return new Promise((resolveResult) => {
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    let stdoutBytes = 0;
+    let settled = false;
+    let timedOut = false;
+    let outputOverflow = false;
+
+    const child = spawn('git', ['-C', sourceRoot, ...args], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+
+    const finish = (code: number | null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolveResult({
+        code,
+        stdout: Buffer.concat(stdout),
+        stderr: Buffer.concat(stderr).toString('utf-8').slice(0, 2_000),
+        timedOut,
+        outputOverflow,
+      });
+    };
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGKILL');
+    }, GIT_TIMEOUT_MS);
+
+    child.stdout?.on('data', (chunk: Buffer) => {
+      stdoutBytes += chunk.byteLength;
+      if (stdoutBytes > MAX_GIT_OUTPUT_BYTES) {
+        outputOverflow = true;
+        child.kill('SIGKILL');
+        return;
+      }
+      stdout.push(chunk);
+    });
+    child.stderr?.on('data', (chunk: Buffer) => stderr.push(chunk));
+    child.on('error', () => finish(null));
+    child.on('close', (code) => finish(code));
+  });
+}
+
+async function inspectAlignment(
+  sourceRoot: string,
+  manifest: MapManifest,
+  currentArtifacts: ArtifactInspection[],
+): Promise<AlignmentInspection> {
+  const currentMismatch = currentArtifacts.find((item) => !item.matches);
+  const headResult = await runGit(sourceRoot, ['rev-parse', '--verify', 'HEAD^{commit}']);
+  const sourceHead = headResult.code === 0
+    ? headResult.stdout.toString('utf-8').trim()
+    : null;
+
+  if (currentMismatch) {
+    return {
+      state: 'drifted',
+      reason: `current_artifact_mismatch:${currentMismatch.artifact.path}`,
+      sourceHead: /^[0-9a-f]{40}$/.test(sourceHead || '') ? sourceHead : null,
+      commitsAhead: null,
+      verifiedArtifactCount: currentArtifacts.filter((item) => item.matches).length,
+    };
+  }
+
+  if (headResult.code !== 0 || headResult.timedOut || headResult.outputOverflow || sourceHead === null || !/^[0-9a-f]{40}$/.test(sourceHead)) {
+    return {
+      state: 'unverifiable',
+      reason: 'source_git_head_unavailable',
+      sourceHead: null,
+      commitsAhead: null,
+      verifiedArtifactCount: currentArtifacts.length,
+    };
+  }
+  const verifiedSourceHead = sourceHead;
+
+  const commitArtifacts = await Promise.all(manifest.artifacts.map(async (artifact) => {
+    const result = await runGit(sourceRoot, [
+      'show',
+      '--no-ext-diff',
+      '--no-textconv',
+      `${manifest.source.commit}:${artifact.path}`,
+    ]);
+    return {
+      artifact,
+      matches: result.code === 0
+        && !result.timedOut
+        && !result.outputOverflow
+        && digestMatches(result.stdout, artifact),
+    };
+  }));
+  const commitMismatch = commitArtifacts.find((item) => !item.matches);
+  if (commitMismatch) {
+    return {
+      state: 'drifted',
+      reason: `source_commit_artifact_mismatch:${commitMismatch.artifact.path}`,
+      sourceHead: verifiedSourceHead,
+      commitsAhead: null,
+      verifiedArtifactCount: commitArtifacts.filter((item) => item.matches).length,
+    };
+  }
+
+  const ancestry = await runGit(sourceRoot, [
+    'merge-base',
+    '--is-ancestor',
+    manifest.source.commit,
+    verifiedSourceHead,
+  ]);
+  if (ancestry.code === 1) {
+    return {
+      state: 'drifted',
+      reason: 'source_commit_not_ancestor',
+      sourceHead: verifiedSourceHead,
+      commitsAhead: null,
+      verifiedArtifactCount: manifest.artifacts.length,
+    };
+  }
+  if (ancestry.code !== 0 || ancestry.timedOut || ancestry.outputOverflow) {
+    return {
+      state: 'unverifiable',
+      reason: 'source_commit_ancestry_unavailable',
+      sourceHead: verifiedSourceHead,
+      commitsAhead: null,
+      verifiedArtifactCount: manifest.artifacts.length,
+    };
+  }
+
+  if (verifiedSourceHead === manifest.source.commit) {
+    return {
+      state: 'exact',
+      reason: 'source_head_matches_manifest_commit',
+      sourceHead: verifiedSourceHead,
+      commitsAhead: 0,
+      verifiedArtifactCount: manifest.artifacts.length,
+    };
+  }
+
+  const headArtifactDiff = await runGit(sourceRoot, [
+    'diff',
+    '--quiet',
+    '--no-ext-diff',
+    manifest.source.commit,
+    verifiedSourceHead,
+    '--',
+    ...manifest.artifacts.map((artifact) => artifact.path),
+  ]);
+  if (headArtifactDiff.code === 1) {
+    return {
+      state: 'drifted',
+      reason: 'source_head_artifact_drift',
+      sourceHead: verifiedSourceHead,
+      commitsAhead: null,
+      verifiedArtifactCount: manifest.artifacts.length,
+    };
+  }
+  if (headArtifactDiff.code !== 0 || headArtifactDiff.timedOut || headArtifactDiff.outputOverflow) {
+    return {
+      state: 'unverifiable',
+      reason: 'source_head_artifact_comparison_unavailable',
+      sourceHead: verifiedSourceHead,
+      commitsAhead: null,
+      verifiedArtifactCount: manifest.artifacts.length,
+    };
+  }
+
+  const countResult = await runGit(sourceRoot, [
+    'rev-list',
+    '--count',
+    `${manifest.source.commit}..${verifiedSourceHead}`,
+  ]);
+  const parsedCount = Number(countResult.stdout.toString('utf-8').trim());
+  const commitsAhead = countResult.code === 0 && Number.isInteger(parsedCount) && parsedCount >= 0
+    ? parsedCount
+    : null;
+
+  return {
+    state: 'compatible',
+    reason: 'current_head_preserves_declared_artifact_bytes',
+    sourceHead: verifiedSourceHead,
+    commitsAhead,
+    verifiedArtifactCount: manifest.artifacts.length,
+  };
+}
+
+function combineFreshness(
+  ageState: EcosystemMapFreshness,
+  alignment: AlignmentInspection,
+): { state: EcosystemMapFreshness; reason: string } {
+  if (alignment.state === 'drifted') {
+    return { state: 'stale', reason: alignment.reason };
+  }
+  if (alignment.state === 'unverifiable') {
+    return { state: 'unknown', reason: alignment.reason };
+  }
+  if (ageState === 'stale') {
+    return { state: 'stale', reason: 'manifest_age_exceeds_threshold' };
+  }
+  if (ageState === 'unknown') {
+    return { state: 'unknown', reason: 'manifest_age_unavailable' };
+  }
+  return { state: 'fresh', reason: 'artifact_alignment_verified' };
 }
 
 export async function getEcosystemMapData(): Promise<EcosystemMapViewData> {
@@ -241,10 +594,17 @@ export async function getEcosystemMapData(): Promise<EcosystemMapViewData> {
     const raw = JSON.parse(await readFile(manifestPath, 'utf-8')) as unknown;
     const manifest = parseManifest(raw);
     const sourceRoot = sourceRootForManifest(manifestPath);
-    const freshnessState = freshness(manifest.source.generatedAt, staleAfterHours);
-    const mapSpec = manifest.artifacts.find((artifact) => artifact.role === 'canonical_ecosystem_map_mermaid');
-    const map = await readArtifact(sourceRoot, mapSpec);
+    const ageState = ageFreshness(manifest.source.generatedAt, staleAfterHours);
+    const currentArtifacts = await Promise.all(
+      manifest.artifacts.map((artifact) => inspectCurrentArtifact(sourceRoot, artifact)),
+    );
+    const mapInspection = currentArtifacts.find(
+      (item) => item.artifact.role === 'canonical_ecosystem_map_mermaid',
+    );
+    const map = mapInspection?.view || null;
     const missingReason = map?.missing_reason || (map ? 'ok' : 'artifact_role_missing');
+    const alignment = await inspectAlignment(sourceRoot, manifest, currentArtifacts);
+    const combinedFreshness = combineFreshness(ageState.freshness_state, alignment);
 
     return {
       map,
@@ -257,9 +617,15 @@ export async function getEcosystemMapData(): Promise<EcosystemMapViewData> {
         source_root: sourceRoot,
         source_repository: manifest.source.repository,
         source_commit: manifest.source.commit,
-        generated_at: freshnessState.generated_at,
-        data_age_minutes: freshnessState.data_age_minutes,
-        freshness_state: freshnessState.freshness_state,
+        source_head: alignment.sourceHead,
+        commits_ahead: alignment.commitsAhead,
+        alignment_state: alignment.state,
+        alignment_reason: alignment.reason,
+        verified_artifact_count: alignment.verifiedArtifactCount,
+        generated_at: ageState.generated_at,
+        data_age_minutes: ageState.data_age_minutes,
+        freshness_state: combinedFreshness.state,
+        freshness_reason: combinedFreshness.reason,
         stale_after_hours: staleAfterHours,
         does_not_establish: manifest.doesNotEstablish,
       },

--- a/src/controllers/ecosystemMap.ts
+++ b/src/controllers/ecosystemMap.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { readFile } from 'node:fs/promises';
+import { lstat, readFile } from 'node:fs/promises';
 import { basename, dirname, join, relative, resolve } from 'node:path';
 import {
   loadEcosystemCrossLinks,
@@ -348,6 +348,24 @@ function digestMatches(raw: Buffer, artifact: MapManifestArtifact): boolean {
 async function inspectCurrentArtifact(sourceRoot: string, artifact: MapManifestArtifact): Promise<ArtifactInspection> {
   const resolvedPath = resolveArtifactPath(sourceRoot, artifact.path);
   try {
+    const fileStat = await lstat(resolvedPath);
+    if (!fileStat.isFile() || fileStat.size !== artifact.bytes) {
+      return {
+        artifact,
+        matches: false,
+        view: {
+          role: artifact.role,
+          path: artifact.path,
+          content_type: artifact.contentType,
+          bytes: artifact.bytes,
+          sha256: artifact.sha256,
+          content: null,
+          missing_reason: fileStat.isSymbolicLink()
+            ? 'artifact_symlink_rejected'
+            : 'artifact_integrity_mismatch',
+        },
+      };
+    }
     const raw = await readFile(resolvedPath);
     const matches = digestMatches(raw, artifact);
     return {

--- a/src/views/ecosystem-map.ejs
+++ b/src/views/ecosystem-map.ejs
@@ -7,6 +7,7 @@
   <style>
     body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0a0e1a; color: #f1f5f9; margin: 0; }
     a { color: #60a5fa; }
+    code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
     nav { position: sticky; top: 0; z-index: 10; display: flex; gap: 4px; padding: 10px 20px; overflow-x: auto; background: rgba(10, 14, 26, 0.96); border-bottom: 1px solid rgba(255,255,255,.08); }
     nav a { color: #94a3b8; text-decoration: none; padding: 6px 14px; border-radius: 6px; font-size: .82em; white-space: nowrap; }
     nav a.active, nav a:hover { color: #3b82f6; background: rgba(59,130,246,.1); }
@@ -15,11 +16,23 @@
     h1 { font-size: 1.9em; margin-bottom: 10px; }
     h2 { margin-top: 0; }
     .subtitle, .empty, .artifact-meta, li, summary { color: #94a3b8; line-height: 1.55; }
-    .notice, .panel, .meta-item { background: rgba(17,24,39,.88); border: 1px solid rgba(255,255,255,.08); border-radius: 14px; padding: 20px 22px; margin-bottom: 18px; }
+    .notice, .panel, .meta-item, .truth-banner { background: rgba(17,24,39,.88); border: 1px solid rgba(255,255,255,.08); border-radius: 14px; padding: 20px 22px; margin-bottom: 18px; }
     .notice strong { color: #3b82f6; }
+    .truth-banner { border-left-width: 5px; }
+    .truth-banner strong { display: block; margin-bottom: 6px; }
+    .truth-banner p { margin: 0; color: #cbd5e1; line-height: 1.55; }
+    .truth-banner[data-state="exact"] { border-left-color: #22c55e; }
+    .truth-banner[data-state="compatible"] { border-left-color: #60a5fa; }
+    .truth-banner[data-state="drifted"] { border-left-color: #ef4444; }
+    .truth-banner[data-state="unverifiable"] { border-left-color: #f59e0b; }
     .meta-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; margin-bottom: 22px; }
+    .meta-item { margin-bottom: 0; }
     .label { color: #64748b; font-size: .72em; text-transform: uppercase; letter-spacing: .08em; margin-bottom: 5px; }
     .value { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .82em; overflow-wrap: anywhere; }
+    .value[data-state="fresh"], .value[data-state="exact"] { color: #86efac; }
+    .value[data-state="compatible"] { color: #93c5fd; }
+    .value[data-state="stale"], .value[data-state="drifted"] { color: #fca5a5; }
+    .value[data-state="unknown"], .value[data-state="unverifiable"] { color: #fde68a; }
     .map-header { display: flex; flex-wrap: wrap; align-items: baseline; justify-content: space-between; gap: 10px 18px; margin-bottom: 14px; }
     .render-status { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .78em; color: #94a3b8; }
     .render-status[data-state="ready"] { color: #86efac; }
@@ -40,7 +53,7 @@
     .link-note { margin: 0 0 14px; color: #94a3b8; line-height: 1.5; }
     @media (max-width: 720px) {
       main { padding: 28px 14px 60px; }
-      .notice, .panel, .meta-item { padding: 16px; }
+      .notice, .panel, .meta-item, .truth-banner { padding: 16px; }
       .map-canvas { padding: 10px; min-height: 360px; }
     }
   </style>
@@ -69,20 +82,47 @@
       <strong>Nur Ansicht.</strong> Der Systemkatalog besitzt Systeme, Beziehungen und Bedeutungen. Leitstand rendert das geprüfte, commit- und hashgebundene Artefakt als SVG. Er bearbeitet die Karte nicht, leitet keine neue Wahrheit ab und löst keine Aufgaben oder Änderungen aus.
     </section>
 
+    <section class="truth-banner" data-state="<%= view_meta.alignment_state %>" aria-label="Inhaltlicher Quellenabgleich">
+      <% if (view_meta.alignment_state === 'exact') { %>
+        <strong>Exakt gebunden</strong>
+        <p>Der Kartencommit entspricht dem aktuellen Systemkatalog-HEAD. Alle <%= view_meta.verified_artifact_count %> deklarierten Artefakte stimmen mit Manifest, Arbeitsbaum und gebundenem Git-Commit überein.</p>
+      <% } else if (view_meta.alignment_state === 'compatible') { %>
+        <strong>Inhalt aktuell, Repository weiterentwickelt</strong>
+        <p>Seit dem Kartencommit gibt es <%= view_meta.commits_ahead === null ? 'weitere' : view_meta.commits_ahead %> spätere Commits. Der aktuelle HEAD und der Arbeitsbaum enthalten weiterhin exakt dieselben fünf Kartenartefakte.</p>
+      <% } else if (view_meta.alignment_state === 'drifted') { %>
+        <strong>Drift erkannt</strong>
+        <p>Mindestens ein Kartenartefakt oder seine Commitbindung stimmt nicht mehr. Technischer Grund: <code><%= view_meta.alignment_reason %></code>.</p>
+      <% } else { %>
+        <strong>Abgleich nicht vollständig möglich</strong>
+        <p>Die Karte kann angezeigt werden, ihre Git-Bindung ist derzeit aber nicht vollständig belegbar. Technischer Grund: <code><%= view_meta.alignment_reason %></code>.</p>
+      <% } %>
+    </section>
+
     <section class="meta-grid" aria-label="Quellenmetadaten">
+      <div class="meta-item"><div class="label">Gesamtstatus</div><div class="value" data-state="<%= view_meta.freshness_state %>"><%= view_meta.freshness_state %> · <%= view_meta.freshness_reason %></div></div>
+      <div class="meta-item"><div class="label">Inhaltsabgleich</div><div class="value" data-state="<%= view_meta.alignment_state %>"><%= view_meta.alignment_state %> · <%= view_meta.verified_artifact_count %>/5 Artefakte</div></div>
       <div class="meta-item"><div class="label">Quellzustand</div><div class="value"><%= view_meta.source_kind %> / <%= view_meta.missing_reason %></div></div>
-      <div class="meta-item"><div class="label">Manifest</div><div class="value"><%= view_meta.manifest_path %></div></div>
-      <div class="meta-item"><div class="label">Quellwurzel</div><div class="value"><%= view_meta.source_root || '—' %></div></div>
-      <div class="meta-item"><div class="label">Repository</div><div class="value"><%= view_meta.source_repository || '—' %></div></div>
+      <div class="meta-item"><div class="label">Alter</div><div class="value"><% if (view_meta.data_age_minutes !== null) { %><%= view_meta.data_age_minutes %> min · Grenze <%= view_meta.stale_after_hours %> h<% } else { %>—<% } %></div></div>
       <div class="meta-item">
-        <div class="label">Commit</div>
+        <div class="label">Gebundener Commit</div>
         <div class="value">
           <% if (view_meta.source_repository && view_meta.source_commit) { %>
             <a href="https://github.com/<%= view_meta.source_repository %>/tree/<%= view_meta.source_commit %>"><%= view_meta.source_commit %></a>
           <% } else { %>—<% } %>
         </div>
       </div>
-      <div class="meta-item"><div class="label">Frische</div><div class="value"><%= view_meta.freshness_state %><% if (view_meta.data_age_minutes !== null) { %> · <%= view_meta.data_age_minutes %> min<% } %></div></div>
+      <div class="meta-item">
+        <div class="label">Aktueller HEAD</div>
+        <div class="value">
+          <% if (view_meta.source_repository && view_meta.source_head) { %>
+            <a href="https://github.com/<%= view_meta.source_repository %>/tree/<%= view_meta.source_head %>"><%= view_meta.source_head %></a>
+          <% } else { %>—<% } %>
+        </div>
+      </div>
+      <div class="meta-item"><div class="label">Commit-Abstand</div><div class="value"><%= view_meta.commits_ahead === null ? '—' : view_meta.commits_ahead %></div></div>
+      <div class="meta-item"><div class="label">Repository</div><div class="value"><%= view_meta.source_repository || '—' %></div></div>
+      <div class="meta-item"><div class="label">Manifest</div><div class="value"><%= view_meta.manifest_path %></div></div>
+      <div class="meta-item"><div class="label">Quellwurzel</div><div class="value"><%= view_meta.source_root || '—' %></div></div>
     </section>
 
     <section class="panel" aria-labelledby="canonical-map-heading">

--- a/tests/controllers/ecosystemMap.test.ts
+++ b/tests/controllers/ecosystemMap.test.ts
@@ -1,7 +1,8 @@
-import { mkdtemp, mkdir, writeFile, rm } from 'fs/promises';
-import { join } from 'path';
-import { tmpdir } from 'os';
+import { execFile } from 'node:child_process';
 import { createHash } from 'node:crypto';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { getEcosystemMapData } from '../../src/controllers/ecosystemMap.js';
 import { loadEcosystemCrossLinks, resolveEcosystemCrossLink } from '../../src/controllers/ecosystemMapLinks.js';
@@ -10,6 +11,39 @@ const OLD_MANIFEST = process.env.LEITSTAND_ECOSYSTEM_MAP_MANIFEST_PATH;
 const OLD_ROOT = process.env.LEITSTAND_ECOSYSTEM_MAP_SOURCE_ROOT;
 const OLD_STALE = process.env.LEITSTAND_ECOSYSTEM_MAP_STALE_AFTER_HOURS;
 const OLD_LINKS = process.env.LEITSTAND_ECOSYSTEM_MAP_LINKS_PATH;
+
+const ARTIFACT_CONTENT = [
+  {
+    role: 'canonical_ecosystem_map_mermaid',
+    path: 'rendered/ecosystem-registry-map.mmd',
+    contentType: 'text/mermaid',
+    content: 'flowchart TD\n  B[Systemkatalog]\n',
+  },
+  {
+    role: 'rendered_catalog_markdown',
+    path: 'rendered/system-catalog.md',
+    contentType: 'text/markdown',
+    content: '# Systemkatalog\n',
+  },
+  {
+    role: 'registry_nodes',
+    path: 'registry/ecosystem/nodes.json',
+    contentType: 'application/json',
+    content: '{"nodes":[]}\n',
+  },
+  {
+    role: 'registry_edges',
+    path: 'registry/ecosystem/edges.json',
+    contentType: 'application/json',
+    content: '{"edges":[]}\n',
+  },
+  {
+    role: 'authority_matrix',
+    path: 'registry/ecosystem/authority-matrix.v1.json',
+    contentType: 'application/json',
+    content: '{"authorities":[]}\n',
+  },
+] as const;
 
 let tempRoots: string[] = [];
 
@@ -29,41 +63,90 @@ afterEach(async () => {
   tempRoots = [];
 });
 
-async function makeFixture(generatedAt = new Date().toISOString()) {
+function git(cwd: string, args: string[], env: NodeJS.ProcessEnv = {}): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile('git', args, {
+      cwd,
+      encoding: 'utf-8',
+      env: { ...process.env, ...env },
+    }, (error, stdout, stderr) => {
+      if (error) {
+        reject(new Error(`git ${args.join(' ')} failed: ${stderr || error.message}`));
+        return;
+      }
+      resolve(stdout.trim());
+    });
+  });
+}
+
+async function initializeRepository(sourceRoot: string): Promise<string> {
+  await git(sourceRoot, ['init', '--quiet']);
+  await git(sourceRoot, ['config', 'user.name', 'Leitstand Test']);
+  await git(sourceRoot, ['config', 'user.email', 'leitstand-test@example.invalid']);
+  await git(sourceRoot, ['add', '--', 'rendered', 'registry']);
+  await git(sourceRoot, ['commit', '--quiet', '-m', 'fixture artifacts']);
+  return git(sourceRoot, ['rev-parse', 'HEAD']);
+}
+
+async function makeFixture(
+  generatedAt = new Date().toISOString(),
+  options: { initializeGit?: boolean } = {},
+) {
   const root = await mkdtemp(join(tmpdir(), 'leitstand-map-'));
   tempRoots.push(root);
   const sourceRoot = join(root, 'systemkatalog');
-  await mkdir(join(sourceRoot, 'rendered'), { recursive: true });
-  const mapContent = 'flowchart TD\n  B[Systemkatalog]\n';
-  await writeFile(join(sourceRoot, 'rendered', 'ecosystem-registry-map.mmd'), mapContent, 'utf-8');
+  await mkdir(sourceRoot, { recursive: true });
+
+  for (const artifact of ARTIFACT_CONTENT) {
+    const target = join(sourceRoot, artifact.path);
+    await mkdir(dirname(target), { recursive: true });
+    await writeFile(target, artifact.content, 'utf-8');
+  }
+
+  const initializeGit = options.initializeGit !== false;
+  const sourceCommit = initializeGit
+    ? await initializeRepository(sourceRoot)
+    : 'a'.repeat(40);
   const manifestPath = join(sourceRoot, 'rendered', 'ecosystem-map-artifact-manifest.json');
   const manifest = {
     schemaVersion: 1,
     kind: 'system_catalog_map_artifact_manifest',
     contractVersion: '1',
+    schemaPath: 'catalog/ecosystem-map-artifact-manifest.schema.v1.json',
+    mode: 'read_only_projection_source',
     source: {
       repository: 'heimgewebe/systemkatalog',
-      commit: 'a'.repeat(40),
+      commit: sourceCommit,
       generatedAt,
     },
-    artifactCount: 1,
-    artifacts: [
-      {
-        role: 'canonical_ecosystem_map_mermaid',
-        path: 'rendered/ecosystem-registry-map.mmd',
-        contentType: 'text/mermaid',
-        bytes: Buffer.byteLength(mapContent),
-        sha256: createHash('sha256').update(mapContent).digest('hex'),
-      },
+    artifactCount: ARTIFACT_CONTENT.length,
+    artifacts: ARTIFACT_CONTENT.map((artifact) => ({
+      role: artifact.role,
+      path: artifact.path,
+      contentType: artifact.contentType,
+      bytes: Buffer.byteLength(artifact.content),
+      sha256: createHash('sha256').update(artifact.content).digest('hex'),
+    })),
+    doesNotEstablish: [
+      'claim_truth',
+      'runtime_correctness',
+      'merge_readiness',
+      'system_catalog_registry_correctness',
+      'consumer_view_correctness',
+      'render_success_validates_map',
     ],
-    doesNotEstablish: ['claim_truth', 'runtime_correctness', 'merge_readiness'],
   };
-  await writeFile(manifestPath, JSON.stringify(manifest), 'utf-8');
-  return { sourceRoot, manifestPath, mapPath: join(sourceRoot, 'rendered', 'ecosystem-registry-map.mmd') };
+  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf-8');
+  return {
+    sourceRoot,
+    manifestPath,
+    sourceCommit,
+    mapPath: join(sourceRoot, 'rendered', 'ecosystem-registry-map.mmd'),
+  };
 }
 
 describe('getEcosystemMapData', () => {
-  it('loads the canonical Systemkatalog map artifact read-only', async () => {
+  it('loads and exactly binds the canonical Systemkatalog artifacts to HEAD', async () => {
     const fixture = await makeFixture();
     process.env.LEITSTAND_ECOSYSTEM_MAP_MANIFEST_PATH = fixture.manifestPath;
 
@@ -71,14 +154,51 @@ describe('getEcosystemMapData', () => {
 
     expect(data.view_meta.source_kind).toBe('artifact');
     expect(data.view_meta.source_repository).toBe('heimgewebe/systemkatalog');
-    expect(data.view_meta.source_commit).toBe('a'.repeat(40));
+    expect(data.view_meta.source_commit).toBe(fixture.sourceCommit);
+    expect(data.view_meta.source_head).toBe(fixture.sourceCommit);
     expect(data.view_meta.source_root).toBe(fixture.sourceRoot);
+    expect(data.view_meta.alignment_state).toBe('exact');
+    expect(data.view_meta.verified_artifact_count).toBe(5);
+    expect(data.view_meta.freshness_state).toBe('fresh');
     expect(data.map?.role).toBe('canonical_ecosystem_map_mermaid');
     expect(data.map?.content).toContain('Systemkatalog');
     expect(data.view_meta.does_not_establish).toContain('runtime_correctness');
   });
 
-  it('rejects a map whose bytes no longer match the manifest', async () => {
+  it('reports compatible newer commits when declared artifacts remain byte-identical', async () => {
+    const fixture = await makeFixture();
+    await writeFile(join(fixture.sourceRoot, 'README.md'), 'unrelated follow-up\n', 'utf-8');
+    await git(fixture.sourceRoot, ['add', '--', 'README.md']);
+    await git(fixture.sourceRoot, ['commit', '--quiet', '-m', 'unrelated follow-up']);
+    process.env.LEITSTAND_ECOSYSTEM_MAP_MANIFEST_PATH = fixture.manifestPath;
+
+    const data = await getEcosystemMapData();
+
+    expect(data.view_meta.alignment_state).toBe('compatible');
+    expect(data.view_meta.alignment_reason).toBe('current_head_preserves_declared_artifact_bytes');
+    expect(data.view_meta.commits_ahead).toBe(1);
+    expect(data.view_meta.source_head).not.toBe(fixture.sourceCommit);
+    expect(data.view_meta.freshness_state).toBe('fresh');
+  });
+
+  it('detects committed HEAD drift even when the working tree is manually restored', async () => {
+    const fixture = await makeFixture();
+    const originalMap = await readFile(fixture.mapPath, 'utf-8');
+    await writeFile(fixture.mapPath, 'committed changed map\n', 'utf-8');
+    await git(fixture.sourceRoot, ['add', '--', 'rendered/ecosystem-registry-map.mmd']);
+    await git(fixture.sourceRoot, ['commit', '--quiet', '-m', 'change map in head']);
+    await writeFile(fixture.mapPath, originalMap, 'utf-8');
+    process.env.LEITSTAND_ECOSYSTEM_MAP_MANIFEST_PATH = fixture.manifestPath;
+
+    const data = await getEcosystemMapData();
+
+    expect(data.map?.content).toContain('Systemkatalog');
+    expect(data.view_meta.alignment_state).toBe('drifted');
+    expect(data.view_meta.alignment_reason).toBe('source_head_artifact_drift');
+    expect(data.view_meta.freshness_state).toBe('stale');
+  });
+
+  it('marks content drift stale when a declared artifact changes', async () => {
     const fixture = await makeFixture();
     await writeFile(fixture.mapPath, 'tampered map\n', 'utf-8');
     process.env.LEITSTAND_ECOSYSTEM_MAP_MANIFEST_PATH = fixture.manifestPath;
@@ -87,7 +207,37 @@ describe('getEcosystemMapData', () => {
 
     expect(data.view_meta.source_kind).toBe('missing');
     expect(data.view_meta.missing_reason).toBe('artifact_integrity_mismatch');
+    expect(data.view_meta.alignment_state).toBe('drifted');
+    expect(data.view_meta.alignment_reason).toContain('current_artifact_mismatch:');
+    expect(data.view_meta.freshness_state).toBe('stale');
     expect(data.map?.content).toBeNull();
+  });
+
+  it('keeps the map visible but reports unverifiable when the source root is not Git-bound', async () => {
+    const fixture = await makeFixture(new Date().toISOString(), { initializeGit: false });
+    process.env.LEITSTAND_ECOSYSTEM_MAP_MANIFEST_PATH = fixture.manifestPath;
+
+    const data = await getEcosystemMapData();
+
+    expect(data.view_meta.source_kind).toBe('artifact');
+    expect(data.map?.content).toContain('Systemkatalog');
+    expect(data.view_meta.alignment_state).toBe('unverifiable');
+    expect(data.view_meta.freshness_state).toBe('unknown');
+    expect(data.view_meta.freshness_reason).toBe('source_git_head_unavailable');
+  });
+
+  it('rejects manifest shapes that weaken the exact artifact contract', async () => {
+    const fixture = await makeFixture();
+    const manifest = JSON.parse(await readFile(fixture.manifestPath, 'utf-8')) as Record<string, unknown>;
+    manifest.unexpected = true;
+    await writeFile(fixture.manifestPath, JSON.stringify(manifest), 'utf-8');
+    process.env.LEITSTAND_ECOSYSTEM_MAP_MANIFEST_PATH = fixture.manifestPath;
+
+    const data = await getEcosystemMapData();
+
+    expect(data.view_meta.source_kind).toBe('corrupt');
+    expect(data.view_meta.missing_reason).toBe('manifest_corrupt');
+    expect(data.map).toBeNull();
   });
 
   it('reports a missing manifest as a missing source instead of throwing', async () => {
@@ -99,17 +249,20 @@ describe('getEcosystemMapData', () => {
 
     expect(data.view_meta.source_kind).toBe('missing');
     expect(data.view_meta.missing_reason).toBe('manifest_missing');
+    expect(data.view_meta.alignment_state).toBe('unverifiable');
     expect(data.map).toBeNull();
   });
 
-  it('marks stale manifests without repairing them', async () => {
+  it('marks age-expired manifests stale without repairing them', async () => {
     const fixture = await makeFixture('2020-01-01T00:00:00Z');
     process.env.LEITSTAND_ECOSYSTEM_MAP_MANIFEST_PATH = fixture.manifestPath;
     process.env.LEITSTAND_ECOSYSTEM_MAP_STALE_AFTER_HOURS = '1';
 
     const data = await getEcosystemMapData();
 
+    expect(data.view_meta.alignment_state).toBe('exact');
     expect(data.view_meta.freshness_state).toBe('stale');
+    expect(data.view_meta.freshness_reason).toBe('manifest_age_exceeds_threshold');
     expect(data.view_meta.source_kind).toBe('artifact');
   });
 
@@ -124,5 +277,4 @@ describe('getEcosystemMapData', () => {
     expect(unknown.status).toBe('unmapped');
     expect(unknown.reason).toBe('node_id_not_in_cross_view_contract');
   });
-
 });

--- a/tests/controllers/ecosystemMap.test.ts
+++ b/tests/controllers/ecosystemMap.test.ts
@@ -1,6 +1,6 @@
 import { execFile } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -196,6 +196,21 @@ describe('getEcosystemMapData', () => {
     expect(data.view_meta.alignment_state).toBe('drifted');
     expect(data.view_meta.alignment_reason).toBe('source_head_artifact_drift');
     expect(data.view_meta.freshness_state).toBe('stale');
+  });
+
+  it('rejects symlinked artifacts before reading their targets', async () => {
+    const fixture = await makeFixture();
+    const target = join(fixture.sourceRoot, 'outside-map.mmd');
+    await writeFile(target, 'flowchart TD\n  B[Systemkatalog]\n', 'utf-8');
+    await rm(fixture.mapPath);
+    await symlink(target, fixture.mapPath);
+    process.env.LEITSTAND_ECOSYSTEM_MAP_MANIFEST_PATH = fixture.manifestPath;
+
+    const data = await getEcosystemMapData();
+
+    expect(data.view_meta.alignment_state).toBe('drifted');
+    expect(data.view_meta.missing_reason).toBe('artifact_symlink_rejected');
+    expect(data.map?.content).toBeNull();
   });
 
   it('marks content drift stale when a declared artifact changes', async () => {

--- a/tests/views/ecosystemMap.test.ts
+++ b/tests/views/ecosystemMap.test.ts
@@ -4,8 +4,9 @@ import ejs from 'ejs';
 import { describe, expect, it } from 'vitest';
 
 describe('ecosystem-map view', () => {
-  it('renders a local read-only SVG canvas while preserving source identity and freshness', async () => {
+  it('renders verified artifact alignment separately from age and repository progress', async () => {
     const commit = 'a'.repeat(40);
+    const head = 'c'.repeat(40);
     const html = await ejs.renderFile(
       join(process.cwd(), 'src/views/ecosystem-map.ejs'),
       {
@@ -30,9 +31,15 @@ describe('ecosystem-map view', () => {
           source_root: '/tmp/systemkatalog',
           source_repository: 'heimgewebe/systemkatalog',
           source_commit: commit,
+          source_head: head,
+          commits_ahead: 4,
+          alignment_state: 'compatible',
+          alignment_reason: 'current_head_preserves_declared_artifact_bytes',
+          verified_artifact_count: 5,
           generated_at: '2026-07-14T00:00:00Z',
           data_age_minutes: 12,
           freshness_state: 'fresh',
+          freshness_reason: 'artifact_alignment_verified',
           stale_after_hours: 168,
           does_not_establish: ['runtime_correctness'],
         },
@@ -46,10 +53,57 @@ describe('ecosystem-map view', () => {
     expect(html).toContain('data-ecosystem-map-navigation');
     expect(html).toContain('/assets/ecosystem-map.mjs');
     expect(html).toContain(commit);
-    expect(html).toContain('fresh · 12 min');
+    expect(html).toContain(head);
+    expect(html).toContain('Inhalt aktuell, Repository weiterentwickelt');
+    expect(html).toContain('4 spätere Commits');
+    expect(html).toContain('aktuelle HEAD und der Arbeitsbaum enthalten weiterhin exakt dieselben fünf Kartenartefakte');
+    expect(html).toContain('compatible · 5/5 Artefakte');
+    expect(html).toContain('fresh · artifact_alignment_verified');
+    expect(html).toContain('12 min · Grenze 168 h');
     expect(html).not.toContain('cdn.jsdelivr');
     expect(html).not.toContain('<form');
     expect(html).not.toContain('contenteditable');
+  });
+
+  it('renders an explicit drift warning instead of presenting an age-only fresh label', async () => {
+    const html = await ejs.renderFile(
+      join(process.cwd(), 'src/views/ecosystem-map.ejs'),
+      {
+        map: null,
+        cross_links: [],
+        cross_link_meta: {
+          source_kind: 'artifact',
+          source_path: '/tmp/cross-links.json',
+          missing_reason: 'ok',
+          does_not_establish: [],
+        },
+        view_meta: {
+          source_kind: 'missing',
+          missing_reason: 'artifact_integrity_mismatch',
+          manifest_path: '/tmp/manifest.json',
+          source_root: '/tmp/systemkatalog',
+          source_repository: 'heimgewebe/systemkatalog',
+          source_commit: 'a'.repeat(40),
+          source_head: 'c'.repeat(40),
+          commits_ahead: null,
+          alignment_state: 'drifted',
+          alignment_reason: 'current_artifact_mismatch:rendered/ecosystem-registry-map.mmd',
+          verified_artifact_count: 4,
+          generated_at: '2026-07-14T00:00:00Z',
+          data_age_minutes: 12,
+          freshness_state: 'stale',
+          freshness_reason: 'current_artifact_mismatch:rendered/ecosystem-registry-map.mmd',
+          stale_after_hours: 168,
+          does_not_establish: ['runtime_correctness'],
+        },
+        node_navigation_json: '[]',
+      },
+      { async: true, localsName: 'locals' },
+    );
+
+    expect(html).toContain('Drift erkannt');
+    expect(html).toContain('current_artifact_mismatch:rendered/ecosystem-registry-map.mmd');
+    expect(html).toContain('stale · current_artifact_mismatch:rendered/ecosystem-registry-map.mmd');
   });
 
   it('uses the lockfile-local Mermaid module with strict rendering and no remote fetch', async () => {


### PR DESCRIPTION
## Zweck

Die Ökosystemkarte im Leitstand trennt künftig Alter, Git-Commit-Abstand und tatsächliche Artefaktdrift. Ein älterer Manifest-Commit wird nicht mehr allein deshalb irreführend als veraltet bewertet.

## Änderungen

- exakte Validierung des Systemkatalog-Manifestvertrags und aller fünf Artefakte
- SHA-256-/Byte-Abgleich gegen Arbeitsbaum und gebundenen Quellcommit
- Git-Abstammungs- und HEAD-Baum-Prüfung mit begrenzten argv-only Git-Prozessen
- Zustände `exact`, `compatible`, `drifted`, `unverifiable`
- verständlicher Statusbanner sowie getrennte Anzeige von Alter, Commit-Abstand und Inhaltsabgleich
- Tests für exakte Bindung, kompatible spätere Commits, echte Drift, verdeckte HEAD-Drift und unverifizierbare Quellen

## Prüfungen

- `pnpm typecheck` — PASS
- `pnpm lint` — PASS
- fokussierte Kartentests — 12/12 PASS
- vollständige Suite im eigenständigen Clone — 353/353 PASS
- realer Systemkatalog-Readback — `compatible`, 4 Commits voraus, 5/5 Artefakte identisch, `fresh`
- isolierter HTTP- und Headless-Browser-Smoke-Test — PASS

## Abgrenzung

Der Leitstand bleibt ausschließlich lesend. Die Änderung beweist weder die fachliche Richtigkeit des Systemkatalogs noch Runtime- oder Merge-Bereitschaft.