### PR TITLE
Leitstand: gemeinsame Shell entkoppeln und browserprüfen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,10 @@ jobs:
       if: success()
       run: pnpm run test
 
+    - name: Browser shell regression
+      if: success()
+      run: pnpm run test:browser-shell
+
     - name: Build
       if: success()
       run: pnpm run build

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "daily-digest": "node dist/cli.js",
     "start:server": "node dist/server.js",
     "typecheck": "tsc --noEmit",
-    "check:vendor-contracts": "node scripts/check-vendored-contracts.mjs"
+    "check:vendor-contracts": "node scripts/check-vendored-contracts.mjs",
+    "test:browser-shell": "node scripts/browser-shell-regression.mjs"
   },
   "bin": {
     "leitstand": "./dist/cli.js"
@@ -41,6 +42,7 @@
     "@typescript-eslint/eslint-plugin": "^6.13.0",
     "@typescript-eslint/parser": "^6.13.0",
     "eslint": "^8.54.0",
+    "playwright-core": "^1.61.1",
     "supertest": "^7.1.4",
     "typescript": "5.3.3",
     "vitest": "^1.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       eslint:
         specifier: ^8.54.0
         version: 8.57.1
+      playwright-core:
+        specifier: ^1.61.1
+        version: 1.61.1
       supertest:
         specifier: ^7.1.4
         version: 7.2.2
@@ -1561,6 +1564,11 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   points-on-curve@0.2.0:
     resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
@@ -3445,6 +3453,8 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.8.0
       pathe: 2.0.3
+
+  playwright-core@1.61.1: {}
 
   points-on-curve@0.2.0: {}
 

--- a/scripts/browser-shell-regression.mjs
+++ b/scripts/browser-shell-regression.mjs
@@ -1,0 +1,210 @@
+import { constants } from 'node:fs';
+import { access, readFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ejs from 'ejs';
+import { chromium } from 'playwright-core';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const VIEWPORTS = [
+  { name: 'mobile', width: 390, height: 844, mobile: true },
+  { name: 'desktop', width: 1280, height: 900, mobile: false },
+];
+
+async function findChrome() {
+  const candidates = [
+    process.env.CHROME_BIN,
+    '/usr/bin/google-chrome',
+    '/usr/bin/google-chrome-stable',
+    '/usr/bin/chromium',
+    '/usr/bin/chromium-browser',
+  ].filter(Boolean);
+
+  for (const candidate of candidates) {
+    try {
+      await access(candidate, constants.X_OK);
+      return candidate;
+    } catch {
+      // Try the next known browser path.
+    }
+  }
+  throw new Error('No supported Chrome/Chromium executable found. Set CHROME_BIN.');
+}
+
+function createHarness(navHtml, shellCss, shellScript) {
+  const script = shellScript.replaceAll('</script', '<\\/script');
+  return `<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Leitstand shell regression</title>
+  <style>${shellCss}</style>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+    body { margin: 0; min-height: 100vh; background: #0a0e1a; color: #f1f5f9; font-family: sans-serif; }
+    main { min-width: 0; padding: 24px; }
+  </style>
+</head>
+<body>
+  ${navHtml}
+  <main><button id="outside-target" type="button">Outside</button><p>Browser shell regression surface.</p></main>
+  <script>${script}</script>
+</body>
+</html>`;
+}
+
+async function waitFrames(page) {
+  await page.evaluate(() => new Promise((resolveFrame) => {
+    requestAnimationFrame(() => requestAnimationFrame(resolveFrame));
+  }));
+}
+
+async function readState(page) {
+  return page.evaluate(() => {
+    const nav = document.querySelector('[data-leitstand-nav]');
+    const toggle = document.querySelector('[data-leitstand-nav-toggle]');
+    const links = document.querySelector('[data-leitstand-nav-links]');
+    const skipLink = document.querySelector('.leitstand-skip-link');
+    const mainAnchor = document.querySelector('#leitstand-content');
+    const active = document.querySelectorAll('[aria-current="page"]');
+    const navRect = nav?.getBoundingClientRect();
+    return {
+      elementsExist: Boolean(nav && toggle && links && skipLink && mainAnchor),
+      mobileMatches: window.matchMedia('(max-width: 960px)').matches,
+      ready: document.documentElement.classList.contains('leitstand-shell-ready'),
+      activeCount: active.length,
+      activeHref: active[0]?.getAttribute('href') ?? null,
+      expanded: toggle?.getAttribute('aria-expanded') ?? null,
+      toggleLabel: toggle?.getAttribute('aria-label') ?? null,
+      toggleDisplay: toggle ? getComputedStyle(toggle).display : null,
+      linksHidden: links?.hidden ?? null,
+      navExpanded: nav?.getAttribute('data-expanded') ?? null,
+      focusedToggle: document.activeElement === toggle,
+      focusedMain: document.activeElement === mainAnchor,
+      scrollWidth: document.documentElement.scrollWidth,
+      innerWidth: window.innerWidth,
+      navLeft: navRect?.left ?? null,
+      navRight: navRect?.right ?? null,
+      navPosition: nav ? getComputedStyle(nav).position : null,
+    };
+  });
+}
+
+function record(checks, name, pass, detail = '') {
+  checks.push({ name, pass: Boolean(pass), detail: String(detail) });
+}
+
+async function runViewport(browser, viewport, html) {
+  const context = await browser.newContext({
+    viewport: { width: viewport.width, height: viewport.height },
+    deviceScaleFactor: 1,
+  });
+  const page = await context.newPage();
+  const checks = [];
+
+  try {
+    await page.setContent(html, { waitUntil: 'load' });
+    await page.waitForFunction(() => document.documentElement.classList.contains('leitstand-shell-ready'));
+    await waitFrames(page);
+
+    let state = await readState(page);
+    record(checks, 'shell elements exist', state.elementsExist);
+    record(checks, 'viewport mode matches', state.mobileMatches === viewport.mobile, `${state.innerWidth}`);
+    record(checks, 'one active route', state.activeCount === 1, state.activeCount);
+    record(checks, 'intent maps to observatory', state.activeHref === '/observatory', state.activeHref);
+    record(checks, 'shell ready class', state.ready);
+    record(checks, 'initial expansion false', state.expanded === 'false', state.expanded);
+    record(checks, 'initial link visibility', state.linksHidden === viewport.mobile, state.linksHidden);
+    record(checks, 'toggle visibility', (state.toggleDisplay !== 'none') === viewport.mobile, state.toggleDisplay);
+    record(checks, 'no document overflow', state.scrollWidth <= state.innerWidth + 1, `${state.scrollWidth}/${state.innerWidth}`);
+    record(checks, 'nav inside viewport', state.navLeft !== null && state.navRight !== null && state.navLeft >= -1 && state.navRight <= state.innerWidth + 1, `${state.navLeft}/${state.navRight}`);
+    record(checks, 'sticky shell', state.navPosition === 'sticky', state.navPosition);
+
+    if (viewport.mobile) {
+      await page.locator('[data-leitstand-nav-toggle]').click();
+      await waitFrames(page);
+      state = await readState(page);
+      record(checks, 'mobile opens', state.expanded === 'true' && state.linksHidden === false && state.navExpanded === 'true');
+      record(checks, 'open label is explicit', state.toggleLabel === 'Navigation schließen', state.toggleLabel);
+      record(checks, 'open menu has no overflow', state.scrollWidth <= state.innerWidth + 1, `${state.scrollWidth}/${state.innerWidth}`);
+
+      await page.keyboard.press('Escape');
+      await waitFrames(page);
+      state = await readState(page);
+      record(checks, 'escape closes', state.expanded === 'false' && state.linksHidden === true);
+      record(checks, 'escape restores focus', state.focusedToggle);
+
+      await page.locator('[data-leitstand-nav-toggle]').click();
+      await waitFrames(page);
+      await page.locator('#outside-target').click();
+      await waitFrames(page);
+      state = await readState(page);
+      record(checks, 'outside click closes', state.expanded === 'false' && state.linksHidden === true);
+
+      await page.evaluate(() => document.querySelector('.leitstand-skip-link')?.click());
+      await waitFrames(page);
+      state = await readState(page);
+      record(checks, 'skip link focuses target', state.focusedMain);
+
+      await page.locator('[data-leitstand-nav-toggle]').click();
+      await page.setViewportSize({ width: 1280, height: 900 });
+      await waitFrames(page);
+      state = await readState(page);
+      record(checks, 'desktop resize resets menu', state.expanded === 'false' && state.linksHidden === false && state.toggleDisplay === 'none');
+
+      await page.setViewportSize({ width: viewport.width, height: viewport.height });
+      await waitFrames(page);
+      state = await readState(page);
+      record(checks, 'mobile resize restores collapsed state', state.expanded === 'false' && state.linksHidden === true && state.toggleDisplay !== 'none');
+    } else {
+      await page.evaluate(() => document.querySelector('.leitstand-skip-link')?.click());
+      await waitFrames(page);
+      state = await readState(page);
+      record(checks, 'skip link focuses target', state.focusedMain);
+    }
+  } finally {
+    await context.close();
+  }
+
+  return { viewport: viewport.name, checks, ok: checks.every((check) => check.pass) };
+}
+
+async function main() {
+  const chrome = await findChrome();
+  const [navHtml, shellCss, shellScript] = await Promise.all([
+    ejs.renderFile(join(ROOT, 'src', 'views', '_nav.ejs'), { currentPath: '/intent/example' }),
+    readFile(join(ROOT, 'src', 'public', 'shell.css'), 'utf-8'),
+    readFile(join(ROOT, 'src', 'public', 'shell.mjs'), 'utf-8'),
+  ]);
+  const html = createHarness(navHtml, shellCss, shellScript);
+  const browser = await chromium.launch({
+    executablePath: chrome,
+    headless: true,
+    args: ['--no-sandbox', '--disable-dev-shm-usage', '--disable-background-networking'],
+  });
+
+  try {
+    const results = [];
+    for (const viewport of VIEWPORTS) results.push(await runViewport(browser, viewport, html));
+
+    const failures = results.flatMap((result) => result.checks
+      .filter((check) => !check.pass)
+      .map((check) => ({ viewport: result.viewport, ...check })));
+    for (const result of results) {
+      const passed = result.checks.filter((check) => check.pass).length;
+      console.log(`${result.viewport}: ${result.ok ? 'PASS' : 'FAIL'} (${passed}/${result.checks.length})`);
+    }
+    if (failures.length > 0) {
+      for (const failure of failures) console.error(`${failure.viewport}: ${failure.name}: ${failure.detail}`);
+      process.exitCode = 1;
+    }
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/src/views/anatomy.ejs
+++ b/src/views/anatomy.ejs
@@ -30,44 +30,6 @@
       width: 100vw;
     }
 
-    /* Navigation Bar */
-    nav {
-      position: fixed;
-      top: 0;
-      left: 0;
-      right: 0;
-      z-index: 100;
-      display: flex;
-      align-items: center;
-      gap: 4px;
-      padding: 10px 20px;
-      background: rgba(10, 14, 26, 0.92);
-      backdrop-filter: blur(20px);
-      -webkit-backdrop-filter: blur(20px);
-      border-bottom: 1px solid var(--border-glass);
-    }
-
-    nav a {
-      text-decoration: none;
-      color: var(--text-secondary);
-      font-size: 0.82em;
-      font-weight: 500;
-      padding: 6px 14px;
-      border-radius: 6px;
-      transition: all 0.2s ease;
-    }
-
-    nav a:hover { color: var(--text-primary); background: var(--bg-glass); }
-    nav a.active { color: var(--accent); background: rgba(59, 130, 246, 0.1); }
-
-    nav .title {
-      font-weight: 700;
-      font-size: 0.9em;
-      color: var(--text-primary);
-      margin-right: 16px;
-      letter-spacing: -0.01em;
-    }
-
     /* Graph Canvas */
     #graph-container {
       position: fixed;

--- a/src/views/bureau.ejs
+++ b/src/views/bureau.ejs
@@ -6,11 +6,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <style>
     body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0a0e1a; color: #f1f5f9; margin: 0; }
-    nav { position: sticky; top: 0; display: flex; flex-wrap: wrap; gap: 4px; padding: 10px 20px; background: rgba(10,14,26,.92); border-bottom: 1px solid rgba(255,255,255,.08); }
-    nav a { color: #94a3b8; text-decoration: none; padding: 6px 14px; border-radius: 6px; font-size: .82em; }
-    nav a.active, nav a:hover { color: #3b82f6; background: rgba(59,130,246,.1); }
-    nav a:focus-visible { outline: 2px solid #3b82f6; outline-offset: 2px; }
-    nav .title { color: #f1f5f9; font-weight: 700; margin-right: 16px; }
     main { max-width: 1180px; margin: 0 auto; padding: 42px 24px 80px; }
     .subtitle, .muted { color: #94a3b8; line-height: 1.55; }
     .notice, .meta-item, .card { background: rgba(17,24,39,.88); border: 1px solid rgba(255,255,255,.08); border-radius: 14px; padding: 20px 22px; margin-bottom: 18px; }

--- a/src/views/checkouts.ejs
+++ b/src/views/checkouts.ejs
@@ -6,11 +6,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <style>
     body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0a0e1a; color: #f1f5f9; margin: 0; }
-    nav { position: sticky; top: 0; display: flex; flex-wrap: wrap; gap: 4px; padding: 10px 20px; background: rgba(10,14,26,.92); border-bottom: 1px solid rgba(255,255,255,.08); }
-    nav a { color: #94a3b8; text-decoration: none; padding: 6px 14px; border-radius: 6px; font-size: .82em; }
-    nav a.active, nav a:hover { color: #3b82f6; background: rgba(59,130,246,.1); }
-    nav a:focus-visible { outline: 2px solid #3b82f6; outline-offset: 2px; }
-    nav .title { color: #f1f5f9; font-weight: 700; margin-right: 16px; }
     main { max-width: 1180px; margin: 0 auto; padding: 42px 24px 80px; }
     .subtitle, .muted { color: #94a3b8; line-height: 1.55; }
     .notice, .meta-item, .card { background: rgba(17,24,39,.88); border: 1px solid rgba(255,255,255,.08); border-radius: 14px; padding: 20px 22px; margin-bottom: 18px; }

--- a/src/views/ecosystem-map.ejs
+++ b/src/views/ecosystem-map.ejs
@@ -8,10 +8,6 @@
     body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0a0e1a; color: #f1f5f9; margin: 0; }
     a { color: #60a5fa; }
     code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
-    nav { position: sticky; top: 0; z-index: 10; display: flex; gap: 4px; padding: 10px 20px; overflow-x: auto; background: rgba(10, 14, 26, 0.96); border-bottom: 1px solid rgba(255,255,255,.08); }
-    nav a { color: #94a3b8; text-decoration: none; padding: 6px 14px; border-radius: 6px; font-size: .82em; white-space: nowrap; }
-    nav a.active, nav a:hover { color: #3b82f6; background: rgba(59,130,246,.1); }
-    nav .title { color: #f1f5f9; font-weight: 700; margin-right: 16px; padding: 6px 0; white-space: nowrap; }
     main { max-width: 1440px; margin: 0 auto; padding: 42px 24px 80px; }
     h1 { font-size: 1.9em; margin-bottom: 10px; }
     h2 { margin-top: 0; }

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -36,38 +36,6 @@
       min-height: 100vh;
     }
 
-    nav {
-      position: sticky;
-      top: 0;
-      z-index: 100;
-      display: flex;
-      align-items: center;
-      gap: 4px;
-      padding: 10px 20px;
-      overflow-x: auto;
-      scrollbar-width: thin;
-      background: rgba(10, 14, 26, 0.92);
-      backdrop-filter: blur(20px);
-      -webkit-backdrop-filter: blur(20px);
-      border-bottom: 1px solid var(--border-glass);
-    }
-
-    nav a {
-      flex: 0 0 auto;
-      text-decoration: none;
-      color: var(--text-secondary);
-      font-size: 0.82em;
-      font-weight: 500;
-      padding: 6px 14px;
-      border-radius: 6px;
-      transition: all 0.2s ease;
-    }
-
-    nav a:hover { color: var(--text-primary); background: var(--bg-glass); }
-    nav a:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
-    nav a.active { color: var(--accent); background: rgba(59, 130, 246, 0.1); }
-    nav .title { flex: 0 0 auto; font-weight: 700; font-size: 0.9em; color: var(--text-primary); margin-right: 16px; }
-
     .main {
       max-width: 1080px;
       margin: 0 auto;
@@ -395,7 +363,6 @@
     }
 
     @media (max-width: 640px) {
-      nav { padding-inline: 14px; }
       .main { padding: 28px 18px 64px; }
       .page-header h1 { font-size: 1.5em; }
       .situation { padding: 18px; }

--- a/src/views/insights.ejs
+++ b/src/views/insights.ejs
@@ -31,41 +31,6 @@
       min-height: 100vh;
     }
 
-    nav {
-      position: sticky;
-      top: 0;
-      z-index: 100;
-      display: flex;
-      align-items: center;
-      gap: 4px;
-      padding: 10px 20px;
-      background: rgba(10, 14, 26, 0.92);
-      backdrop-filter: blur(20px);
-      -webkit-backdrop-filter: blur(20px);
-      border-bottom: 1px solid var(--border-glass);
-    }
-
-    nav a {
-      text-decoration: none;
-      color: var(--text-secondary);
-      font-size: 0.82em;
-      font-weight: 500;
-      padding: 6px 14px;
-      border-radius: 6px;
-      transition: all 0.2s ease;
-    }
-
-    nav a:hover { color: var(--text-primary); background: var(--bg-glass); }
-    nav a.active { color: var(--accent); background: rgba(59, 130, 246, 0.1); }
-
-    nav .title {
-      font-weight: 700;
-      font-size: 0.9em;
-      color: var(--text-primary);
-      margin-right: 16px;
-      letter-spacing: -0.01em;
-    }
-
     .main {
       max-width: 860px;
       margin: 0 auto;

--- a/src/views/intent.ejs
+++ b/src/views/intent.ejs
@@ -4,9 +4,6 @@
   <title>Aktueller Intent - Leitstand</title>
   <style>
     body { font-family: sans-serif; padding: 20px; }
-    nav { margin-bottom: 20px; padding: 10px; background: #f0f0f0; }
-    nav a { margin-right: 15px; text-decoration: none; color: #333; font-weight: bold; }
-    nav a:hover { text-decoration: underline; }
     .card { border: 1px solid #ccc; padding: 20px; border-radius: 5px; max-width: 600px; }
     .meta { color: #666; font-size: 0.9em; margin-bottom: 20px; }
     ul { list-style-type: none; padding: 0; }

--- a/src/views/observatory.ejs
+++ b/src/views/observatory.ejs
@@ -40,32 +40,6 @@
       overflow-x: hidden;
     }
 
-    /* Navigation */
-    nav {
-      position: sticky;
-      top: 0;
-      z-index: 100;
-      backdrop-filter: blur(16px);
-      background-color: rgba(17, 24, 39, 0.5);
-      border-bottom: 1px solid var(--border-glass);
-      padding: 12px 20px;
-      margin-bottom: 30px;
-    }
-
-    nav a {
-      display: inline-block;
-      margin-right: 20px;
-      text-decoration: none;
-      color: var(--text-secondary);
-      font-weight: 500;
-      font-size: 0.95em;
-      transition: color 0.2s ease;
-    }
-
-    nav a:hover {
-      color: var(--accent);
-    }
-
     /* Main Container */
     .main-wrapper {
       max-width: 1080px;
@@ -450,14 +424,6 @@
         padding: 0 12px 30px 12px;
       }
 
-      nav {
-        padding: 10px 12px;
-      }
-
-      nav a {
-        margin-right: 12px;
-        font-size: 0.9em;
-      }
     }
   </style>
   <link rel="stylesheet" href="/assets/shell.css">

--- a/src/views/ops.ejs
+++ b/src/views/ops.ejs
@@ -37,43 +37,6 @@
       margin: 0;
     }
 
-    nav { 
-      position: sticky;
-      top: 0;
-      z-index: 100;
-      display: flex;
-      align-items: center;
-      gap: 4px;
-      padding: 10px 20px;
-      background: rgba(10, 14, 26, 0.92);
-      backdrop-filter: blur(20px);
-      -webkit-backdrop-filter: blur(20px);
-      border-bottom: 1px solid var(--border-glass);
-      margin-bottom: 0;
-    }
-
-    nav a { 
-      text-decoration: none;
-      color: var(--text-secondary);
-      font-size: 0.82em;
-      font-weight: 500;
-      padding: 6px 14px;
-      border-radius: 6px;
-      transition: all 0.2s ease;
-      margin-right: 0;
-    }
-
-    nav a:hover { 
-      color: var(--text-primary); 
-      background: var(--bg-glass); 
-      text-decoration: none;
-    }
-
-    nav a.active { 
-      color: var(--accent); 
-      background: rgba(59, 130, 246, 0.1); 
-    }
-
     .main-wrapper {
       max-width: 1080px;
       margin: 0 auto;

--- a/src/views/reflexion.ejs
+++ b/src/views/reflexion.ejs
@@ -31,41 +31,6 @@
       min-height: 100vh;
     }
 
-    nav {
-      position: sticky;
-      top: 0;
-      z-index: 100;
-      display: flex;
-      align-items: center;
-      gap: 4px;
-      padding: 10px 20px;
-      background: rgba(10, 14, 26, 0.92);
-      backdrop-filter: blur(20px);
-      -webkit-backdrop-filter: blur(20px);
-      border-bottom: 1px solid var(--border-glass);
-    }
-
-    nav a {
-      text-decoration: none;
-      color: var(--text-secondary);
-      font-size: 0.82em;
-      font-weight: 500;
-      padding: 6px 14px;
-      border-radius: 6px;
-      transition: all 0.2s ease;
-    }
-
-    nav a:hover { color: var(--text-primary); background: var(--bg-glass); }
-    nav a.active { color: var(--accent); background: rgba(139, 92, 246, 0.1); }
-
-    nav .title {
-      font-weight: 700;
-      font-size: 0.9em;
-      color: var(--text-primary);
-      margin-right: 16px;
-      letter-spacing: -0.01em;
-    }
-
     .main {
       max-width: 960px;
       margin: 0 auto;

--- a/src/views/repobriefs.ejs
+++ b/src/views/repobriefs.ejs
@@ -6,10 +6,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <style>
     body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0a0e1a; color: #f1f5f9; margin: 0; }
-    nav { position: sticky; top: 0; display: flex; gap: 4px; padding: 10px 20px; background: rgba(10,14,26,.92); border-bottom: 1px solid rgba(255,255,255,.08); }
-    nav a { color: #94a3b8; text-decoration: none; padding: 6px 14px; border-radius: 6px; font-size: .82em; }
-    nav a.active, nav a:hover { color: #3b82f6; background: rgba(59,130,246,.1); }
-    nav .title { color: #f1f5f9; font-weight: 700; margin-right: 16px; }
     main { max-width: 1180px; margin: 0 auto; padding: 42px 24px 80px; }
     .subtitle, .muted, li { color: #94a3b8; line-height: 1.55; }
     .notice, .card, .meta-item { background: rgba(17,24,39,.88); border: 1px solid rgba(255,255,255,.08); border-radius: 14px; padding: 20px 22px; margin-bottom: 18px; }

--- a/src/views/timeline.ejs
+++ b/src/views/timeline.ejs
@@ -28,34 +28,6 @@
       min-height: 100vh;
     }
 
-    /* Navigation */
-    nav {
-      position: sticky;
-      top: 0;
-      z-index: 100;
-      display: flex;
-      align-items: center;
-      gap: 4px;
-      padding: 10px 20px;
-      background: rgba(10, 14, 26, 0.92);
-      backdrop-filter: blur(20px);
-      border-bottom: 1px solid var(--border-glass);
-    }
-
-    nav a {
-      text-decoration: none;
-      color: var(--text-secondary);
-      font-size: 0.82em;
-      font-weight: 500;
-      padding: 6px 14px;
-      border-radius: 6px;
-      transition: all 0.2s ease;
-    }
-
-    nav a:hover { color: var(--text-primary); background: var(--bg-glass); }
-    nav a.active { color: var(--accent); background: rgba(59, 130, 246, 0.1); }
-    nav .title { font-weight: 700; font-size: 0.9em; color: var(--text-primary); margin-right: 16px; }
-
     /* Main Layout */
     .main {
       max-width: 960px;

--- a/tests/views/navigation.test.ts
+++ b/tests/views/navigation.test.ts
@@ -39,13 +39,18 @@ function readView(file: string): string {
   return readFileSync(join(viewsRoot, file), 'utf-8');
 }
 
+function inlineStyles(view: string): string {
+  return [...view.matchAll(/<style>([\s\S]*?)<\/style>/g)].map((match) => match[1]).join('\n');
+}
+
 describe('canonical navigation parity', () => {
-  it.each(navViews)('%s consumes the shared shell without a private nav copy', (file) => {
+  it.each(navViews)('%s consumes only the shared shell navigation', (file) => {
     const view = readView(file);
     expect(view).toContain("<%- include('_nav') %>");
     expect(view).toContain('href="/assets/shell.css"');
     expect(view).toContain('src="/assets/shell.mjs"');
     expect(view).not.toContain('<nav aria-label="Hauptnavigation">');
+    expect(inlineStyles(view)).not.toMatch(/(^|\n)\s*nav(?:\s|[.#:[>+~])/m);
   });
 
   it('the shared partial exposes the canonical read-only route set', () => {
@@ -84,6 +89,24 @@ describe('canonical navigation parity', () => {
     expect(css).toContain('prefers-reduced-motion');
     expect(script).toContain("event.key === 'Escape'");
     expect(script).toContain("window.matchMedia('(max-width: 960px)')");
+  });
+
+  it('binds the real browser shell regression into CI', () => {
+    const packageJson = JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf-8')) as {
+      scripts?: Record<string, string>;
+    };
+    const browserRegression = readFileSync(join(process.cwd(), 'scripts', 'browser-shell-regression.mjs'), 'utf-8');
+    const ci = readFileSync(join(process.cwd(), '.github', 'workflows', 'ci.yml'), 'utf-8');
+
+    expect(packageJson.scripts?.['test:browser-shell']).toBe('node scripts/browser-shell-regression.mjs');
+    expect(browserRegression).toContain("from 'playwright-core'");
+    expect(browserRegression).toContain("{ name: 'mobile', width: 390");
+    expect(browserRegression).toContain("{ name: 'desktop', width: 1280");
+    expect(browserRegression).toContain("record(checks, 'escape restores focus'");
+    expect(browserRegression).toContain("record(checks, 'no document overflow'");
+    expect(browserRegression).toContain("record(checks, 'desktop resize resets menu'");
+    expect(ci).toContain('name: Browser shell regression');
+    expect(ci).toContain('run: pnpm run test:browser-shell');
   });
 
   it('copies the shared shell into the supported static mirror', () => {


### PR DESCRIPTION
## Ziel
Die gemeinsame Leitstand-Shell als einzige Navigationsdarstellung absichern und reale responsive Interaktionen in CI prüfen.

## Änderungen
- 57 tote, private `nav`-CSS-Regeln aus zwölf EJS-Views entfernt
- Quellvertrag verhindert neue private Navigationsregeln in Views
- echter Headless-Chrome-Test über `playwright-core`
- Mobile: Öffnen, Escape, Fokus-Rückgabe, Außenklick, Skip-Link, Overflow und Viewportwechsel
- Desktop: aktiver Pfad, Sichtbarkeit, Skip-Link, Sticky-Verhalten und Overflow
- Browservertrag in CI aufgenommen

## Prüfung
- `pnpm install --frozen-lockfile`
- `node --check scripts/browser-shell-regression.mjs`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`: 44 Dateien / 363 Tests
- `pnpm test:browser-shell`: mobile 20/20, desktop 12/12
- `pnpm build`
- `pnpm build:static`
- statischer Readback: echte Navigation, genau ein aktiver Pfad, Shell-Assets vorhanden, kein `[object Promise]`
- `git diff --check`

## Grenzen
Keine Änderung an Produktlogik, Datenquellen, Zustandswahrheit oder externen Mutationen. `playwright-core` ist ausschließlich Entwicklungs-/CI-Abhängigkeit und nutzt einen vorhandenen Chrome/Chromium-Browser.