### PR TITLE
Leitstand-Systemkarte als Vollbild-Arbeitsfläche öffnen

### DIFF
--- a/scripts/browser-shell-regression.mjs
+++ b/scripts/browser-shell-regression.mjs
@@ -41,7 +41,6 @@ function createHarness(navHtml, shellCss, shellScript) {
   <title>Leitstand shell regression</title>
   <style>${shellCss}</style>
   <style>
-    *, *::before, *::after { box-sizing: border-box; }
     body { margin: 0; min-height: 100vh; background: #0a0e1a; color: #f1f5f9; font-family: sans-serif; }
     main { min-width: 0; padding: 24px; }
   </style>
@@ -87,6 +86,7 @@ async function readState(page) {
       navLeft: navRect?.left ?? null,
       navRight: navRect?.right ?? null,
       navPosition: nav ? getComputedStyle(nav).position : null,
+      navBoxSizing: nav ? getComputedStyle(nav).boxSizing : null,
     };
   });
 }
@@ -120,6 +120,7 @@ async function runViewport(browser, viewport, html) {
     record(checks, 'no document overflow', state.scrollWidth <= state.innerWidth + 1, `${state.scrollWidth}/${state.innerWidth}`);
     record(checks, 'nav inside viewport', state.navLeft !== null && state.navRight !== null && state.navLeft >= -1 && state.navRight <= state.innerWidth + 1, `${state.navLeft}/${state.navRight}`);
     record(checks, 'sticky shell', state.navPosition === 'sticky', state.navPosition);
+    record(checks, 'shell owns border-box sizing', state.navBoxSizing === 'border-box', state.navBoxSizing);
 
     if (viewport.mobile) {
       await page.locator('[data-leitstand-nav-toggle]').click();

--- a/src/public/ecosystem-map.mjs
+++ b/src/public/ecosystem-map.mjs
@@ -61,7 +61,7 @@ function installExplorerStyles() {
   const style = document.createElement('style');
   style.dataset.ecosystemExplorerStyles = '';
   style.textContent = `
-    .map-explorer { display:grid; gap:14px; margin:0 0 16px; padding:16px; border:1px solid rgba(255,255,255,.09); border-radius:12px; background:rgba(2,6,23,.55); }
+    .map-explorer { display:grid; align-content:start; gap:14px; margin:0; padding:16px; max-height:620px; overflow:auto; border:1px solid rgba(255,255,255,.09); border-radius:12px; background:rgba(2,6,23,.55); }
     .map-explorer-row { display:flex; flex-wrap:wrap; gap:10px; align-items:center; }
     .map-search { flex:1 1 280px; min-width:0; padding:10px 12px; border-radius:9px; border:1px solid rgba(255,255,255,.16); background:#0f172a; color:#f8fafc; font:inherit; }
     .map-search:focus, .map-filter:focus, .map-control:focus, .map-result-button:focus, .map-relation-button:focus, .map-detail button:focus, .map-detail a:focus { outline:2px solid #60a5fa; outline-offset:2px; }
@@ -89,7 +89,9 @@ function installExplorerStyles() {
     .map-detail-actions a, .map-detail-actions button { border:1px solid rgba(255,255,255,.16); border-radius:8px; padding:8px 12px; font:inherit; text-decoration:none; cursor:pointer; }
     .map-detail-actions a { color:#dbeafe; background:rgba(59,130,246,.2); }
     .map-detail-actions button { color:#cbd5e1; background:#111827; }
-    .map-canvas { touch-action:none; cursor:grab; }
+    .map-workspace.is-map-fullscreen .map-explorer { max-height:none; height:100%; min-height:0; }
+    .map-workspace.is-map-fullscreen .map-results { max-height:min(32vh, 320px); }
+    .map-canvas { touch-action:none; cursor:grab; min-width:0; }
     .map-canvas.is-panning { cursor:grabbing; user-select:none; }
     .map-canvas svg { min-width:100%; }
     .map-canvas g.node { transition:opacity .15s ease, filter .15s ease; }
@@ -101,8 +103,12 @@ function installExplorerStyles() {
     .map-canvas [data-edge="true"].is-outgoing { stroke:#60a5fa !important; stroke-width:3px !important; opacity:1; }
     .map-canvas [data-edge="true"].is-incoming { stroke:#fbbf24 !important; stroke-width:3px !important; stroke-dasharray:7 4; opacity:1; }
     .map-canvas g.edgeLabel.is-outgoing, .map-canvas g.edgeLabel.is-incoming { opacity:1; font-weight:700; }
+    @media (max-width:1100px) {
+      .map-explorer { max-height:none; }
+    }
     @media (max-width:720px) {
       .map-explorer { padding:12px; }
+      .map-workspace.is-map-fullscreen .map-explorer { height:auto; max-height:44vh; }
       .map-filter, .map-control { padding:10px 13px; }
       .map-relations { grid-template-columns:1fr; }
       .map-results { max-height:220px; }
@@ -145,7 +151,8 @@ function createExplorer(canvas, navigation) {
       </div>
     </aside>
   `;
-  canvas.before(explorer);
+  const workspaceContent = canvas.closest('[data-map-workspace-content]');
+  (workspaceContent || canvas.parentElement).prepend(explorer);
 
   const types = [...new Set(navigation.map((item) => nodeType(item.node_id)))].filter((type) => TYPE_LABELS[type]);
   const filters = explorer.querySelector('[data-map-filters]');
@@ -159,6 +166,137 @@ function createExplorer(canvas, navigation) {
     filters.append(button);
   }
   return explorer;
+}
+
+function createFullscreenController(workspace, toggleButton, closeButton) {
+  if (!workspace || !toggleButton || !closeButton) return null;
+
+  let fallbackActive = false;
+  let previousFocus = null;
+
+  function nativeActive() {
+    return document.fullscreenElement === workspace;
+  }
+
+  function active() {
+    return fallbackActive || nativeActive();
+  }
+
+  function focusableElements() {
+    return [...workspace.querySelectorAll(
+      'button:not([disabled]):not([hidden]), a[href], input:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    )].filter((element) => element.getClientRects().length > 0);
+  }
+
+  function applyState(nextActive, { restoreFocus = false } = {}) {
+    workspace.classList.toggle('is-map-fullscreen', nextActive);
+    document.body.classList.toggle('map-fullscreen-open', nextActive);
+    toggleButton.setAttribute('aria-pressed', nextActive ? 'true' : 'false');
+    toggleButton.textContent = nextActive ? 'Vollbild schließen' : 'Vollbild öffnen';
+    closeButton.hidden = !nextActive;
+
+    if (nextActive) {
+      workspace.setAttribute('role', 'dialog');
+      workspace.setAttribute('aria-modal', 'true');
+      workspace.setAttribute('aria-label', 'Ökosystemkarte im Vollbild');
+      window.requestAnimationFrame(() => {
+        if (active()) closeButton.focus({ preventScroll: true });
+      });
+    } else {
+      workspace.removeAttribute('role');
+      workspace.removeAttribute('aria-modal');
+      workspace.removeAttribute('aria-label');
+      if (restoreFocus && previousFocus?.focus) {
+        window.requestAnimationFrame(() => previousFocus.focus({ preventScroll: true }));
+      }
+    }
+    window.dispatchEvent(new Event('resize'));
+  }
+
+  async function enter() {
+    if (active()) return;
+    previousFocus = document.activeElement;
+    if (typeof workspace.requestFullscreen === 'function') {
+      try {
+        await workspace.requestFullscreen();
+        return;
+      } catch {
+        // iPadOS and restricted browsers may reject element fullscreen. Use the viewport overlay.
+      }
+    }
+    fallbackActive = true;
+    applyState(true);
+  }
+
+  async function exit() {
+    if (!active()) return;
+    if (nativeActive() && typeof document.exitFullscreen === 'function') {
+      await document.exitFullscreen();
+      return;
+    }
+    fallbackActive = false;
+    applyState(false, { restoreFocus: true });
+  }
+
+  async function toggle() {
+    if (active()) await exit();
+    else await enter();
+  }
+
+  toggleButton.addEventListener('click', () => void toggle());
+  closeButton.addEventListener('click', () => void exit());
+  document.addEventListener('fullscreenchange', () => {
+    if (nativeActive()) {
+      fallbackActive = false;
+      applyState(true);
+    } else if (!fallbackActive) {
+      applyState(false, { restoreFocus: true });
+    }
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && active()) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      void exit();
+      return;
+    }
+
+    const target = event.target;
+    let currentTarget = target instanceof Element ? target : null;
+    let isTyping = false;
+    while (currentTarget) {
+      if (currentTarget.matches('input, textarea, select') || currentTarget.isContentEditable) {
+        isTyping = true;
+        break;
+      }
+      currentTarget = currentTarget.parentElement;
+    }
+    if (event.key.toLocaleLowerCase('de') === 'f' && !event.ctrlKey && !event.metaKey && !event.altKey && !isTyping) {
+      event.preventDefault();
+      void toggle();
+      return;
+    }
+
+    if (event.key !== 'Tab' || !active()) return;
+    const focusable = focusableElements();
+    if (focusable.length === 0) {
+      event.preventDefault();
+      workspace.focus({ preventScroll: true });
+      return;
+    }
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus({ preventScroll: true });
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus({ preventScroll: true });
+    }
+  }, true);
+
+  return { active, enter, exit, toggle };
 }
 
 function edgeIdentity(element) {
@@ -730,8 +868,12 @@ async function renderEcosystemMap() {
   const navigationData = document.querySelector('[data-ecosystem-map-navigation]');
   const status = document.querySelector('[data-ecosystem-map-render-status]');
   const sourceDetails = document.querySelector('[data-ecosystem-map-source-details]');
+  const workspace = document.querySelector('[data-ecosystem-map-workspace]');
+  const fullscreenToggle = document.querySelector('[data-map-fullscreen-toggle]');
+  const fullscreenClose = document.querySelector('[data-map-fullscreen-close]');
   if (!canvas || !source || !navigationData || !status) return;
 
+  createFullscreenController(workspace, fullscreenToggle, fullscreenClose);
   const navigation = JSON.parse(navigationData.textContent || '[]');
   const definition = source.textContent || '';
   if (!definition.trim()) {

--- a/src/public/shell.css
+++ b/src/public/shell.css
@@ -1,3 +1,9 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
 .leitstand-skip-link {
   position: fixed;
   top: 8px;

--- a/src/views/ecosystem-map.ejs
+++ b/src/views/ecosystem-map.ejs
@@ -6,12 +6,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <style>
     body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0a0e1a; color: #f1f5f9; margin: 0; }
+    body.map-fullscreen-open { overflow: hidden; }
     a { color: #60a5fa; }
     code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
-    main { max-width: 1440px; margin: 0 auto; padding: 42px 24px 80px; }
+    main { max-width: 1600px; margin: 0 auto; padding: 42px 24px 80px; }
+    .page-header { margin-bottom: 20px; }
+    .page-header h1 { margin-top: 0; }
     h1 { font-size: 1.9em; margin-bottom: 10px; }
     h2 { margin-top: 0; }
     .subtitle, .empty, .artifact-meta, li, summary { color: #94a3b8; line-height: 1.55; }
+    .artifact-meta { min-width: 0; overflow-wrap: anywhere; }
     .notice, .panel, .meta-item, .truth-banner { background: rgba(17,24,39,.88); border: 1px solid rgba(255,255,255,.08); border-radius: 14px; padding: 20px 22px; margin-bottom: 18px; }
     .notice strong { color: #3b82f6; }
     .truth-banner { border-left-width: 5px; }
@@ -29,12 +33,32 @@
     .value[data-state="compatible"] { color: #93c5fd; }
     .value[data-state="stale"], .value[data-state="drifted"] { color: #fca5a5; }
     .value[data-state="unknown"], .value[data-state="unverifiable"] { color: #fde68a; }
-    .map-header { display: flex; flex-wrap: wrap; align-items: baseline; justify-content: space-between; gap: 10px 18px; margin-bottom: 14px; }
+    .map-header { display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: 12px 18px; margin-bottom: 14px; }
+    .map-header-copy { display: grid; gap: 6px; }
+    .map-header-copy h2 { margin: 0; }
+    .map-header-actions { display: flex; flex-wrap: wrap; gap: 10px; }
+    .map-action { border: 1px solid rgba(96,165,250,.55); border-radius: 9px; background: rgba(59,130,246,.18); color: #dbeafe; padding: 9px 13px; font: inherit; cursor: pointer; }
+    .map-action:hover { background: rgba(59,130,246,.28); }
+    .map-action:focus { outline: 2px solid #60a5fa; outline-offset: 2px; }
+    .map-workspace { position: relative; }
+    .map-workspace-toolbar { display: none; align-items: center; justify-content: space-between; gap: 16px; padding: 0 2px; }
+    .map-workspace-title { font-weight: 700; }
+    .map-workspace-content { display: grid; grid-template-columns: minmax(280px, 340px) minmax(0, 1fr); gap: 14px; align-items: start; min-width: 0; }
+    .map-workspace.is-map-fullscreen { position: fixed; inset: 0; z-index: 1000; display: grid; grid-template-rows: auto minmax(0, 1fr); gap: 12px; padding: 14px; background: #060a13; }
+    .map-workspace.is-map-fullscreen .map-workspace-toolbar { display: flex; }
+    .map-workspace.is-map-fullscreen .map-workspace-content { min-height: 0; height: 100%; align-items: stretch; }
+    .map-workspace.is-map-fullscreen .map-canvas { min-height: 0; height: 100%; overflow: hidden; }
+    .map-workspace.is-map-fullscreen .map-canvas svg { width: 100%; height: 100%; min-width: 0; max-height: none; }
+    .source-details { padding: 0; overflow: hidden; }
+    .source-details > summary { padding: 18px 22px; font-weight: 700; color: #dbeafe; }
+    .source-details > summary:hover { background: rgba(255,255,255,.025); }
+    .source-details-content { padding: 0 22px 22px; }
+    .source-details .notice { margin-top: 0; }
     .render-status { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .78em; color: #94a3b8; }
     .render-status[data-state="ready"] { color: #86efac; }
     .render-status[data-state="warning"] { color: #fde68a; }
     .render-status[data-state="error"] { color: #fca5a5; }
-    .map-canvas { min-height: 420px; overflow: auto; padding: 18px; background: rgba(2,6,23,.72); border: 1px solid rgba(255,255,255,.08); border-radius: 12px; }
+    .map-canvas { min-height: 620px; overflow: hidden; padding: 18px; background: rgba(2,6,23,.72); border: 1px solid rgba(255,255,255,.08); border-radius: 12px; }
     .map-canvas[data-render-state="loading"] { display: grid; place-items: center; color: #64748b; }
     .map-canvas svg { display: block; min-width: 980px; width: 100%; height: auto; margin: 0 auto; }
     .map-canvas g.node.navigable-node { cursor: pointer; }
@@ -47,10 +71,21 @@
     summary { cursor: pointer; }
     pre { background: rgba(2,6,23,.72); color: #dbeafe; border: 1px solid rgba(255,255,255,.08); border-radius: 10px; padding: 16px; overflow: auto; font-size: .78em; line-height: 1.45; max-height: 520px; }
     .link-note { margin: 0 0 14px; color: #94a3b8; line-height: 1.5; }
+    @media (max-width: 1100px) {
+      .map-workspace-content { grid-template-columns: 1fr; }
+      .map-canvas { min-height: 520px; }
+    }
     @media (max-width: 720px) {
       main { padding: 28px 14px 60px; }
       .notice, .panel, .meta-item, .truth-banner { padding: 16px; }
-      .map-canvas { padding: 10px; min-height: 360px; }
+      .map-header-actions, .map-action { width: 100%; }
+      .map-action { min-height: 44px; }
+      .map-workspace.is-map-fullscreen { padding: 10px; }
+      .map-workspace.is-map-fullscreen .map-workspace-content { grid-template-rows: minmax(0, auto) minmax(260px, 1fr); overflow: auto; }
+      .source-details { padding: 0; }
+      .source-details > summary { padding: 16px; }
+      .source-details-content { padding: 0 16px 16px; }
+      .map-canvas { padding: 10px; min-height: 420px; }
     }
   </style>
   <link rel="stylesheet" href="/assets/shell.css">
@@ -60,12 +95,10 @@
   <%- include('_nav') %>
 
   <main>
-    <h1>Ökosystemkarte</h1>
-    <p class="subtitle">Grafische, ausschließlich lesende Projektion der vom Systemkatalog verantworteten Ökosystemsemantik.</p>
-
-    <section class="notice" aria-label="Zuständigkeitsgrenze">
-      <strong>Nur Ansicht.</strong> Der Systemkatalog besitzt Systeme, Beziehungen und Bedeutungen. Leitstand rendert das geprüfte, commit- und hashgebundene Artefakt als SVG. Er bearbeitet die Karte nicht, leitet keine neue Wahrheit ab und löst keine Aufgaben oder Änderungen aus.
-    </section>
+    <header class="page-header">
+      <h1>Ökosystemkarte</h1>
+      <p class="subtitle">Grafische, ausschließlich lesende Projektion der vom Systemkatalog verantworteten Ökosystemsemantik.</p>
+    </header>
 
     <section class="truth-banner" data-state="<%= view_meta.alignment_state %>" aria-label="Inhaltlicher Quellenabgleich">
       <% if (view_meta.alignment_state === 'exact') { %>
@@ -83,45 +116,33 @@
       <% } %>
     </section>
 
-    <section class="meta-grid" aria-label="Quellenmetadaten">
-      <div class="meta-item"><div class="label">Gesamtstatus</div><div class="value" data-state="<%= view_meta.freshness_state %>"><%= view_meta.freshness_state %> · <%= view_meta.freshness_reason %></div></div>
-      <div class="meta-item"><div class="label">Inhaltsabgleich</div><div class="value" data-state="<%= view_meta.alignment_state %>"><%= view_meta.alignment_state %> · <%= view_meta.verified_artifact_count %>/5 Artefakte</div></div>
-      <div class="meta-item"><div class="label">Quellzustand</div><div class="value"><%= view_meta.source_kind %> / <%= view_meta.missing_reason %></div></div>
-      <div class="meta-item"><div class="label">Alter</div><div class="value"><% if (view_meta.data_age_minutes !== null) { %><%= view_meta.data_age_minutes %> min · Grenze <%= view_meta.stale_after_hours %> h<% } else { %>—<% } %></div></div>
-      <div class="meta-item">
-        <div class="label">Gebundener Commit</div>
-        <div class="value">
-          <% if (view_meta.source_repository && view_meta.source_commit) { %>
-            <a href="https://github.com/<%= view_meta.source_repository %>/tree/<%= view_meta.source_commit %>"><%= view_meta.source_commit %></a>
-          <% } else { %>—<% } %>
-        </div>
-      </div>
-      <div class="meta-item">
-        <div class="label">Aktueller HEAD</div>
-        <div class="value">
-          <% if (view_meta.source_repository && view_meta.source_head) { %>
-            <a href="https://github.com/<%= view_meta.source_repository %>/tree/<%= view_meta.source_head %>"><%= view_meta.source_head %></a>
-          <% } else { %>—<% } %>
-        </div>
-      </div>
-      <div class="meta-item"><div class="label">Commit-Abstand</div><div class="value"><%= view_meta.commits_ahead === null ? '—' : view_meta.commits_ahead %></div></div>
-      <div class="meta-item"><div class="label">Repository</div><div class="value"><%= view_meta.source_repository || '—' %></div></div>
-      <div class="meta-item"><div class="label">Manifest</div><div class="value"><%= view_meta.manifest_path %></div></div>
-      <div class="meta-item"><div class="label">Quellwurzel</div><div class="value"><%= view_meta.source_root || '—' %></div></div>
-    </section>
-
-    <section class="panel" aria-labelledby="canonical-map-heading">
+    <section class="panel map-panel" aria-labelledby="canonical-map-heading" data-ecosystem-map-panel>
       <div class="map-header">
-        <h2 id="canonical-map-heading">Kanonische Karte</h2>
-        <div class="render-status" data-ecosystem-map-render-status data-state="loading">SVG wird lokal gerendert …</div>
+        <div class="map-header-copy">
+          <h2 id="canonical-map-heading">Kanonische Karte</h2>
+          <div class="render-status" data-ecosystem-map-render-status data-state="loading">SVG wird lokal gerendert …</div>
+        </div>
+        <% if (map && map.content) { %>
+          <div class="map-header-actions">
+            <button type="button" class="map-action" data-map-fullscreen-toggle aria-controls="ecosystem-map-workspace" aria-pressed="false" aria-keyshortcuts="F">Vollbild öffnen</button>
+          </div>
+        <% } %>
       </div>
       <% if (map && map.content) { %>
         <p class="artifact-meta">
           <a href="https://github.com/<%= view_meta.source_repository %>/blob/<%= view_meta.source_commit %>/<%= map.path %>"><%= map.path %></a>
           · <%= map.bytes %> Bytes · sha256 <%= map.sha256 %>
         </p>
-        <p class="link-note">Knoten mit einer passenden Leitstand-Ansicht öffnen diese Ansicht. Alle übrigen Knoten führen zur exakten Definitionszeile im gebundenen Systemkatalog-Commit. Tastatur: Tab, dann Enter oder Leertaste.</p>
-        <div class="map-canvas" data-ecosystem-map-canvas data-render-state="loading" aria-live="polite">Karte wird vorbereitet …</div>
+        <p class="link-note">Knoten mit einer passenden Leitstand-Ansicht öffnen diese Ansicht. Alle übrigen Knoten führen zur exakten Definitionszeile im gebundenen Systemkatalog-Commit. Tastatur: / sucht, F schaltet Vollbild, Esc beendet Vollbild oder Auswahl.</p>
+        <div id="ecosystem-map-workspace" class="map-workspace" data-ecosystem-map-workspace tabindex="-1">
+          <div class="map-workspace-toolbar">
+            <span class="map-workspace-title">Ökosystemkarte</span>
+            <button type="button" class="map-action" data-map-fullscreen-close hidden>Vollbild schließen</button>
+          </div>
+          <div class="map-workspace-content" data-map-workspace-content>
+            <div class="map-canvas" data-ecosystem-map-canvas data-render-state="loading" aria-live="polite">Karte wird vorbereitet …</div>
+          </div>
+        </div>
         <pre hidden data-ecosystem-map-source><%= map.content %></pre>
         <script type="application/json" data-ecosystem-map-navigation><%- node_navigation_json %></script>
         <details data-ecosystem-map-source-details>
@@ -132,6 +153,42 @@
         <p class="empty">Die kanonische Mermaid-Quelle ist nicht verfügbar. Grund: <%= map ? map.missing_reason : view_meta.missing_reason %>.</p>
       <% } %>
     </section>
+
+    <details class="panel source-details">
+      <summary>Quellen-, Prüf- und Zuständigkeitsdetails</summary>
+      <div class="source-details-content">
+        <section class="notice" aria-label="Zuständigkeitsgrenze">
+          <strong>Nur Ansicht.</strong> Der Systemkatalog besitzt Systeme, Beziehungen und Bedeutungen. Leitstand rendert das geprüfte, commit- und hashgebundene Artefakt als SVG. Er bearbeitet die Karte nicht, leitet keine neue Wahrheit ab und löst keine Aufgaben oder Änderungen aus.
+        </section>
+
+        <section class="meta-grid" aria-label="Quellenmetadaten">
+          <div class="meta-item"><div class="label">Gesamtstatus</div><div class="value" data-state="<%= view_meta.freshness_state %>"><%= view_meta.freshness_state %> · <%= view_meta.freshness_reason %></div></div>
+          <div class="meta-item"><div class="label">Inhaltsabgleich</div><div class="value" data-state="<%= view_meta.alignment_state %>"><%= view_meta.alignment_state %> · <%= view_meta.verified_artifact_count %>/5 Artefakte</div></div>
+          <div class="meta-item"><div class="label">Quellzustand</div><div class="value"><%= view_meta.source_kind %> / <%= view_meta.missing_reason %></div></div>
+          <div class="meta-item"><div class="label">Alter</div><div class="value"><% if (view_meta.data_age_minutes !== null) { %><%= view_meta.data_age_minutes %> min · Grenze <%= view_meta.stale_after_hours %> h<% } else { %>—<% } %></div></div>
+          <div class="meta-item">
+            <div class="label">Gebundener Commit</div>
+            <div class="value">
+              <% if (view_meta.source_repository && view_meta.source_commit) { %>
+                <a href="https://github.com/<%= view_meta.source_repository %>/tree/<%= view_meta.source_commit %>"><%= view_meta.source_commit %></a>
+              <% } else { %>—<% } %>
+            </div>
+          </div>
+          <div class="meta-item">
+            <div class="label">Aktueller HEAD</div>
+            <div class="value">
+              <% if (view_meta.source_repository && view_meta.source_head) { %>
+                <a href="https://github.com/<%= view_meta.source_repository %>/tree/<%= view_meta.source_head %>"><%= view_meta.source_head %></a>
+              <% } else { %>—<% } %>
+            </div>
+          </div>
+          <div class="meta-item"><div class="label">Commit-Abstand</div><div class="value"><%= view_meta.commits_ahead === null ? '—' : view_meta.commits_ahead %></div></div>
+          <div class="meta-item"><div class="label">Repository</div><div class="value"><%= view_meta.source_repository || '—' %></div></div>
+          <div class="meta-item"><div class="label">Manifest</div><div class="value"><%= view_meta.manifest_path %></div></div>
+          <div class="meta-item"><div class="label">Quellwurzel</div><div class="value"><%= view_meta.source_root || '—' %></div></div>
+        </section>
+      </div>
+    </details>
 
     <section class="panel" aria-label="Spezifische Leitstand-Verknüpfungen">
       <h2>Spezifische Ansichten</h2>

--- a/tests/views/ecosystemMap.test.ts
+++ b/tests/views/ecosystemMap.test.ts
@@ -51,6 +51,13 @@ describe('ecosystem-map view', () => {
     expect(html).toContain('data-ecosystem-map-canvas');
     expect(html).toContain('data-ecosystem-map-source');
     expect(html).toContain('data-ecosystem-map-navigation');
+    expect(html).toContain('data-ecosystem-map-workspace');
+    expect(html).toContain('data-map-workspace-content');
+    expect(html).toContain('data-map-fullscreen-toggle');
+    expect(html).toContain('data-map-fullscreen-close');
+    expect(html).toContain('aria-keyshortcuts="F"');
+    expect(html).toContain('Quellen-, Prüf- und Zuständigkeitsdetails');
+    expect(html.indexOf('data-ecosystem-map-panel')).toBeLessThan(html.indexOf('Quellen-, Prüf- und Zuständigkeitsdetails'));
     expect(html).toContain('/assets/ecosystem-map.mjs');
     expect(html).toContain(commit);
     expect(html).toContain(head);
@@ -104,6 +111,7 @@ describe('ecosystem-map view', () => {
     expect(html).toContain('Drift erkannt');
     expect(html).toContain('current_artifact_mismatch:rendered/ecosystem-registry-map.mmd');
     expect(html).toContain('stale · current_artifact_mismatch:rendered/ecosystem-registry-map.mmd');
+    expect(html).not.toContain('data-map-fullscreen-toggle');
   });
 
   it('uses the lockfile-local Mermaid module with strict rendering and no remote fetch', async () => {
@@ -115,6 +123,13 @@ describe('ecosystem-map view', () => {
     expect(browserModule).toContain("from '/vendor/mermaid/mermaid.esm.min.mjs'");
     expect(browserModule).toContain("securityLevel: 'strict'");
     expect(browserModule).toContain("setAttribute('role', 'button')");
+    expect(browserModule).toContain('function createFullscreenController');
+    expect(browserModule).toContain('workspace.requestFullscreen');
+    expect(browserModule).toContain("workspace.classList.toggle('is-map-fullscreen'");
+    expect(browserModule).toContain("workspace.setAttribute('aria-modal', 'true')");
+    expect(browserModule).toContain("event.stopImmediatePropagation()");
+    expect(browserModule).toContain("event.key.toLocaleLowerCase('de') === 'f'");
+    expect(browserModule).toContain("canvas.closest('[data-map-workspace-content]')");
     expect(browserModule).not.toContain('fetch(');
     expect(browserModule).not.toContain('contenteditable');
   });


### PR DESCRIPTION
## Zweck

Die kanonische Leitstand-Systemkarte wird per Klick als bildschirmfüllende Arbeitsfläche nutzbar. Gleichzeitig wird die Kartenansicht in der Informationshierarchie nach vorne gezogen und auf Desktop sowie Mobilgerät besser bedienbar.

## Änderungen

- Vollbild-Schalter mit nativer Fullscreen-API und robustem Viewport-Fallback
- `F` zum Umschalten, `Esc` zum Schließen, Fokusfalle und Fokus-Rückgabe
- Explorer und Karte als gemeinsame responsive Arbeitsfläche
- technische Quellen- und Prüfdetails standardmäßig eingeklappt
- globale Shell-Box-Sizing-Basis gegen Navigationsüberlauf
- lange Quellenpfade umbrechen auf Mobilgeräten
- härtere Browser-Shell-Regression ohne testseitiges Kaschieren des Produkt-CSS

## Belege

- `pnpm test`: 222/222
- `pnpm test:browser-shell`: mobil 21/21, Desktop 13/13
- `pnpm test:release-runtime`: 28/28
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- echter Playwright-Lauf: Desktop 1440×900 und Mobil 390×844 bestanden

## Grenzen

Leitstand bleibt read-only. Der PR führt keine Mutation, Taskausführung, Quellenreparatur oder zweite Zustandswahrheit ein.