### PR TITLE
docs: source system roles from Systemkatalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,18 +29,12 @@ Leitstand ist ausdrücklich **nicht**:
 Alle Änderungen im Repo müssen dieser Invariante entsprechen.
 Lokale Artefaktschreibvorgänge (Caches, Digests, Build-Outputs) sind zulässig, solange sie der reinen Darstellungs- und Observer-Pipeline dienen.
 
-### The Heimgewebe Organism
+### Heimgewebe system landscape
 
-The heimgewebe organization consists of several interconnected repositories and organs:
-- **Bureau**: Task registry, claims and queue truth.
-- **Grabowski**: Local execution, worktrees, receipts and operator-side tooling.
-- **Plexer**: Bounded operational event transport.
-- **Chronik**: Event history and audit/event store.
-- **WGX**: Fleet CLI and metrics snapshot generator.
-- **semantAH**: Semantic index and daily insights.
-- **Heimlern**: Learning/proposal reports from operational friction.
-- **metarepo**: Shared contracts, documentation and reusable CI.
-- **Leitstand**: This repository — read-only dashboard, digest and operator-observation view surface.
+Current system purposes, lifecycle states, and relationships are maintained in the
+[Systemkatalog](https://github.com/heimgewebe/systemkatalog). Leitstand consumes the
+[rendered system catalog](https://github.com/heimgewebe/systemkatalog/blob/main/rendered/system-catalog.md)
+as a read-only source and does not maintain a competing system-role inventory. Repository-local observer invariants remain defined here.
 
 ## Security & Public Usage
 
@@ -249,7 +243,7 @@ The underlying JSON schemas are documented in the **metarepo**:
 - `contracts/event.line.schema.json`
 - `audit.git.v1` – Currently implemented in acs and mirrored in leitstand types; a metarepo contract is planned.
 
-A curated index of all contracts can be found in `metarepo/docs/contracts-index.md`.
+A curated index of shared contracts is maintained in [`metarepo/docs/contracts/contracts-index.md`](https://github.com/heimgewebe/metarepo/blob/main/docs/contracts/contracts-index.md).
 
 **Note:** New Leitstand features (like the Ops Viewer) fit into this model: they visualize data (artifacts) without violating the authority of generation or mutation (WGX/ACS).
 
@@ -344,13 +338,8 @@ This is the initial iteration focused on generating daily digests and operationa
 ## License
 MIT
 
-## Organism Context
+## System context
 
-This repository is part of the **Heimgewebe Organism**.
-
-The overarching architecture, axes, roles, and contracts are centrally described in:
-👉 [`metarepo/docs/system/heimgewebe-organismus.md`](https://github.com/heimgewebe/metarepo/blob/main/docs/heimgewebe-organismus.md)
-and the target vision:
-👉 [`metarepo/docs/heimgewebe-zielbild.md`](https://github.com/heimgewebe/metarepo/blob/main/docs/heimgewebe-zielbild.md).
-
-All role definitions, data flows, and contract assignments for this repo are anchored there.
+Current cross-system purposes, lifecycle states, and relationships are maintained in the
+[Systemkatalog](https://github.com/heimgewebe/systemkatalog). Leitstand remains a read-only observer; its local implementation and
+observer boundary are defined in this repository.

--- a/docs/architecture/non-goals.md
+++ b/docs/architecture/non-goals.md
@@ -10,7 +10,7 @@ summary: >
 
 # Explizite Nicht-Ziele (Non-Goals)
 
-Um Leitstand stabil als **Observer** im Heimgewebe-Organismus zu verankern, wird definiert, was das System *nicht* tun wird. 
+Um Leitstand stabil als **Observer** im Heimgewebe-Systemverbund zu verankern, wird definiert, was das System *nicht* tun wird.
 
 Leitstand wird nicht:
 * **mutierende oder orchestrierende Commands ausführen:** Leitstand führt keine Kommandos aus, die den Zustand anderer Repositories oder externer Systemdienste verändern oder steuern. Lokale read-orientierte Hilfsskripte (z. B. Fetch-Skripte für Datenabruf) sind davon ausgenommen, solange sie keinen schreibenden Einfluss auf externe Systeme haben.

--- a/docs/blueprints/leitstand_visualization.md
+++ b/docs/blueprints/leitstand_visualization.md
@@ -2,13 +2,17 @@
 id: docs.blueprints.leitstand_visualization
 title: Blaupause: Visualisierung des Heimgewebes im Leitstand
 doc_type: architecture
-status: active
-canonicality: canonical
+status: historical
+canonicality: non-normative
 summary: >
   Blaupause: Visualisierung des Heimgewebes im Leitstand
 ---
 
 # Blaupause: Visualisierung des Heimgewebes im Leitstand
+
+> **Historischer Konzeptstand:** Diese Blaupause dokumentiert die frühere Organismusmetapher
+> und ist keine aktuelle System-, Rollen- oder Quellenwahrheit. Aktuelle Systemzwecke und
+> Beziehungen werden im [Systemkatalog](https://github.com/heimgewebe/systemkatalog) geführt.
 
 ## Abhakbare Umsetzungsroadmap
 

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -9,7 +9,7 @@
   <title>Leitstand</title>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Leitstand – Beobachtungs- und Verdichtungsmodul des Heimgewebe-Organismus.">
+  <meta name="description" content="Leitstand – Beobachtungs- und Verdichtungsmodul der Heimgewebe-Systeme.">
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
@@ -337,25 +337,6 @@
     .info-card a { color: #93c5fd; }
     .info-card a:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
-    .info-card .role-list {
-      list-style: none;
-      padding: 0;
-      margin-top: 12px;
-      display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-      gap: 8px;
-      font-size: 0.82em;
-      color: var(--text-secondary);
-    }
-
-    .info-card .role-list li {
-      padding: 6px 10px;
-      background: var(--bg-glass);
-      border: 1px solid var(--border-glass);
-      border-radius: 8px;
-    }
-
-    .info-card .role-list strong { color: var(--text-primary); font-weight: 600; }
 
     @media (max-width: 860px) {
       .surface-grid { grid-template-columns: 1fr; }
@@ -395,7 +376,7 @@
     <header class="page-header">
       <h1>Leitstand</h1>
       <p class="subtitle">
-        Beobachtungs- und Verdichtungsmodul des Heimgewebe-Organismus.
+        Beobachtungs- und Verdichtungsmodul der Heimgewebe-Systeme.
         Strikter Observer: visualisiert Zustände, ohne externe Systeme zu mutieren.
       </p>
     </header>
@@ -534,17 +515,13 @@
     <section class="info-card" aria-labelledby="rolle-heading">
       <h2 id="rolle-heading">Rolle des Leitstands</h2>
       <p>
-        Der Leitstand beobachtet, verdichtet und visualisiert den Zustand des Heimgewebe-Organismus.
+        Der Leitstand beobachtet, verdichtet und visualisiert belegte Zustände der Heimgewebe-Systeme.
         Er ist ausdrücklich kein Orchestrator, keine Steuerinstanz und schreibt nicht in externe Systeme.
       </p>
-      <ul class="role-list">
-        <li><strong>chronik</strong> – Event-Log</li>
-        <li><strong>semantAH</strong> – Semantik &amp; Insights</li>
-        <li><strong>wgx</strong> – Fleet-Metriken</li>
-        <li><strong>heimgeist</strong> – Reflexion</li>
-        <li><strong>hauski</strong> – Entscheidungen</li>
-        <li><strong>metarepo</strong> – Contracts &amp; Governance</li>
-      </ul>
+      <p>
+        Systemrollen und Beziehungen stammen aus dem Systemkatalog.
+        <a href="/ecosystem-map">Systemkarte öffnen</a>.
+      </p>
     </section>
   </main>
 </body>

--- a/src/views/timeline.ejs
+++ b/src/views/timeline.ejs
@@ -350,7 +350,7 @@
   <div class="main">
     <div class="page-header">
       <h1>Zeitachse</h1>
-      <p class="subtitle">Chronologische Ereignisse des Heimgewebe-Organismus</p>
+      <p class="subtitle">Chronologische Ereignisse der Heimgewebe-Systeme</p>
     </div>
 
     <!-- Window/Replay Controls — always visible (operator can adjust window even when empty) -->


### PR DESCRIPTION
## Zweck

Leitstand soll Systemzustände beobachten, aber keine zweite statische Rollen- und Architekturwahrheit führen.

## Änderung

- README auf Systemkatalog als Primärquelle umgestellt
- statische Rollenliste aus der Laufzeitoberfläche entfernt
- Laufzeittexte auf Observer-Funktion begrenzt
- alte Visualisierungsblaupause auf `historical` und `non-normative` gesetzt
- veralteten Metarepo-Contractindex-Link korrigiert

## Prüfung

- Lint, Typecheck und Build grün
- 364 Tests bestanden
- Browser-Shell 32/32 bestanden
- Repository-, Dokument-, Drift- und Observer-Gates bestanden
- T006-Drift-, Ziel- und Whitespace-Gate bestanden

Bureau: `METAREPO-LEGACY-RECONCILIATION-V1-T006`