### PR TITLE
Leitstand-Release erkennt Änderungen in Merge-Commits

### DIFF
--- a/scripts/ci/check-drift-gates.sh
+++ b/scripts/ci/check-drift-gates.sh
@@ -59,7 +59,20 @@ fi
 
 log_success "Doc Link Integrity Passed."
 
-# Identify modified files depending on context
+# Identify modified files depending on context.
+# `git show --name-only` emits no paths for a merge commit unless a parent is
+# selected. Release builds run on reviewed merge commits, so always compare the
+# current tree with its first parent when one exists. Root commits retain an
+# explicit `--root` fallback.
+latest_commit_modified_files() {
+    local revision="${1:-HEAD}"
+    if git rev-parse --verify "${revision}^1" >/dev/null 2>&1; then
+        git diff --name-only "${revision}^1" "$revision"
+    else
+        git show --root --name-only --pretty='' "$revision"
+    fi
+}
+
 # Default to empty, populated conditionally
 MODIFIED_FILES=""
 
@@ -89,7 +102,7 @@ if [[ "${GITHUB_ACTIONS:-}" == "true" || "${CI:-}" == "true" ]]; then
         BEFORE_SHA=$(grep -o '"before": *"[^"]*"' "$GITHUB_EVENT_PATH" 2>/dev/null | awk -F'"' '{print $4}' || echo "0000000000000000000000000000000000000000")
         if [[ -z "$BEFORE_SHA" || "$BEFORE_SHA" == "0000000000000000000000000000000000000000" || "$BEFORE_SHA" == "null" ]]; then
             log_info "New branch or missing before SHA. Diffing latest commit only."
-            MODIFIED_FILES=$(git show --name-only --pretty='' "${GITHUB_SHA:-HEAD}" || true)
+            MODIFIED_FILES=$(latest_commit_modified_files "${GITHUB_SHA:-HEAD}" || true)
         else
             log_info "Diffing range: $BEFORE_SHA..${GITHUB_SHA:-HEAD}"
             MODIFIED_FILES=$(git diff --name-only "$BEFORE_SHA..${GITHUB_SHA:-HEAD}" || true)
@@ -98,8 +111,8 @@ if [[ "${GITHUB_ACTIONS:-}" == "true" || "${CI:-}" == "true" ]]; then
 
     # Global Fallback in CI if still empty
     if [[ -z "$MODIFIED_FILES" ]]; then
-        log_info "Fallback: using git show --name-only against HEAD"
-        MODIFIED_FILES=$(git show --name-only --pretty='' HEAD || true)
+        log_info "Fallback: diffing HEAD against its first parent"
+        MODIFIED_FILES=$(latest_commit_modified_files || true)
     fi
 
     if [[ -z "$MODIFIED_FILES" ]]; then
@@ -115,8 +128,8 @@ else
         } | awk 'NF' | sort -u
     )
     if [[ -z "$MODIFIED_FILES" ]]; then
-        log_info "Clean working tree. Diffing against latest commit..."
-        MODIFIED_FILES=$(git show --name-only --pretty='' HEAD || true)
+        log_info "Clean working tree. Diffing latest commit against its first parent..."
+        MODIFIED_FILES=$(latest_commit_modified_files || true)
     fi
 
     if [[ -z "$MODIFIED_FILES" ]]; then

--- a/tests/test_release_runtime.py
+++ b/tests/test_release_runtime.py
@@ -371,6 +371,79 @@ class ReleaseRuntimeTest(unittest.TestCase):
         with self.assertRaisesRegex(release.ReleaseError, "redirect failed"):
             release._route_matrix(request, label="test")
 
