### PR TITLE
Leitstand-Release nutzt sicheres System-CA-Bündel

### DIFF
--- a/docs/runbooks/local-release-runtime.md
+++ b/docs/runbooks/local-release-runtime.md
@@ -97,6 +97,8 @@ Success requires agreement between release manifest, user-systemd, process state
 
 Redirect verification uses parsed status and location fields. Raw CRLF-sensitive header matching is not part of the contract.
 
+Canonical HTTPS verification never disables certificate validation. The adapter first uses Python's configured CA file. When the Python/OpenSSL build has no usable compiled CA file, it may use the first existing operating-system CA bundle from its fixed platform list. A fallback bundle is accepted only when it is a regular file owned by root and is not writable by group or others. If no trusted bundle is available or certificate verification fails, postflight fails and the coupled transaction restores the prior runtime.
+
 ## Receipts and idempotency
 
 Build, switch, rollback, failure and deployment effects write create-only JSON receipts plus SHA-256 sidecars below:

--- a/scripts/leitstand-release.py
+++ b/scripts/leitstand-release.py
@@ -57,6 +57,12 @@ DEFAULT_POSTFLIGHT_TIMEOUT_SECONDS = 35.0
 DEFAULT_STABILITY_SECONDS = 2.0
 DEFAULT_POLL_SECONDS = 1.0
 BROWSER_BINARIES = ("chromium", "chromium-browser", "google-chrome-stable", "google-chrome")
+SYSTEM_CA_BUNDLE_CANDIDATES = (
+    Path("/etc/ssl/certs/ca-certificates.crt"),
+    Path("/etc/pki/tls/certs/ca-bundle.crt"),
+    Path("/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"),
+    Path("/etc/ssl/ca-bundle.pem"),
+)
 
 WEB_SERVICE = "leitstand.service"
 STORAGE_SERVICE = "leitstand-storage-health.service"
@@ -1663,6 +1669,31 @@ def units_match(paths: Paths, target: Path, config: RuntimeConfig) -> bool:
         return False
 
 
+def _system_ca_bundle() -> Path | None:
+    """Return a trusted OS CA bundle when Python's compiled default is absent."""
+    for candidate in SYSTEM_CA_BUNDLE_CANDIDATES:
+        try:
+            metadata = candidate.stat()
+        except OSError:
+            continue
+        if not stat.S_ISREG(metadata.st_mode):
+            continue
+        if metadata.st_uid != 0 or metadata.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+            continue
+        return candidate
+    return None
+
+
+def _tls_context() -> ssl.SSLContext:
+    defaults = ssl.get_default_verify_paths()
+    if defaults.cafile is not None:
+        return ssl.create_default_context()
+    bundle = _system_ca_bundle()
+    if bundle is not None:
+        return ssl.create_default_context(cafile=str(bundle))
+    return ssl.create_default_context()
+
+
 def _http_request(
     host: str,
     port: int,
@@ -1678,7 +1709,7 @@ def _http_request(
             host,
             port,
             timeout=timeout,
-            context=ssl.create_default_context(),
+            context=_tls_context(),
         )
     else:
         connection = http.client.HTTPConnection(host, port, timeout=timeout)

--- a/tests/test_release_runtime.py
+++ b/tests/test_release_runtime.py
@@ -444,6 +444,39 @@ class ReleaseRuntimeTest(unittest.TestCase):
         self.assertIn("README.md", result.stdout)
         self.assertIn("All Drift Gates Passed", result.stdout)
 
+    def test_tls_context_uses_secure_system_bundle_when_python_default_is_missing(self) -> None:
+        bundle = Path("/trusted/system/ca-certificates.crt")
+        context = Mock()
+        with (
+            patch.object(release.ssl, "get_default_verify_paths", return_value=Mock(cafile=None)),
+            patch.object(release, "_system_ca_bundle", return_value=bundle),
+            patch.object(release.ssl, "create_default_context", return_value=context) as create,
+        ):
+            self.assertIs(release._tls_context(), context)
+        create.assert_called_once_with(cafile=str(bundle))
+
+    def test_tls_context_preserves_existing_python_default(self) -> None:
+        context = Mock()
+        with (
+            patch.object(
+                release.ssl,
+                "get_default_verify_paths",
+                return_value=Mock(cafile="/configured/ca.pem"),
+            ),
+            patch.object(release.ssl, "create_default_context", return_value=context) as create,
+        ):
+            self.assertIs(release._tls_context(), context)
+        create.assert_called_once_with()
+
+    def test_system_ca_bundle_rejects_group_writable_candidate(self) -> None:
+        bundle = Path("/unsafe/system/ca-certificates.crt")
+        metadata = Mock(st_uid=0, st_mode=stat.S_IFREG | 0o664)
+        with (
+            patch.object(release, "SYSTEM_CA_BUNDLE_CANDIDATES", (bundle,)),
+            patch.object(Path, "stat", return_value=metadata),
+        ):
+            self.assertIsNone(release._system_ca_bundle())
+
     def test_health_validation_requires_exact_thresholds_and_fresh_sources(self) -> None:
         head = "6" * 40
         health = {


### PR DESCRIPTION
## Problem

Der transaktionale Release erreichte nach dem Cutover die kanonische HTTPS-Postflight-Prüfung, scheiterte dort aber mit `CERTIFICATE_VERIFY_FAILED`. Die Zertifikatskette ist gültig (`curl` meldet Verifikation 0); Python 3.10 erwartet auf diesem Host `/usr/lib/ssl/cert.pem`, diese Datei existiert nicht. Das gültige Betriebssystembündel liegt unter `/etc/ssl/certs/ca-certificates.crt`.

Der Release hat daraufhin korrekt den vorherigen Dienstzustand wiederhergestellt.

## Lösung

- Python-konfiguriertes CA-Bündel bleibt vorrangig
- nur wenn kein Python-CA-File verfügbar ist: feste Liste üblicher Betriebssystembündel
- Fallback nur auf reguläre, root-eigene und nicht gruppen-/fremdbeschreibbare Dateien
- Zertifikatsprüfung wird niemals abgeschaltet
- Runbook dokumentiert Verhalten und Rückweg

## Belege

- echter kanonischer HTTPS-Request mit dem neuen Adapter: `200 ok`
- 3 gezielte CA-Bundle-Tests grün
- `pnpm test:release-runtime`: 32/32
- `pnpm test`: 222/222
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- Drift-Guard einschließlich Runbook-Vertrag grün

## Wirkung und Grenze

Der Fix verändert nur die Trust-Store-Auswahl des Release-Postflights. DNS, Caddy, Zertifikate und Leitstand-Runtime werden dadurch nicht umkonfiguriert.