### PR TITLE
Leitstand: Lagebild, gemeinsame Navigation und Worktree-Health

### DIFF
--- a/scripts/build-static.mjs
+++ b/scripts/build-static.mjs
@@ -1,11 +1,19 @@
-import { mkdir, writeFile, readFile } from "node:fs/promises";
+import { copyFile, mkdir, writeFile, readFile } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import ejs from "ejs";
 
 const ROOT = process.cwd();
 const VIEWS = join(ROOT, "src", "views");
 const OUT = join(ROOT, "dist", "site");
+const STATIC_ASSETS = ["shell.css", "shell.mjs"];
 
+async function copyStaticAssets() {
+  const assetsOut = join(OUT, "assets");
+  await mkdir(assetsOut, { recursive: true });
+  await Promise.all(STATIC_ASSETS.map((name) => (
+    copyFile(join(ROOT, "src", "public", name), join(assetsOut, name))
+  )));
+}
 
 const STATIC_MIRROR_SUPPORTED_ROUTES = [
   { route: "/", output: "index.html", view: "index", reason: "static landing page" },
@@ -81,7 +89,7 @@ async function renderTo(outPath, viewName, data = {}, extraLocals = {}) {
   const context = { ...data, ...extraLocals };
 
   const html = await ejs.renderFile(join(VIEWS, `${viewName}.ejs`), context, {
-    async: true,
+    async: false,
     rmWhitespace: false,
     localsName: "locals", // accessible as 'locals' in template
   });
@@ -92,9 +100,10 @@ async function renderTo(outPath, viewName, data = {}, extraLocals = {}) {
 
 async function main() {
   await mkdir(OUT, { recursive: true });
+  await copyStaticAssets();
 
   // 1) Home
-  await renderTo(join(OUT, "index.html"), "index");
+  await renderTo(join(OUT, "index.html"), "index", {}, { currentPath: "/" });
 
   // Strict Symmetry Check
   const isStrict = process.env.LEITSTAND_STRICT === '1' || process.env.NODE_ENV === 'production' || process.env.OBSERVATORY_STRICT === '1';
@@ -389,7 +398,8 @@ async function main() {
           is_strict: isStrict,
           forensics: metaForensics
       },
-      observatoryUrl: observatoryUrl
+      observatoryUrl: observatoryUrl,
+      currentPath: "/observatory"
     }
   );
 
@@ -398,7 +408,7 @@ async function main() {
   const intentData = await readJson(intentPath);
 
   await mkdir(join(OUT, "intent"), { recursive: true });
-  await renderTo(join(OUT, "intent", "index.html"), "intent", { data: intentData });
+  await renderTo(join(OUT, "intent", "index.html"), "intent", { data: intentData }, { currentPath: "/intent" });
 
   await writeStaticBoundaryManifest();
 

--- a/src/controllers/dashboard.ts
+++ b/src/controllers/dashboard.ts
@@ -30,8 +30,32 @@ export interface DashboardPhase {
   error_reason: string | null;
 }
 
+export interface DashboardAttentionItem {
+  phase_id: DashboardPhase['id'];
+  title: string;
+  href: string;
+  severity: 'critical' | 'warning' | 'info';
+  reason: string;
+}
+
+/**
+ * Derived projection only. It does not introduce a second health source; every
+ * field is calculated from the phase source/freshness contracts above.
+ */
+export interface DashboardSummary {
+  state: 'healthy' | 'attention' | 'critical';
+  state_label: 'Stabil' | 'Prüfbedarf' | 'Kritisch';
+  headline: string;
+  total_count: number;
+  verified_fresh_count: number;
+  attention_count: number;
+  unavailable_count: number;
+  attention: DashboardAttentionItem[];
+}
+
 export interface DashboardData {
   phases: DashboardPhase[];
+  summary: DashboardSummary;
 }
 
 /**
@@ -56,6 +80,105 @@ async function safeLoad<T>(name: string, loader: () => Promise<T>): Promise<{ da
     console.warn(`[Dashboard] ${name} load failed:`, msg);
     return { data: null, error: publicErrorReason(msg) };
   }
+}
+
+function summarizePhase(phase: DashboardPhase): DashboardAttentionItem | null {
+  if (phase.source_kind === 'error') {
+    return {
+      phase_id: phase.id,
+      title: phase.title,
+      href: phase.href,
+      severity: 'critical',
+      reason: 'Datenquelle konnte nicht geladen werden',
+    };
+  }
+
+  if (phase.source_kind === 'missing') {
+    return {
+      phase_id: phase.id,
+      title: phase.title,
+      href: phase.href,
+      severity: 'critical',
+      reason: 'Keine belastbare Datenquelle verfügbar',
+    };
+  }
+
+  const reasons: string[] = [];
+  let severity: DashboardAttentionItem['severity'] = 'info';
+
+  if (phase.source_kind === 'fixture') {
+    reasons.push('Ersatzdaten statt eines Artefakts');
+    severity = 'warning';
+  }
+  if (phase.freshness_state === 'stale') {
+    reasons.push('Daten sind veraltet');
+    severity = 'warning';
+  } else if (phase.freshness_state === 'unknown') {
+    reasons.push('Datenfrische ist nicht belegt');
+  }
+
+  if (reasons.length === 0) return null;
+
+  return {
+    phase_id: phase.id,
+    title: phase.title,
+    href: phase.href,
+    severity,
+    reason: reasons.join(' · '),
+  };
+}
+
+export function summarizeDashboard(phases: DashboardPhase[]): DashboardSummary {
+  const severityRank: Record<DashboardAttentionItem['severity'], number> = {
+    critical: 0,
+    warning: 1,
+    info: 2,
+  };
+  const attention = phases
+    .map(summarizePhase)
+    .filter((item): item is DashboardAttentionItem => item !== null)
+    .sort((left, right) => severityRank[left.severity] - severityRank[right.severity]
+      || phases.findIndex((phase) => phase.id === left.phase_id) - phases.findIndex((phase) => phase.id === right.phase_id));
+  const unavailableCount = phases.filter((phase) => phase.source_kind === 'missing' || phase.source_kind === 'error').length;
+  const verifiedFreshCount = phases.filter((phase) => phase.source_kind === 'artifact' && phase.freshness_state === 'fresh').length;
+  const hasCritical = attention.some((item) => item.severity === 'critical');
+
+  if (hasCritical) {
+    return {
+      state: 'critical',
+      state_label: 'Kritisch',
+      headline: `${unavailableCount} ${unavailableCount === 1 ? 'Bereich liefert' : 'Bereiche liefern'} keine belastbaren Daten`,
+      total_count: phases.length,
+      verified_fresh_count: verifiedFreshCount,
+      attention_count: attention.length,
+      unavailable_count: unavailableCount,
+      attention,
+    };
+  }
+
+  if (attention.length > 0) {
+    return {
+      state: 'attention',
+      state_label: 'Prüfbedarf',
+      headline: `${attention.length} ${attention.length === 1 ? 'Bereich benötigt' : 'Bereiche benötigen'} Prüfung`,
+      total_count: phases.length,
+      verified_fresh_count: verifiedFreshCount,
+      attention_count: attention.length,
+      unavailable_count: unavailableCount,
+      attention,
+    };
+  }
+
+  return {
+    state: 'healthy',
+    state_label: 'Stabil',
+    headline: 'Alle Bereiche liefern frische Artefakte',
+    total_count: phases.length,
+    verified_fresh_count: verifiedFreshCount,
+    attention_count: 0,
+    unavailable_count: 0,
+    attention: [],
+  };
 }
 
 export async function getDashboardData(): Promise<DashboardData> {
@@ -136,5 +259,5 @@ export async function getDashboardData(): Promise<DashboardData> {
     },
   ];
 
-  return { phases };
+  return { phases, summary: summarizeDashboard(phases) };
 }

--- a/src/public/shell.css
+++ b/src/public/shell.css
@@ -1,0 +1,186 @@
+.leitstand-skip-link {
+  position: fixed;
+  top: 8px;
+  left: 12px;
+  z-index: 1000;
+  padding: 10px 14px;
+  border-radius: 8px;
+  background: #f8fafc;
+  color: #0f172a;
+  font-weight: 700;
+  text-decoration: none;
+  transform: translateY(-160%);
+  transition: transform 120ms ease;
+}
+
+.leitstand-skip-link:focus {
+  transform: translateY(0);
+  outline: 3px solid #60a5fa;
+  outline-offset: 2px;
+}
+
+.leitstand-main-anchor {
+  display: block;
+  width: 0;
+  height: 0;
+  scroll-margin-top: 72px;
+  outline: none;
+}
+
+.leitstand-nav {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  min-height: 52px;
+  padding: 8px clamp(12px, 2vw, 24px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(10, 14, 26, 0.96);
+  color: #f1f5f9;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.leitstand-nav__brand,
+.leitstand-nav__link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.leitstand-nav__brand {
+  display: inline-flex;
+  align-items: center;
+  min-height: 36px;
+  padding: 6px 10px;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: 750;
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+}
+
+.leitstand-nav__links {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  min-width: 0;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(148, 163, 184, 0.5) transparent;
+}
+
+.leitstand-nav__link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 36px;
+  padding: 7px 10px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  color: #aab7ca;
+  font-size: 0.79rem;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+  transition: color 120ms ease, background-color 120ms ease, border-color 120ms ease;
+}
+
+.leitstand-nav__brand:hover,
+.leitstand-nav__link:hover {
+  color: #f8fafc;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.leitstand-nav__link.active,
+.leitstand-nav__link[aria-current="page"] {
+  border-color: rgba(96, 165, 250, 0.32);
+  background: rgba(59, 130, 246, 0.14);
+  color: #bfdbfe;
+}
+
+.leitstand-nav__brand:focus-visible,
+.leitstand-nav__link:focus-visible,
+.leitstand-nav__toggle:focus-visible {
+  outline: 2px solid #60a5fa;
+  outline-offset: 2px;
+}
+
+.leitstand-nav__toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 38px;
+  padding: 7px 11px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.05);
+  color: #e2e8f0;
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.leitstand-nav__toggle-icon {
+  min-width: 1em;
+  text-align: center;
+}
+
+@media (max-width: 960px) {
+  .leitstand-nav {
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 8px;
+    background: #0a0e1a;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+
+  .leitstand-nav__toggle {
+    display: inline-flex;
+  }
+
+  html:not(.leitstand-shell-ready) .leitstand-nav__toggle {
+    display: none;
+  }
+
+  .leitstand-nav__links {
+    grid-column: 1 / -1;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 6px;
+    width: 100%;
+    padding: 4px 0 8px;
+    overflow: visible;
+  }
+
+  html.leitstand-shell-ready .leitstand-nav__links[hidden] {
+    display: none;
+  }
+
+  .leitstand-nav__link {
+    justify-content: flex-start;
+    min-height: 42px;
+    padding: 10px 12px;
+    border-color: rgba(255, 255, 255, 0.08);
+    background: rgba(255, 255, 255, 0.025);
+    font-size: 0.86rem;
+  }
+}
+
+@media (max-width: 520px) {
+  .leitstand-nav__links {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .leitstand-skip-link,
+  .leitstand-nav__link {
+    transition: none;
+  }
+}

--- a/src/public/shell.mjs
+++ b/src/public/shell.mjs
@@ -1,0 +1,62 @@
+const nav = document.querySelector('[data-leitstand-nav]');
+const toggle = nav?.querySelector('[data-leitstand-nav-toggle]');
+const links = nav?.querySelector('[data-leitstand-nav-links]');
+const toggleIcon = toggle?.querySelector('.leitstand-nav__toggle-icon');
+
+if (nav && toggle && links) {
+  const mobileQuery = window.matchMedia('(max-width: 960px)');
+  document.documentElement.classList.add('leitstand-shell-ready');
+
+  const setExpanded = (expanded, { restoreFocus = false } = {}) => {
+    const mobile = mobileQuery.matches;
+    const next = mobile && expanded;
+    nav.dataset.expanded = String(next);
+    toggle.setAttribute('aria-expanded', String(next));
+    toggle.setAttribute('aria-label', next ? 'Navigation schließen' : 'Navigation öffnen');
+    links.hidden = mobile && !next;
+    if (toggleIcon) toggleIcon.textContent = next ? '×' : '☰';
+    if (restoreFocus) toggle.focus();
+  };
+
+  const syncViewport = () => setExpanded(false);
+
+  toggle.addEventListener('click', () => {
+    setExpanded(toggle.getAttribute('aria-expanded') !== 'true');
+  });
+
+  links.addEventListener('click', (event) => {
+    if (event.target.closest('a') && mobileQuery.matches) setExpanded(false);
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && toggle.getAttribute('aria-expanded') === 'true') {
+      setExpanded(false, { restoreFocus: true });
+    }
+  });
+
+  document.addEventListener('click', (event) => {
+    if (
+      mobileQuery.matches
+      && toggle.getAttribute('aria-expanded') === 'true'
+      && !nav.contains(event.target)
+    ) {
+      setExpanded(false);
+    }
+  });
+
+  if (typeof mobileQuery.addEventListener === 'function') {
+    mobileQuery.addEventListener('change', syncViewport);
+  } else {
+    mobileQuery.addListener(syncViewport);
+  }
+
+  syncViewport();
+}
+
+const skipLink = document.querySelector('.leitstand-skip-link');
+const mainAnchor = document.querySelector('#leitstand-content');
+if (skipLink && mainAnchor) {
+  skipLink.addEventListener('click', () => {
+    window.requestAnimationFrame(() => mainAnchor.focus({ preventScroll: true }));
+  });
+}

--- a/src/runtimeHealth.ts
+++ b/src/runtimeHealth.ts
@@ -227,6 +227,56 @@ async function resolveGitDir(cwd: string): Promise<string> {
   return resolve(cwd, gitdir);
 }
 
+async function resolveCommonGitDir(gitDir: string): Promise<string> {
+  try {
+    const commonDir = (await readFile(join(gitDir, 'commondir'), 'utf-8')).trim();
+    return commonDir ? resolve(gitDir, commonDir) : gitDir;
+  } catch {
+    return gitDir;
+  }
+}
+
+function isSafeGitRef(ref: string): boolean {
+  return ref.startsWith('refs/')
+    && !ref.includes('\\')
+    && ref.split('/').every((segment) => segment !== '' && segment !== '.' && segment !== '..');
+}
+
+async function readPackedRef(commonGitDir: string, ref: string): Promise<string | null> {
+  try {
+    const packedRefs = await readFile(join(commonGitDir, 'packed-refs'), 'utf-8');
+    for (const line of packedRefs.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#') || trimmed.startsWith('^')) continue;
+      const separator = trimmed.indexOf(' ');
+      if (separator <= 0) continue;
+      const head = trimmed.slice(0, separator);
+      const packedRef = trimmed.slice(separator + 1);
+      if (packedRef === ref && GIT_HEAD_RE.test(head)) return head;
+    }
+  } catch {
+    // A missing packed-refs file is normal when every ref is loose.
+  }
+  return null;
+}
+
+async function readGitRef(gitDir: string, ref: string): Promise<string | null> {
+  if (!isSafeGitRef(ref)) return null;
+  const commonGitDir = await resolveCommonGitDir(gitDir);
+  const candidatePaths = [...new Set([join(gitDir, ref), join(commonGitDir, ref)])];
+
+  for (const candidatePath of candidatePaths) {
+    try {
+      const head = (await readFile(candidatePath, 'utf-8')).trim();
+      if (GIT_HEAD_RE.test(head)) return head;
+    } catch {
+      // Continue with the common directory or packed refs.
+    }
+  }
+
+  return readPackedRef(commonGitDir, ref);
+}
+
 async function readGitHealth(cwd: string): Promise<RuntimeHealthReceipt['git']> {
   const gitDir = await resolveGitDir(cwd);
   const headPath = join(gitDir, 'HEAD');
@@ -239,13 +289,12 @@ async function readGitHealth(cwd: string): Promise<RuntimeHealthReceipt['git']> 
     const rawHead = (await readFile(headPath, 'utf-8')).trim();
     if (rawHead.startsWith('ref:')) {
       const ref = rawHead.slice('ref:'.length).trim();
-      const refPath = join(gitDir, ref);
-      const head = (await readFile(refPath, 'utf-8')).trim();
+      const head = await readGitRef(gitDir, ref);
       const branch = ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref;
       return {
         ...base,
-        status: GIT_HEAD_RE.test(head) ? 'ok' : 'warn',
-        reason: GIT_HEAD_RE.test(head) ? 'git_head_resolved' : 'git_head_unexpected_format',
+        status: head ? 'ok' : 'warn',
+        reason: head ? 'git_head_resolved' : 'git_ref_unresolved',
         head,
         branch,
       };

--- a/src/server.ts
+++ b/src/server.ts
@@ -99,6 +99,11 @@ app.use('/vendor/mermaid', express.static(join(process.cwd(), 'node_modules', 'm
   maxAge: '1h',
 }));
 
+app.use((req, res, next) => {
+  res.locals.currentPath = req.path;
+  next();
+});
+
 app.post('/events', async (req, res) => {
   // 1. Authorization
   const { token, isStrict } = envConfig;

--- a/src/views/_nav.ejs
+++ b/src/views/_nav.ejs
@@ -1,0 +1,41 @@
+<%
+const navPath = typeof currentPath === 'string' ? currentPath : '';
+const navItems = [
+  { href: '/', label: 'Home' },
+  { href: '/bureau', label: 'Bureau' },
+  { href: '/checkouts', label: 'Checkouts' },
+  { href: '/observatory', label: 'Observatorium' },
+  { href: '/ecosystem-map', label: 'Systemkarte' },
+  { href: '/repobriefs', label: 'RepoBriefs' },
+  { href: '/anatomy', label: 'Anatomie' },
+  { href: '/timeline', label: 'Zeitachse' },
+  { href: '/insights', label: 'Erkenntnisse' },
+  { href: '/reflexion', label: 'Reflexion' },
+  { href: '/ops', label: 'Ops' },
+];
+const isActiveRoute = (href) => {
+  if (href === '/') return navPath === '/';
+  if (href === '/observatory' && (navPath === '/intent' || navPath.startsWith('/intent/'))) return true;
+  return navPath === href || navPath.startsWith(`${href}/`);
+};
+%>
+<a class="leitstand-skip-link" href="#leitstand-content">Zum Inhalt springen</a>
+<nav class="leitstand-nav" data-leitstand-nav data-expanded="false" aria-label="Hauptnavigation">
+  <a class="leitstand-nav__brand" href="/" aria-label="Leitstand – Startseite">Leitstand</a>
+  <button class="leitstand-nav__toggle"
+          type="button"
+          data-leitstand-nav-toggle
+          aria-expanded="false"
+          aria-controls="leitstand-nav-links">
+    <span>Menü</span>
+    <span class="leitstand-nav__toggle-icon" aria-hidden="true">☰</span>
+  </button>
+  <div class="leitstand-nav__links" id="leitstand-nav-links" data-leitstand-nav-links>
+    <% navItems.forEach(function(item) { const active = isActiveRoute(item.href); %>
+      <a class="leitstand-nav__link<%= active ? ' active' : '' %>"
+         href="<%= item.href %>"
+         <%- active ? 'aria-current="page"' : '' %>><%= item.label %></a>
+    <% }); %>
+  </div>
+</nav>
+<span id="leitstand-content" class="leitstand-main-anchor" tabindex="-1"></span>

--- a/src/views/anatomy.ejs
+++ b/src/views/anatomy.ejs
@@ -329,22 +329,11 @@
     ::-webkit-scrollbar-track { background: transparent; }
     ::-webkit-scrollbar-thumb { background: var(--border-glass); border-radius: 2px; }
   </style>
+  <link rel="stylesheet" href="/assets/shell.css">
+  <script type="module" src="/assets/shell.mjs"></script>
 </head>
 <body>
-  <nav aria-label="Hauptnavigation">
-    <span class="title">Leitstand</span>
-    <a href="/">Home</a>
-    <a href="/bureau">Bureau</a>
-    <a href="/checkouts">Checkouts</a>
-    <a href="/observatory">Observatorium</a>
-    <a href="/ecosystem-map">Ecosystem Map</a>
-    <a href="/repobriefs">RepoBriefs</a>
-    <a href="/anatomy" class="active" aria-current="page">Anatomie</a>
-    <a href="/timeline">Zeitachse</a>
-    <a href="/insights">Erkenntnisse</a>
-    <a href="/reflexion">Reflexion</a>
-    <a href="/ops">Ops</a>
-  </nav>
+  <%- include('_nav') %>
 
   <div id="tooltip">
     <div class="tt-label"></div>

--- a/src/views/bureau.ejs
+++ b/src/views/bureau.ejs
@@ -39,22 +39,11 @@
     code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: #dbeafe; }
     ul { margin-left: 20px; color: #94a3b8; }
   </style>
+  <link rel="stylesheet" href="/assets/shell.css">
+  <script type="module" src="/assets/shell.mjs"></script>
 </head>
 <body>
-  <nav aria-label="Hauptnavigation">
-    <span class="title">Leitstand</span>
-    <a href="/">Home</a>
-    <a href="/bureau" class="active" aria-current="page">Bureau</a>
-    <a href="/checkouts">Checkouts</a>
-    <a href="/observatory">Observatorium</a>
-    <a href="/ecosystem-map">Ecosystem Map</a>
-    <a href="/repobriefs">RepoBriefs</a>
-    <a href="/anatomy">Anatomie</a>
-    <a href="/timeline">Zeitachse</a>
-    <a href="/insights">Erkenntnisse</a>
-    <a href="/reflexion">Reflexion</a>
-    <a href="/ops">Ops</a>
-  </nav>
+  <%- include('_nav') %>
 
   <main>
     <h1>Bureau Task Board</h1>

--- a/src/views/checkouts.ejs
+++ b/src/views/checkouts.ejs
@@ -37,22 +37,11 @@
     code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: #dbeafe; }
     ul { margin-left: 20px; color: #94a3b8; }
   </style>
+  <link rel="stylesheet" href="/assets/shell.css">
+  <script type="module" src="/assets/shell.mjs"></script>
 </head>
 <body>
-  <nav aria-label="Hauptnavigation">
-    <span class="title">Leitstand</span>
-    <a href="/">Home</a>
-    <a href="/bureau">Bureau</a>
-    <a href="/checkouts" class="active" aria-current="page">Checkouts</a>
-    <a href="/observatory">Observatorium</a>
-    <a href="/ecosystem-map">Ecosystem Map</a>
-    <a href="/repobriefs">RepoBriefs</a>
-    <a href="/anatomy">Anatomie</a>
-    <a href="/timeline">Zeitachse</a>
-    <a href="/insights">Erkenntnisse</a>
-    <a href="/reflexion">Reflexion</a>
-    <a href="/ops">Ops</a>
-  </nav>
+  <%- include('_nav') %>
 
   <main>
     <h1>Checkout / Worktree Health</h1>

--- a/src/views/ecosystem-map.ejs
+++ b/src/views/ecosystem-map.ejs
@@ -57,22 +57,11 @@
       .map-canvas { padding: 10px; min-height: 360px; }
     }
   </style>
+  <link rel="stylesheet" href="/assets/shell.css">
+  <script type="module" src="/assets/shell.mjs"></script>
 </head>
 <body>
-  <nav aria-label="Hauptnavigation">
-    <span class="title">Leitstand</span>
-    <a href="/">Home</a>
-    <a href="/bureau">Bureau</a>
-    <a href="/checkouts">Checkouts</a>
-    <a href="/observatory">Observatorium</a>
-    <a href="/ecosystem-map" class="active" aria-current="page">Ökosystemkarte</a>
-    <a href="/repobriefs">RepoBriefs</a>
-    <a href="/anatomy">Anatomie</a>
-    <a href="/timeline">Zeitachse</a>
-    <a href="/insights">Erkenntnisse</a>
-    <a href="/reflexion">Reflexion</a>
-    <a href="/ops">Ops</a>
-  </nav>
+  <%- include('_nav') %>
 
   <main>
     <h1>Ökosystemkarte</h1>

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -1,4 +1,8 @@
-<% const phaseCards = Array.isArray(locals.phases) ? locals.phases : []; %>
+<%
+  const phaseCards = Array.isArray(locals.phases) ? locals.phases : [];
+  const dashboardSummary = locals.summary && typeof locals.summary === 'object' ? locals.summary : null;
+  const attentionItems = Array.isArray(dashboardSummary?.attention) ? dashboardSummary.attention : [];
+%>
 <!DOCTYPE html>
 <html lang="de">
 <head>
@@ -40,6 +44,8 @@
       align-items: center;
       gap: 4px;
       padding: 10px 20px;
+      overflow-x: auto;
+      scrollbar-width: thin;
       background: rgba(10, 14, 26, 0.92);
       backdrop-filter: blur(20px);
       -webkit-backdrop-filter: blur(20px);
@@ -47,6 +53,7 @@
     }
 
     nav a {
+      flex: 0 0 auto;
       text-decoration: none;
       color: var(--text-secondary);
       font-size: 0.82em;
@@ -59,7 +66,7 @@
     nav a:hover { color: var(--text-primary); background: var(--bg-glass); }
     nav a:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
     nav a.active { color: var(--accent); background: rgba(59, 130, 246, 0.1); }
-    nav .title { font-weight: 700; font-size: 0.9em; color: var(--text-primary); margin-right: 16px; }
+    nav .title { flex: 0 0 auto; font-weight: 700; font-size: 0.9em; color: var(--text-primary); margin-right: 16px; }
 
     .main {
       max-width: 1080px;
@@ -68,7 +75,7 @@
     }
 
     .page-header {
-      margin-bottom: 36px;
+      margin-bottom: 30px;
     }
 
     .page-header h1 {
@@ -93,6 +100,145 @@
       color: var(--text-muted);
       margin-bottom: 16px;
     }
+
+    .situation {
+      display: grid;
+      gap: 20px;
+      padding: 24px;
+      margin-bottom: 32px;
+      border: 1px solid var(--border-glass);
+      border-left-width: 4px;
+      border-radius: 14px;
+      background: linear-gradient(135deg, rgba(30, 41, 59, 0.96), rgba(15, 23, 42, 0.88));
+    }
+
+    .situation-healthy { border-left-color: var(--ok); }
+    .situation-attention { border-left-color: var(--warn); }
+    .situation-critical { border-left-color: var(--fail); }
+
+    .situation-header {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 20px;
+    }
+
+    .situation-kicker {
+      margin-bottom: 6px;
+      color: var(--text-muted);
+      font-size: 0.7em;
+      font-weight: 700;
+      letter-spacing: 0.11em;
+      text-transform: uppercase;
+    }
+
+    .situation h2 {
+      font-size: 1.25em;
+      line-height: 1.35;
+    }
+
+    .state-badge {
+      flex: 0 0 auto;
+      display: inline-flex;
+      align-items: center;
+      padding: 6px 11px;
+      border: 1px solid currentColor;
+      border-radius: 999px;
+      font-size: 0.76em;
+      font-weight: 700;
+    }
+
+    .situation-healthy .state-badge { color: var(--ok); }
+    .situation-attention .state-badge { color: var(--warn); }
+    .situation-critical .state-badge { color: var(--fail); }
+
+    .summary-stats {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 10px;
+    }
+
+    .summary-stat {
+      padding: 14px;
+      border: 1px solid var(--border-glass);
+      border-radius: 10px;
+      background: var(--bg-glass);
+    }
+
+    .summary-stat dt {
+      color: var(--text-muted);
+      font-size: 0.7em;
+      line-height: 1.35;
+    }
+
+    .summary-stat dd {
+      margin-top: 5px;
+      font-size: 1.35em;
+      font-weight: 700;
+      font-variant-numeric: tabular-nums;
+    }
+
+    .attention-block h3 {
+      margin-bottom: 10px;
+      font-size: 0.85em;
+      color: var(--text-secondary);
+    }
+
+    .attention-list {
+      display: grid;
+      gap: 8px;
+      list-style: none;
+    }
+
+    .attention-item a {
+      display: grid;
+      grid-template-columns: auto 1fr auto;
+      gap: 10px;
+      align-items: center;
+      padding: 11px 12px;
+      color: inherit;
+      text-decoration: none;
+      border: 1px solid var(--border-glass);
+      border-radius: 9px;
+      background: rgba(2, 6, 23, 0.34);
+    }
+
+    .attention-item a:hover { border-color: rgba(59, 130, 246, 0.45); }
+    .attention-item a:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+    .attention-title { font-size: 0.86em; font-weight: 650; }
+    .attention-reason { color: var(--text-secondary); font-size: 0.78em; line-height: 1.4; }
+    .attention-arrow { color: var(--text-muted); }
+
+    .severity-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: var(--unknown);
+    }
+
+    .severity-critical { background: var(--fail); }
+    .severity-warning { background: var(--warn); }
+    .severity-info { background: var(--unknown); }
+
+    .situation-clear {
+      color: var(--ok);
+      font-size: 0.86em;
+    }
+
+    .projection-note {
+      color: var(--text-muted);
+      font-size: 0.72em;
+      line-height: 1.45;
+    }
+
+    .surface-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 16px;
+      margin-bottom: 40px;
+    }
+
+    .surface-grid .info-card { margin-bottom: 0; }
 
     .phase-grid {
       display: grid;
@@ -220,6 +366,9 @@
       line-height: 1.6;
     }
 
+    .info-card a { color: #93c5fd; }
+    .info-card a:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
     .info-card .role-list {
       list-style: none;
       padding: 0;
@@ -240,9 +389,20 @@
 
     .info-card .role-list strong { color: var(--text-primary); font-weight: 600; }
 
+    @media (max-width: 860px) {
+      .surface-grid { grid-template-columns: 1fr; }
+      .summary-stats { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    }
+
     @media (max-width: 640px) {
+      nav { padding-inline: 14px; }
       .main { padding: 28px 18px 64px; }
       .page-header h1 { font-size: 1.5em; }
+      .situation { padding: 18px; }
+      .situation-header { display: grid; }
+      .state-badge { justify-self: start; }
+      .attention-item a { grid-template-columns: auto 1fr; }
+      .attention-arrow { display: none; }
     }
 
     /* Visually hidden text accessible to screen readers */
@@ -258,22 +418,11 @@
       border: 0;
     }
   </style>
+  <link rel="stylesheet" href="/assets/shell.css">
+  <script type="module" src="/assets/shell.mjs"></script>
 </head>
 <body>
-  <nav aria-label="Hauptnavigation">
-    <span class="title">Leitstand</span>
-    <a href="/" class="active" aria-current="page">Home</a>
-    <a href="/bureau">Bureau</a>
-    <a href="/checkouts">Checkouts</a>
-    <a href="/observatory">Observatorium</a>
-    <a href="/ecosystem-map">Ecosystem Map</a>
-    <a href="/repobriefs">RepoBriefs</a>
-    <a href="/anatomy">Anatomie</a>
-    <a href="/timeline">Zeitachse</a>
-    <a href="/insights">Erkenntnisse</a>
-    <a href="/reflexion">Reflexion</a>
-    <a href="/ops">Ops</a>
-  </nav>
+  <%- include('_nav') %>
 
   <main class="main" id="main">
     <header class="page-header">
@@ -284,29 +433,92 @@
       </p>
     </header>
 
-    <section class="info-card" aria-labelledby="ecosystem-map-heading">
-      <h2 id="ecosystem-map-heading">Ecosystem Map</h2>
-      <p>
-        Read-only system catalog map source view: zeigt Mermaid-Quellen, Commit, Manifest, Freshness und Boundary-Hinweis.
-        <a href="/ecosystem-map">Ecosystem Map öffnen</a>.
-      </p>
-    </section>
+    <% if (dashboardSummary) { %>
+      <section class="situation situation-<%= dashboardSummary.state %>"
+               aria-labelledby="situation-heading"
+               data-dashboard-state="<%= dashboardSummary.state %>">
+        <div class="situation-header">
+          <div>
+            <p class="situation-kicker">Aktuelles Lagebild</p>
+            <h2 id="situation-heading"><%= dashboardSummary.headline %></h2>
+          </div>
+          <span class="state-badge"><%= dashboardSummary.state_label %></span>
+        </div>
 
-    <section class="info-card" aria-labelledby="execution-heading">
-      <h2 id="execution-heading">Ausführungs-Achse (Bureau · Grabowski)</h2>
-      <p>
-        Read-only Projektion des Operator-Ökosystems, das die Ausführungswahrheit erzeugt.
-        Snapshots werden von einem separaten Producer erzeugt; Leitstand rendert sie nur.
-        <a href="/bureau">Bureau Task Board öffnen</a> · <a href="/checkouts">Checkout Health öffnen</a>.
-      </p>
-    </section>
+        <dl class="summary-stats" aria-label="Verdichtete Zustandszahlen">
+          <div class="summary-stat">
+            <dt>Beobachtete Bereiche</dt>
+            <dd><%= dashboardSummary.total_count %></dd>
+          </div>
+          <div class="summary-stat">
+            <dt>Artefakt + frisch belegt</dt>
+            <dd><%= dashboardSummary.verified_fresh_count %></dd>
+          </div>
+          <div class="summary-stat">
+            <dt>Mit Prüfhinweis</dt>
+            <dd><%= dashboardSummary.attention_count %></dd>
+          </div>
+          <div class="summary-stat">
+            <dt>Nicht belastbar verfügbar</dt>
+            <dd><%= dashboardSummary.unavailable_count %></dd>
+          </div>
+        </dl>
 
-    <section class="info-card" aria-labelledby="repobrief-heading">
-      <h2 id="repobrief-heading">RepoBrief / rLens</h2>
-      <p>
-        Read-only bundle observability: zeigt Snapshot-Status, Required Artifacts und Export-Safety-Warnungen.
-        <a href="/repobriefs">RepoBriefs öffnen</a>.
-      </p>
+        <% if (attentionItems.length > 0) { %>
+          <div class="attention-block">
+            <h3>Priorisierte Prüfungen</h3>
+            <ol class="attention-list">
+              <% attentionItems.forEach(function(item) { %>
+                <li class="attention-item">
+                  <a href="<%= item.href %>" data-attention-phase="<%= item.phase_id %>">
+                    <span class="severity-dot severity-<%= item.severity %>" aria-hidden="true"></span>
+                    <span>
+                      <span class="attention-title"><%= item.title %></span><br>
+                      <span class="attention-reason"><%= item.reason %></span>
+                    </span>
+                    <span class="attention-arrow" aria-hidden="true">→</span>
+                  </a>
+                </li>
+              <% }); %>
+            </ol>
+          </div>
+        <% } else { %>
+          <p class="situation-clear">Keine Prüfhinweise aus den vorhandenen Quellen- und Frischebelegen.</p>
+        <% } %>
+
+        <p class="projection-note">
+          Dieses Lagebild verdichtet nur die darunter angezeigten Quellen- und Frischebelege. Es erzeugt keine eigene Zustandswahrheit.
+        </p>
+      </section>
+    <% } %>
+
+    <section aria-labelledby="surfaces-heading">
+      <h2 id="surfaces-heading" class="section-title">Arbeitsflächen</h2>
+      <div class="surface-grid">
+        <article class="info-card" aria-labelledby="ecosystem-map-heading">
+          <h2 id="ecosystem-map-heading">Ecosystem Map</h2>
+          <p>
+            Systemkatalog als interaktive Karte mit Quelle, Commit, Manifest, Frische und klarer Read-only-Grenze.
+            <a href="/ecosystem-map">Karte öffnen</a>.
+          </p>
+        </article>
+
+        <article class="info-card" aria-labelledby="execution-heading">
+          <h2 id="execution-heading">Ausführung</h2>
+          <p>
+            Read-only-Projektion von Bureau und Grabowski. Snapshots stammen vom separaten Producer.
+            <a href="/bureau">Tasks</a> · <a href="/checkouts">Checkouts</a>.
+          </p>
+        </article>
+
+        <article class="info-card" aria-labelledby="repobrief-heading">
+          <h2 id="repobrief-heading">RepoBrief / rLens</h2>
+          <p>
+            Bundle-Status, Pflichtartefakte und Export-Safety-Warnungen ohne versteckten Refresh.
+            <a href="/repobriefs">RepoBriefs öffnen</a>.
+          </p>
+        </article>
+      </div>
     </section>
 
     <section aria-labelledby="phasen-heading">

--- a/src/views/insights.ejs
+++ b/src/views/insights.ejs
@@ -584,22 +584,11 @@
 
     .evidenz-node a:hover { text-decoration: underline; }
   </style>
+  <link rel="stylesheet" href="/assets/shell.css">
+  <script type="module" src="/assets/shell.mjs"></script>
 </head>
 <body>
-  <nav aria-label="Hauptnavigation">
-    <span class="title">Leitstand</span>
-    <a href="/">Home</a>
-    <a href="/bureau">Bureau</a>
-    <a href="/checkouts">Checkouts</a>
-    <a href="/observatory">Observatorium</a>
-    <a href="/ecosystem-map">Ecosystem Map</a>
-    <a href="/repobriefs">RepoBriefs</a>
-    <a href="/anatomy">Anatomie</a>
-    <a href="/timeline">Zeitachse</a>
-    <a href="/insights" class="active" aria-current="page">Erkenntnisse</a>
-    <a href="/reflexion">Reflexion</a>
-    <a href="/ops">Ops</a>
-  </nav>
+  <%- include('_nav') %>
 
   <div class="main">
     <div class="page-header">

--- a/src/views/intent.ejs
+++ b/src/views/intent.ejs
@@ -13,22 +13,11 @@
     li { background: #eee; margin: 5px 0; padding: 10px; border-radius: 4px; }
     .confidence { font-weight: bold; color: green; }
   </style>
+  <link rel="stylesheet" href="/assets/shell.css">
+  <script type="module" src="/assets/shell.mjs"></script>
 </head>
 <body>
-  <nav aria-label="Hauptnavigation">
-    <span class="title">Leitstand</span>
-    <a href="/">Home</a>
-    <a href="/bureau">Bureau</a>
-    <a href="/checkouts">Checkouts</a>
-    <a href="/observatory">Observatorium</a>
-    <a href="/ecosystem-map">Ecosystem Map</a>
-    <a href="/repobriefs">RepoBriefs</a>
-    <a href="/anatomy">Anatomie</a>
-    <a href="/timeline">Zeitachse</a>
-    <a href="/insights">Erkenntnisse</a>
-    <a href="/reflexion">Reflexion</a>
-    <a href="/ops">Ops</a>
-  </nav>
+  <%- include('_nav') %>
   <h1>Aktueller Intent</h1>
   <p class="meta">Generated at: <%= data.generated_at %></p>
 

--- a/src/views/observatory.ejs
+++ b/src/views/observatory.ejs
@@ -460,22 +460,11 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="/assets/shell.css">
+  <script type="module" src="/assets/shell.mjs"></script>
 </head>
 <body>
-  <nav aria-label="Hauptnavigation">
-    <span class="title">Leitstand</span>
-    <a href="/">Home</a>
-    <a href="/bureau">Bureau</a>
-    <a href="/checkouts">Checkouts</a>
-    <a href="/observatory" class="active" aria-current="page">Observatorium</a>
-    <a href="/ecosystem-map">Ecosystem Map</a>
-    <a href="/repobriefs">RepoBriefs</a>
-    <a href="/anatomy">Anatomie</a>
-    <a href="/timeline">Zeitachse</a>
-    <a href="/insights">Erkenntnisse</a>
-    <a href="/reflexion">Reflexion</a>
-    <a href="/ops">Ops</a>
-  </nav>
+  <%- include('_nav') %>
 
   <div class="main-wrapper">
     <h1>Observatorium</h1>

--- a/src/views/ops.ejs
+++ b/src/views/ops.ejs
@@ -240,22 +240,11 @@
         font-size: 0.85em;
     }
   </style>
+  <link rel="stylesheet" href="/assets/shell.css">
+  <script type="module" src="/assets/shell.mjs"></script>
 </head>
 <body>
-  <nav aria-label="Hauptnavigation">
-    <span class="title">Leitstand</span>
-    <a href="/">Home</a>
-    <a href="/bureau">Bureau</a>
-    <a href="/checkouts">Checkouts</a>
-    <a href="/observatory">Observatorium</a>
-    <a href="/ecosystem-map">Ecosystem Map</a>
-    <a href="/repobriefs">RepoBriefs</a>
-    <a href="/anatomy">Anatomie</a>
-    <a href="/timeline">Zeitachse</a>
-    <a href="/insights">Erkenntnisse</a>
-    <a href="/reflexion">Reflexion</a>
-    <a href="/ops" class="active" aria-current="page">Ops</a>
-  </nav>
+  <%- include('_nav') %>
 
   <div class="main-wrapper">
     <div class="page-header">

--- a/src/views/reflexion.ejs
+++ b/src/views/reflexion.ejs
@@ -308,22 +308,11 @@
       color: var(--text-muted);
     }
   </style>
+  <link rel="stylesheet" href="/assets/shell.css">
+  <script type="module" src="/assets/shell.mjs"></script>
 </head>
 <body>
-  <nav aria-label="Hauptnavigation">
-    <span class="title">Leitstand</span>
-    <a href="/">Home</a>
-    <a href="/bureau">Bureau</a>
-    <a href="/checkouts">Checkouts</a>
-    <a href="/observatory">Observatorium</a>
-    <a href="/ecosystem-map">Ecosystem Map</a>
-    <a href="/repobriefs">RepoBriefs</a>
-    <a href="/anatomy">Anatomie</a>
-    <a href="/timeline">Zeitachse</a>
-    <a href="/insights">Erkenntnisse</a>
-    <a href="/reflexion" class="active" aria-current="page">Reflexion</a>
-    <a href="/ops">Ops</a>
-  </nav>
+  <%- include('_nav') %>
 
   <div class="main">
     <div class="page-header">

--- a/src/views/repobriefs.ejs
+++ b/src/views/repobriefs.ejs
@@ -23,22 +23,11 @@
     code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: #dbeafe; }
     ul { margin-left: 20px; }
   </style>
+  <link rel="stylesheet" href="/assets/shell.css">
+  <script type="module" src="/assets/shell.mjs"></script>
 </head>
 <body>
-  <nav aria-label="Hauptnavigation">
-    <span class="title">Leitstand</span>
-    <a href="/">Home</a>
-    <a href="/bureau">Bureau</a>
-    <a href="/checkouts">Checkouts</a>
-    <a href="/observatory">Observatorium</a>
-    <a href="/ecosystem-map">Ecosystem Map</a>
-    <a href="/repobriefs" class="active" aria-current="page">RepoBriefs</a>
-    <a href="/anatomy">Anatomie</a>
-    <a href="/timeline">Zeitachse</a>
-    <a href="/insights">Erkenntnisse</a>
-    <a href="/reflexion">Reflexion</a>
-    <a href="/ops">Ops</a>
-  </nav>
+  <%- include('_nav') %>
 
   <main>
     <h1>RepoBrief / rLens Observability</h1>

--- a/src/views/timeline.ejs
+++ b/src/views/timeline.ejs
@@ -369,22 +369,11 @@
 
     .source-badge .warn { color: #f59e0b; }
   </style>
+  <link rel="stylesheet" href="/assets/shell.css">
+  <script type="module" src="/assets/shell.mjs"></script>
 </head>
 <body>
-  <nav aria-label="Hauptnavigation">
-    <span class="title">Leitstand</span>
-    <a href="/">Home</a>
-    <a href="/bureau">Bureau</a>
-    <a href="/checkouts">Checkouts</a>
-    <a href="/observatory">Observatorium</a>
-    <a href="/ecosystem-map">Ecosystem Map</a>
-    <a href="/repobriefs">RepoBriefs</a>
-    <a href="/anatomy">Anatomie</a>
-    <a href="/timeline" class="active" aria-current="page">Zeitachse</a>
-    <a href="/insights">Erkenntnisse</a>
-    <a href="/reflexion">Reflexion</a>
-    <a href="/ops">Ops</a>
-  </nav>
+  <%- include('_nav') %>
 
   <div class="main">
     <div class="page-header">

--- a/tests/controllers/dashboard.test.ts
+++ b/tests/controllers/dashboard.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { getDashboardData } from '../../src/controllers/dashboard.js';
+import { getDashboardData, summarizeDashboard, type DashboardPhase } from '../../src/controllers/dashboard.js';
 import * as anatomyCtrl from '../../src/controllers/anatomy.js';
 import * as insightsCtrl from '../../src/controllers/insights.js';
 import * as timelineCtrl from '../../src/controllers/timeline.js';
@@ -14,7 +14,7 @@ describe('getDashboardData controller', () => {
     vi.restoreAllMocks();
   });
 
-  it('returns a tile for each of the five phases in a stable order', async () => {
+  it('returns a tile for each phase and a derived situation summary', async () => {
     vi.spyOn(anatomyCtrl, 'getAnatomyData').mockResolvedValue({
       anatomy: { nodes: [], edges: [], achsen: {}, generated_at: '2026-04-01T00:00:00.000Z' } as never,
       health: {
@@ -115,9 +115,24 @@ describe('getDashboardData controller', () => {
     for (const phase of result.phases) {
       expect(phase.error_reason).toBeNull();
     }
+
+    expect(result.summary).toMatchObject({
+      state: 'attention',
+      state_label: 'Prüfbedarf',
+      total_count: 5,
+      verified_fresh_count: 2,
+      attention_count: 3,
+      unavailable_count: 0,
+    });
+    expect(result.summary.attention.map((item) => item.phase_id)).toEqual([
+      'physiologie',
+      'zeitachse',
+      'reflexion',
+    ]);
+    expect(result.summary.attention[0].reason).toContain('Ersatzdaten');
   });
 
-  it('masks strict-mode error messages as an opaque token in error_reason', async () => {
+  it('masks strict-mode error messages and raises a critical summary', async () => {
     vi.spyOn(anatomyCtrl, 'getAnatomyData').mockRejectedValue(
       new Error('Strict load failed: /data/artifacts/anatomy/2026-05-18.json not found'),
     );
@@ -166,6 +181,10 @@ describe('getDashboardData controller', () => {
     expect(insightsTile.source_kind).toBe('error');
     expect(insightsTile.error_reason).toBe('strict-load-failed');
     expect(insightsTile.error_reason).not.toContain('/var/run');
+
+    expect(result.summary.state).toBe('critical');
+    expect(result.summary.unavailable_count).toBe(5);
+    expect(result.summary.attention[0].severity).toBe('critical');
   });
 
   it('isolates failures so one broken controller does not break the others', async () => {
@@ -220,5 +239,34 @@ describe('getDashboardData controller', () => {
 
     const reflexionTile = result.phases.find((p) => p.id === 'reflexion')!;
     expect(reflexionTile.source_kind).toBe('missing');
+    expect(result.summary.state).toBe('critical');
+    expect(result.summary.attention_count).toBe(5);
+  });
+
+  it('reports a stable state only when every projected phase is artifact-backed and fresh', () => {
+    const phases: DashboardPhase[] = [
+      {
+        id: 'anatomie',
+        phase: 1,
+        title: 'Anatomie',
+        description: 'Test',
+        href: '/anatomy',
+        source_kind: 'artifact',
+        freshness_state: 'fresh',
+        metric: '1 Knoten',
+        error_reason: null,
+      },
+    ];
+
+    expect(summarizeDashboard(phases)).toEqual({
+      state: 'healthy',
+      state_label: 'Stabil',
+      headline: 'Alle Bereiche liefern frische Artefakte',
+      total_count: 1,
+      verified_fresh_count: 1,
+      attention_count: 0,
+      unavailable_count: 0,
+      attention: [],
+    });
   });
 });

--- a/tests/runtimeHealth.test.ts
+++ b/tests/runtimeHealth.test.ts
@@ -61,6 +61,49 @@ describe('runtime health receipt', () => {
     expect(receipt.doesNotEstablish).toContain('dns_correctness');
   });
 
+  it('resolves a loose branch ref from a linked worktree common Git directory', async () => {
+    await writeSnapshots('2026-07-08T17:55:00.000Z');
+    const commonGitDir = join(testDir, '.git-common');
+    const worktreeGitDir = join(commonGitDir, 'worktrees', 'linked');
+    await rm(join(testDir, '.git'), { recursive: true, force: true });
+    await mkdir(join(commonGitDir, 'refs', 'heads'), { recursive: true });
+    await mkdir(worktreeGitDir, { recursive: true });
+    await writeFile(join(testDir, '.git'), `gitdir: ${worktreeGitDir}\n`, 'utf-8');
+    await writeFile(join(worktreeGitDir, 'HEAD'), 'ref: refs/heads/feature\n', 'utf-8');
+    await writeFile(join(worktreeGitDir, 'commondir'), '../..\n', 'utf-8');
+    await writeFile(join(commonGitDir, 'refs', 'heads', 'feature'), `${'b'.repeat(40)}\n`, 'utf-8');
+
+    const receipt = await getRuntimeHealthData({ cwd: testDir, now, staleAfterMs: 20 * 60 * 1000 });
+
+    expect(receipt.status).toBe('ok');
+    expect(receipt.git.status).toBe('ok');
+    expect(receipt.git.head).toBe('b'.repeat(40));
+    expect(receipt.git.branch).toBe('feature');
+  });
+
+  it('resolves a packed branch ref from a linked worktree common Git directory', async () => {
+    await writeSnapshots('2026-07-08T17:55:00.000Z');
+    const commonGitDir = join(testDir, '.git-common');
+    const worktreeGitDir = join(commonGitDir, 'worktrees', 'linked');
+    await rm(join(testDir, '.git'), { recursive: true, force: true });
+    await mkdir(worktreeGitDir, { recursive: true });
+    await writeFile(join(testDir, '.git'), `gitdir: ${worktreeGitDir}\n`, 'utf-8');
+    await writeFile(join(worktreeGitDir, 'HEAD'), 'ref: refs/heads/packed-feature\n', 'utf-8');
+    await writeFile(join(worktreeGitDir, 'commondir'), '../..\n', 'utf-8');
+    await writeFile(
+      join(commonGitDir, 'packed-refs'),
+      `# pack-refs with: peeled fully-peeled sorted\n${'c'.repeat(40)} refs/heads/packed-feature\n`,
+      'utf-8',
+    );
+
+    const receipt = await getRuntimeHealthData({ cwd: testDir, now, staleAfterMs: 20 * 60 * 1000 });
+
+    expect(receipt.status).toBe('ok');
+    expect(receipt.git.status).toBe('ok');
+    expect(receipt.git.head).toBe('c'.repeat(40));
+    expect(receipt.git.branch).toBe('packed-feature');
+  });
+
   it('warns when snapshots are stale', async () => {
     await writeSnapshots('2026-07-08T17:00:00.000Z');
 
@@ -71,7 +114,6 @@ describe('runtime health receipt', () => {
     expect(receipt.snapshots.bureau_tasks.reason).toBe('snapshot_stale');
     expect(receipt.snapshots.checkout_inventory.status).toBe('warn');
   });
-
 
   it('fails when a snapshot has the wrong contract kind', async () => {
     await writeFile(

--- a/tests/views/ecosystemMap.test.ts
+++ b/tests/views/ecosystemMap.test.ts
@@ -45,7 +45,7 @@ describe('ecosystem-map view', () => {
         },
         node_navigation_json: '[{"mermaid_id":"repo_bureau","href":"/bureau"}]',
       },
-      { async: true, localsName: 'locals' },
+      { async: false, localsName: 'locals' },
     );
 
     expect(html).toContain('data-ecosystem-map-canvas');
@@ -98,7 +98,7 @@ describe('ecosystem-map view', () => {
         },
         node_navigation_json: '[]',
       },
-      { async: true, localsName: 'locals' },
+      { async: false, localsName: 'locals' },
     );
 
     expect(html).toContain('Drift erkannt');

--- a/tests/views/index.test.ts
+++ b/tests/views/index.test.ts
@@ -2,18 +2,66 @@ import { describe, expect, it } from 'vitest';
 import { join } from 'node:path';
 import ejs from 'ejs';
 
+const viewPath = join(process.cwd(), 'src/views/index.ejs');
+const renderOptions = {
+  async: false,
+  localsName: 'locals',
+} as const;
+
 describe('index.ejs', () => {
   it('renders without phases locals (static build safety)', async () => {
-    const html = await ejs.renderFile(
-      join(process.cwd(), 'src/views/index.ejs'),
-      {},
-      {
-        async: true,
-        localsName: 'locals',
-      },
-    );
+    const html = await ejs.renderFile(viewPath, {}, renderOptions);
 
     expect(html).toContain('Leitstand');
+    expect(html).toContain('class="leitstand-nav"');
+    expect(html).not.toContain('[object Promise]');
     expect(html).toContain('Die Phasenübersicht ist aktuell nicht verfügbar.');
+  });
+
+  it('renders the derived situation summary and prioritized attention links', async () => {
+    const html = await ejs.renderFile(
+      viewPath,
+      {
+        currentPath: '/',
+        phases: [
+          {
+            id: 'zeitachse',
+            phase: 3,
+            title: 'Zeitachse',
+            description: 'Chronologische Events',
+            href: '/timeline',
+            source_kind: 'artifact',
+            freshness_state: 'unknown',
+            metric: '3 Events',
+            error_reason: null,
+          },
+        ],
+        summary: {
+          state: 'attention',
+          state_label: 'Prüfbedarf',
+          headline: '1 Bereich benötigt Prüfung',
+          total_count: 1,
+          verified_fresh_count: 0,
+          attention_count: 1,
+          unavailable_count: 0,
+          attention: [
+            {
+              phase_id: 'zeitachse',
+              title: 'Zeitachse',
+              href: '/timeline',
+              severity: 'info',
+              reason: 'Datenfrische ist nicht belegt',
+            },
+          ],
+        },
+      },
+      renderOptions,
+    );
+
+    expect(html).toContain('data-dashboard-state="attention"');
+    expect(html).toContain('1 Bereich benötigt Prüfung');
+    expect(html).toContain('data-attention-phase="zeitachse"');
+    expect(html).toContain('Datenfrische ist nicht belegt');
+    expect(html).toContain('Es erzeugt keine eigene Zustandswahrheit.');
   });
 });

--- a/tests/views/navigation.test.ts
+++ b/tests/views/navigation.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { renderFile } from 'ejs';
 import { describe, expect, it } from 'vitest';
 
 const canonicalRoutes = [
@@ -16,51 +17,83 @@ const canonicalRoutes = [
   '/ops',
 ];
 
-const navViews: Array<{ file: string; active?: string }> = [
-  { file: 'index.ejs', active: '/' },
-  { file: 'bureau.ejs', active: '/bureau' },
-  { file: 'checkouts.ejs', active: '/checkouts' },
-  { file: 'observatory.ejs', active: '/observatory' },
-  { file: 'ecosystem-map.ejs', active: '/ecosystem-map' },
-  { file: 'repobriefs.ejs', active: '/repobriefs' },
-  { file: 'anatomy.ejs', active: '/anatomy' },
-  { file: 'timeline.ejs', active: '/timeline' },
-  { file: 'insights.ejs', active: '/insights' },
-  { file: 'reflexion.ejs', active: '/reflexion' },
-  { file: 'ops.ejs', active: '/ops' },
-  { file: 'intent.ejs' },
+const navViews = [
+  'index.ejs',
+  'bureau.ejs',
+  'checkouts.ejs',
+  'observatory.ejs',
+  'ecosystem-map.ejs',
+  'repobriefs.ejs',
+  'anatomy.ejs',
+  'timeline.ejs',
+  'insights.ejs',
+  'reflexion.ejs',
+  'ops.ejs',
+  'intent.ejs',
 ];
 
-function readView(file: string): string {
-  return readFileSync(join(process.cwd(), 'src', 'views', file), 'utf-8');
-}
+const viewsRoot = join(process.cwd(), 'src', 'views');
+const navPartial = join(viewsRoot, '_nav.ejs');
 
-function navBlock(html: string): string {
-  const match = html.match(/<nav[^>]*aria-label="Hauptnavigation"[^>]*>[\s\S]*?<\/nav>/);
-  if (!match) throw new Error('missing canonical navigation block');
-  return match[0];
+function readView(file: string): string {
+  return readFileSync(join(viewsRoot, file), 'utf-8');
 }
 
 describe('canonical navigation parity', () => {
-  it.each(navViews)('$file exposes the canonical read-only route set', ({ file }) => {
-    const nav = navBlock(readView(file));
+  it.each(navViews)('%s consumes the shared shell without a private nav copy', (file) => {
+    const view = readView(file);
+    expect(view).toContain("<%- include('_nav') %>");
+    expect(view).toContain('href="/assets/shell.css"');
+    expect(view).toContain('src="/assets/shell.mjs"');
+    expect(view).not.toContain('<nav aria-label="Hauptnavigation">');
+  });
+
+  it('the shared partial exposes the canonical read-only route set', () => {
+    const partial = readFileSync(navPartial, 'utf-8');
     for (const route of canonicalRoutes) {
-      expect(nav).toContain(`href="${route}"`);
+      expect(partial).toContain(`href: '${route}'`);
     }
+    expect(partial).not.toContain('<form');
+    expect(partial).not.toContain('method="post"');
+    expect(partial).not.toContain('data-action');
   });
 
-  it.each(navViews.filter((view) => view.active))('$file marks only its active route', ({ file, active }) => {
-    const nav = navBlock(readView(file));
-    const activeMatches = [...nav.matchAll(/<a href="([^"]+)" class="active" aria-current="page">/g)].map((match) => match[1]);
-    expect(activeMatches).toEqual([active]);
+  it.each(canonicalRoutes)('marks only %s as the active canonical route', async (route) => {
+    const html = await renderFile(navPartial, { currentPath: route });
+    const activeMatches = [
+      ...html.matchAll(/<a class="leitstand-nav__link active"\s+href="([^"]+)"\s+aria-current="page">/g),
+    ].map((match) => match[1]);
+    expect(activeMatches).toEqual([route]);
   });
 
-  it('canonical navigation contains links only and no action forms', () => {
-    for (const view of navViews) {
-      const nav = navBlock(readView(view.file));
-      expect(nav).not.toContain('<form');
-      expect(nav).not.toContain('method="post"');
-      expect(nav).not.toContain('data-action');
-    }
+  it.each(['/intent', '/intent/example'])('maps %s back to the Observatorium section', async (currentPath) => {
+    const html = await renderFile(navPartial, { currentPath });
+    expect(html).toMatch(/href="\/observatory"\s+aria-current="page"/);
+  });
+
+  it('provides progressive mobile navigation and a keyboard skip target', () => {
+    const partial = readFileSync(navPartial, 'utf-8');
+    const css = readFileSync(join(process.cwd(), 'src', 'public', 'shell.css'), 'utf-8');
+    const script = readFileSync(join(process.cwd(), 'src', 'public', 'shell.mjs'), 'utf-8');
+
+    expect(partial).toContain('data-leitstand-nav-toggle');
+    expect(partial).toContain('aria-controls="leitstand-nav-links"');
+    expect(partial).toContain('href="#leitstand-content"');
+    expect(partial).toContain('id="leitstand-content"');
+    expect(css).toContain('@media (max-width: 960px)');
+    expect(css).toContain('prefers-reduced-motion');
+    expect(script).toContain("event.key === 'Escape'");
+    expect(script).toContain("window.matchMedia('(max-width: 960px)')");
+  });
+
+  it('copies the shared shell into the supported static mirror', () => {
+    const buildScript = readFileSync(join(process.cwd(), 'scripts', 'build-static.mjs'), 'utf-8');
+
+    expect(buildScript).toContain('const STATIC_ASSETS = ["shell.css", "shell.mjs"]');
+    expect(buildScript).toContain('copyFile(join(ROOT, "src", "public", name), join(assetsOut, name))');
+    expect(buildScript).toContain('await copyStaticAssets()');
+    expect(buildScript).toContain('{ currentPath: "/" }');
+    expect(buildScript).toContain('currentPath: "/observatory"');
+    expect(buildScript).toContain('{ currentPath: "/intent" }');
   });
 });


### PR DESCRIPTION
## Ziel
Den Leitstand vom reinen Ansichtenverzeichnis zu einem priorisierten, weiterhin read-only Lagebild weiterentwickeln und die Navigation konsistent machen.

## Änderungen
- abgeleitetes Lagebild aus vorhandenen source_kind-/freshness_state-Belegen
- priorisierte Prüfhinweise ohne zweites Wahrheitsmodell
- gemeinsame responsive Navigation mit Tastatur- und Mobile-Verhalten
- statischer Mirror kopiert Shell-Assets und rendert Includes korrekt
- Runtime-Health löst Git-Refs in verknüpften Worktrees und packed-refs auf

## Prüfung
- pnpm lint
- pnpm typecheck
- pnpm test: 44 Dateien / 362 Tests
- pnpm build
- pnpm build:static
- statischer Readback: echte Navigation, genau ein aktiver Menüpunkt, kein [object Promise]
- Live-Readback: Startseite und Shell-Assets HTTP 200; isolierter /health-Fail ausschließlich wegen fehlender Producer-Snapshots, Git/Server ok

## Grenzen
Das Lagebild ist nur eine Projektion vorhandener Quellen- und Frischebelege. Es erzeugt keine eigene Zustandswahrheit und mutiert keine externen Systeme.