+    def test_drift_gate_detects_files_from_clean_merge_commit(self) -> None:
+        repo = self.root / "drift-merge-repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.email", "test@example.invalid"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+
+        (repo / "scripts/ci").mkdir(parents=True)
+        (repo / "docs").mkdir()
+        (repo / "scripts/ci/check-drift-gates.sh").write_bytes(
+            (REPO_ROOT / "scripts/ci/check-drift-gates.sh").read_bytes()
+        )
+        os.chmod(repo / "scripts/ci/check-drift-gates.sh", 0o755)
+        (repo / "docs/index.md").write_text(
+            "[Runtime](runtime.contract.md)\n", encoding="utf-8"
+        )
+        (repo / "docs/runtime.contract.md").write_text("# Runtime\n", encoding="utf-8")
+        (repo / "docs/drift.signals.md").write_text(
+            "[Runtime](runtime.contract.md)\n", encoding="utf-8"
+        )
+        (repo / "docs/drift.map.yaml").write_text(
+            "rules:\n"
+            "  - trigger: \"^never-match$\"\n"
+            "    require: \"docs/runtime.contract.md\"\n"
+            "    message: \"fixture rule\"\n",
+            encoding="utf-8",
+        )
+        (repo / "README.md").write_text("base\n", encoding="utf-8")
+        subprocess.run(["git", "add", "."], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "base"], cwd=repo, check=True)
+
+        subprocess.run(["git", "checkout", "-q", "-b", "feature"], cwd=repo, check=True)
+        (repo / "README.md").write_text("feature\n", encoding="utf-8")
+        subprocess.run(["git", "add", "README.md"], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "feature"], cwd=repo, check=True)
+        subprocess.run(["git", "checkout", "-q", "main"], cwd=repo, check=True)
+        subprocess.run(
+            ["git", "merge", "-q", "--no-ff", "feature", "-m", "merge feature"],
+            cwd=repo,
+            check=True,
+        )
+
+        parent_line = subprocess.check_output(
+            ["git", "rev-list", "--parents", "-n", "1", "HEAD"], cwd=repo, text=True
+        ).split()
+        self.assertEqual(len(parent_line), 3)
+        self.assertEqual(
+            subprocess.check_output(
+                ["git", "show", "--name-only", "--pretty=", "HEAD"], cwd=repo, text=True
+            ).strip(),
+            "",
+        )
+
+        env = os.environ.copy()
+        env["CI"] = "true"
+        env.pop("GITHUB_ACTIONS", None)
+        env.pop("GITHUB_EVENT_NAME", None)
+        env.pop("GITHUB_EVENT_PATH", None)
+        env.pop("GITHUB_BASE_REF", None)
+        env.pop("GITHUB_SHA", None)
+        result = subprocess.run(
+            ["bash", "scripts/ci/check-drift-gates.sh"],
+            cwd=repo,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Fallback: diffing HEAD against its first parent", result.stdout)
+        self.assertIn("README.md", result.stdout)
+        self.assertIn("All Drift Gates Passed", result.stdout)
+
     def test_health_validation_requires_exact_thresholds_and_fresh_sources(self) -> None:
         head = "6" * 40
         health = {


### PR DESCRIPTION
## Problem

Der transaktionale Release von Merge-Commit `660191e` wurde vor jedem Cutover vom Drift-Guard blockiert. Im CI-/Release-Fallback verwendet der Guard `git show --name-only HEAD`; bei Merge-Commits liefert das keine Dateipfade. Dadurch bleibt `MODIFIED_FILES` leer und der Release stoppt fail-closed.

## Lösung

- gemeinsame Dateiableitung für den letzten Commit
- bei vorhandenem Elterncommit: Diff gegen den ersten Elterncommit
- bei Root-Commit: expliziter `--root`-Fallback
- explizite Revisionen wie `GITHUB_SHA` bleiben erhalten
- Regression erzeugt einen echten sauberen Merge-Commit und belegt, dass `README.md` erkannt wird

## Belege

- Bash-Syntaxprüfung grün
- gezielter Merge-Commit-Regressionsfall grün
- `pnpm test:release-runtime`: 29/29
- `pnpm test`: 222/222
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- Drift-Guard auf dem tatsächlichen Diff grün

## Wirkung und Grenze

Der Fix ändert nur die Ermittlung geänderter Dateien. Die Drift-Regeln, der fail-closed Releasevertrag und die Runtime selbst bleiben unverändert.