### PR TITLE
Bind visualization pilot evidence to real sources

### DIFF
--- a/docs/reports/visualization-pilot-2026-07-20.json
+++ b/docs/reports/visualization-pilot-2026-07-20.json
@@ -1,0 +1,287 @@
+{
+  "schemaVersion": 1,
+  "kind": "leitstand_visualization_pilot_evidence",
+  "taskId": "LSV-V1-T007",
+  "observedAt": "2026-07-20T12:10:00Z",
+  "observedLeitstand": {
+    "repository": "heimgewebe/leitstand",
+    "commit": "4218e10ab4ea9dc029c98009f4f142c7bbcc81eb",
+    "release": "/home/alex/.local/lib/leitstand/releases/4218e10ab4ea9dc029c98009f4f142c7bbcc81eb-runtime-v1",
+    "service": {
+      "unit": "leitstand.service",
+      "activeState": "active",
+      "subState": "running",
+      "restartCount": 0
+    }
+  },
+  "sourceContract": {
+    "mode": "identity_only",
+    "contentCopied": false,
+    "description": "The pilot records source identities, digests, timestamps and bounded verdicts. It does not copy private source contents or reinterpret source-system truth."
+  },
+  "sources": [
+    {
+      "id": "systemkatalog",
+      "displayName": "Systemkatalog ecosystem map",
+      "authority": "canonical_map_semantics",
+      "evidenceMode": "live_artifact",
+      "observedState": "valid",
+      "artifact": {
+        "kind": "system_catalog_map_artifact_manifest",
+        "path": "/home/alex/.local/share/systemkatalog/releases/d8230e73bd6c56b2930ec801694af84e19ed3d26/rendered/ecosystem-map-artifact-manifest.json",
+        "sha256": "9454a0df40ff06887a36bed3503afbcbe06efaa2566ccf73930d6c2c669949d1",
+        "bytes": 1861,
+        "generatedAt": "2026-07-15T20:38:43Z",
+        "sourceRepository": "heimgewebe/systemkatalog",
+        "sourceCommit": "a765da7e1222b435c35b4797adb01dfba5a8b1b8"
+      },
+      "surfacedBy": [
+        "/ecosystem-map"
+      ],
+      "doesNotEstablish": [
+        "claim_truth",
+        "runtime_correctness",
+        "map_semantic_correctness"
+      ]
+    },
+    {
+      "id": "repoground",
+      "displayName": "RepoGround canonical publication",
+      "authority": "repository_bundle_identity",
+      "evidenceMode": "live_artifact",
+      "observedState": "valid",
+      "artifact": {
+        "kind": "repoground.bundle.manifest",
+        "path": "/home/alex/repos/manifest-publications/bundles/heimgewebe__repoground/main/20260720T021738Z-b1ea71cdce4b/heimgewebe__repoground__main-max-260720-0217_merge.bundle.manifest.json",
+        "sha256": "d60cd4491ccf1a634b59f0aaa84b71bf6c8fca1a67536025a26b214af6603f19",
+        "bytes": 18397,
+        "generatedAt": "2026-07-20T02:18:05Z",
+        "sourceRepository": "heimgewebe/repoground",
+        "sourceCommit": "9b4b643c448e018049d03ab1ec945af99018e2b1"
+      },
+      "surfacedBy": [
+        "/repobriefs"
+      ],
+      "doesNotEstablish": [
+        "repo_understood",
+        "public_export_safety",
+        "runtime_correctness"
+      ]
+    },
+    {
+      "id": "chronik",
+      "displayName": "Chronik RepoGround publication",
+      "authority": "repository_bundle_identity",
+      "evidenceMode": "live_artifact",
+      "observedState": "valid",
+      "artifact": {
+        "kind": "repoground.bundle.manifest",
+        "path": "/home/alex/repos/manifest-publications/bundles/heimgewebe__chronik/main/20260720T030937Z-4448b417af44/heimgewebe__chronik__main-max-260720-0309_merge.bundle.manifest.json",
+        "sha256": "b7ec7d730dbc367733e60a170c04b3b7ffb6c729fb135a19e767fab1c773793d",
+        "bytes": 17750,
+        "generatedAt": "2026-07-20T03:09:38Z",
+        "sourceRepository": "heimgewebe/chronik",
+        "sourceCommit": "63154c36fcd806bd2ac140f1ef287ea0c5fc914e"
+      },
+      "surfacedBy": [
+        "/repobriefs"
+      ],
+      "doesNotEstablish": [
+        "chronik_ledger_integrity",
+        "chronik_runtime_health",
+        "event_truth"
+      ]
+    },
+    {
+      "id": "wgx",
+      "displayName": "WGX RepoGround publication",
+      "authority": "repository_bundle_identity",
+      "evidenceMode": "live_artifact",
+      "observedState": "valid",
+      "artifact": {
+        "kind": "repoground.bundle.manifest",
+        "path": "/home/alex/repos/manifest-publications/bundles/heimgewebe__wgx/main/20260720T031329Z-08d0dbb8a7f5/heimgewebe__wgx__main-max-260720-0313_merge.bundle.manifest.json",
+        "sha256": "41b51a95cfd890ec774a48d9369ee7ad7b0d54bad01ab07613dd48bb564bc331",
+        "bytes": 17636,
+        "generatedAt": "2026-07-20T03:13:29Z",
+        "sourceRepository": "heimgewebe/wgx",
+        "sourceCommit": "01efb27f424466c951a196f095c549d1afdd10da"
+      },
+      "surfacedBy": [
+        "/repobriefs"
+      ],
+      "doesNotEstablish": [
+        "wgx_runtime_health",
+        "metric_truth",
+        "deployment_correctness"
+      ]
+    },
+    {
+      "id": "semantah",
+      "displayName": "semantAH RepoGround publication",
+      "authority": "repository_bundle_identity",
+      "evidenceMode": "live_artifact",
+      "observedState": "valid",
+      "artifact": {
+        "kind": "repoground.bundle.manifest",
+        "path": "/home/alex/repos/manifest-publications/bundles/heimgewebe__semantAH/main/20260720T010824Z-9fad49f38602/heimgewebe__semantAH__main-max-260720-0108_merge.bundle.manifest.json",
+        "sha256": "38228717f34b10178e9932381be3a5dd795a603ce9c0982d924729e195cb3e76",
+        "bytes": 17778,
+        "generatedAt": "2026-07-20T01:08:25Z",
+        "sourceRepository": "heimgewebe/semantAH",
+        "sourceCommit": "d53000a909946a0381a8b365c4af7abd2456e8f6"
+      },
+      "surfacedBy": [
+        "/repobriefs"
+      ],
+      "doesNotEstablish": [
+        "semantic_quality",
+        "index_freshness",
+        "runtime_correctness"
+      ]
+    }
+  ],
+  "scenarios": [
+    {
+      "id": "valid-system-map",
+      "state": "valid",
+      "evidenceMode": "live_artifact",
+      "sourceIds": [
+        "systemkatalog"
+      ],
+      "liveIncidentObserved": false,
+      "verifier": {
+        "testFile": "tests/controllers/ecosystemMap.test.ts",
+        "assertion": "A digest-bound manifest and its declared artifacts load into typed valid view data."
+      }
+    },
+    {
+      "id": "missing-system-map-manifest",
+      "state": "missing",
+      "evidenceMode": "synthetic_fault_injection",
+      "sourceIds": [
+        "systemkatalog"
+      ],
+      "liveIncidentObserved": false,
+      "verifier": {
+        "testFile": "tests/controllers/ecosystemMap.test.ts",
+        "assertion": "A configured missing manifest produces an explicit missing/degraded state rather than green output."
+      }
+    },
+    {
+      "id": "corrupt-system-map-manifest",
+      "state": "corrupt",
+      "evidenceMode": "synthetic_fault_injection",
+      "sourceIds": [
+        "systemkatalog"
+      ],
+      "liveIncidentObserved": false,
+      "verifier": {
+        "testFile": "tests/controllers/ecosystemMap.test.ts",
+        "assertion": "Malformed JSON or a digest mismatch produces an explicit corrupt state and no trusted rendering input."
+      }
+    },
+    {
+      "id": "stale-system-map-manifest",
+      "state": "stale",
+      "evidenceMode": "synthetic_fault_injection",
+      "sourceIds": [
+        "systemkatalog"
+      ],
+      "liveIncidentObserved": false,
+      "verifier": {
+        "testFile": "tests/controllers/ecosystemMap.test.ts",
+        "assertion": "An artifact outside the configured freshness window remains readable but is visibly classified stale."
+      }
+    },
+    {
+      "id": "stale-leitstand-repoground-publication",
+      "state": "stale",
+      "evidenceMode": "live_artifact",
+      "sourceIds": [
+        "repoground"
+      ],
+      "liveIncidentObserved": true,
+      "artifact": {
+        "kind": "repoground.bundle.manifest",
+        "path": "/home/alex/repos/manifest-publications/bundles/heimgewebe__leitstand/main/20260720T001041Z-cd227fe58773/heimgewebe__leitstand__main-max-260720-0010_merge.bundle.manifest.json",
+        "sha256": "31b7c51bcd9fb4f17a39187f506c03388e9134aed2de11071783da038970554a",
+        "generatedAt": "2026-07-20T00:10:42Z",
+        "sourceCommit": "c9de5b077e431b3087920cea159ce19ba1319b7b",
+        "comparedWithCommit": "4218e10ab4ea9dc029c98009f4f142c7bbcc81eb"
+      },
+      "verifier": {
+        "testFile": "tests/controllers/repoBrief.test.ts",
+        "assertion": "Leitstand does not infer freshness merely from a timestamp and therefore cannot relabel this older publication green."
+      }
+    },
+    {
+      "id": "missing-repoground-index",
+      "state": "missing",
+      "evidenceMode": "synthetic_fault_injection",
+      "sourceIds": [
+        "repoground"
+      ],
+      "liveIncidentObserved": false,
+      "verifier": {
+        "testFile": "tests/controllers/repoBrief.test.ts",
+        "assertion": "A missing configured bundle index yields an empty degraded read-only state."
+      }
+    },
+    {
+      "id": "export-safety-fail",
+      "state": "export-safety-fail",
+      "evidenceMode": "live_artifact",
+      "sourceIds": [
+        "repoground"
+      ],
+      "liveIncidentObserved": true,
+      "artifact": {
+        "kind": "lenskit.export_safety_report",
+        "path": "/home/alex/repos/merges/leitstand-max-260705-0643/leitstand-max-260705-0443_merge.export_safety_report.json",
+        "sha256": "b0cf4ffb2ee6bbbb7277cb5fe70dd48080d212a033d5c156a42dc1e03290af39",
+        "status": "fail",
+        "reason": "agent_export_gate_required_but_missing_or_not_pass"
+      },
+      "verifier": {
+        "testFile": "tests/controllers/repoBrief.test.ts",
+        "assertion": "Export-safety failure and public-export readiness remain independent visible fields and are never converted into a green bundle verdict."
+      }
+    }
+  ],
+  "validation": {
+    "focusedVitest": {
+      "files": 5,
+      "tests": 37,
+      "status": "pass",
+      "receiptSha256": "bd7671e0a828fac9832573865cf95a829e0d9ad6ddcaff081e534cf88ff22864"
+    },
+    "browserShell": {
+      "mobile": "21/21 pass",
+      "desktop": "13/13 pass",
+      "receiptSha256": "aea066b3fd584d1d2e289fdd23da1a6ae3468c3a6ee87def237ba050e65ebcd0"
+    }
+  },
+  "boundary": {
+    "viewOnly": true,
+    "mutationsAllowed": false,
+    "writeCapabilities": [],
+    "forbiddenActions": [
+      "task_dispatch",
+      "source_repair",
+      "repository_mutation",
+      "merge",
+      "deployment",
+      "external_refresh"
+    ]
+  },
+  "doesNotEstablish": [
+    "source_truth",
+    "runtime_correctness",
+    "comprehensive_source_coverage",
+    "public_export_safety",
+    "visual_perfection",
+    "future_freshness",
+    "task_readiness"
+  ]
+}

--- a/docs/reports/visualization-pilot-2026-07-20.md
+++ b/docs/reports/visualization-pilot-2026-07-20.md
@@ -1,0 +1,91 @@
+---
+id: report.visualization-pilot-2026-07-20
+title: Leitstand Visualization Pilot Evidence 2026-07-20
+doc_type: report
+status: active
+canonicality: supporting
+summary: >
+  Commit-bound pilot evidence for LSV-V1-T007 covering real source identities,
+  explicit degraded states and the view-only Leitstand boundary.
+---
+
+# Leitstand Visualization Pilot Evidence — 2026-07-20
+
+## Result
+
+`LSV-V1-T007` is exercised against Leitstand commit
+`4218e10ab4ea9dc029c98009f4f142c7bbcc81eb`.
+
+The machine-readable evidence is
+[`visualization-pilot-2026-07-20.json`](./visualization-pilot-2026-07-20.json).
+It is the normative pilot record for the exact source identities and scenario
+classification below.
+
+## Evidence model
+
+The pilot separates two kinds of evidence:
+
+1. **Live artifacts** record files that existed and were read on the operator
+   host. Only identity, digest, timestamp and bounded status fields are copied.
+2. **Synthetic fault injection** exercises missing, corrupt and stale inputs in
+   isolated tests. These scenarios prove degraded-state behavior; they are not
+   reported as live incidents.
+
+This distinction prevents a test fixture from being mistaken for operational
+history.
+
+## Real source identities
+
+| Source | Artifact | Source commit | Observed state |
+| --- | --- | --- | --- |
+| Systemkatalog | production-bound ecosystem-map manifest | `a765da7e1222b435c35b4797adb01dfba5a8b1b8` | valid |
+| RepoGround | canonical RepoGround bundle publication | `9b4b643c448e018049d03ab1ec945af99018e2b1` | valid |
+| Chronik | canonical RepoGround publication for Chronik | `63154c36fcd806bd2ac140f1ef287ea0c5fc914e` | valid identity only |
+| WGX | canonical RepoGround publication for WGX | `01efb27f424466c951a196f095c549d1afdd10da` | valid identity only |
+| semantAH | canonical RepoGround publication for semantAH | `d53000a909946a0381a8b365c4af7abd2456e8f6` | valid identity only |
+
+The Chronik, WGX and semantAH rows prove the existence and provenance of their
+repository publications. They do not prove ledger integrity, runtime health,
+metric truth, semantic quality or deployment correctness.
+
+## Explicit degraded states
+
+| State | Evidence | Live incident? | Expected Leitstand behavior |
+| --- | --- | --- | --- |
+| `missing` | isolated controller fault injection | no | empty/degraded state, never green |
+| `corrupt` | malformed JSON and digest mismatch tests | no | reject trusted rendering input |
+| `stale` | freshness-window test plus an older real Leitstand RepoGround publication | mixed | readable but visibly non-current or unknown |
+| `export-safety-fail` | real export-safety report with status `fail` | yes | failure stays visible and blocks public-ready framing |
+
+The real export-safety failure is digest-bound to
+`b0cf4ffb2ee6bbbb7277cb5fe70dd48080d212a033d5c156a42dc1e03290af39`.
+Its recorded reason is
+`agent_export_gate_required_but_missing_or_not_pass`.
+
+## Validation
+
+- Focused Vitest set: **37/37 passed** across ecosystem-map, navigation and
+  RepoGround controller/view tests.
+- Browser shell regression against the sealed production release:
+  **mobile 21/21**, **desktop 13/13**.
+- Production service: active/running with zero recorded restarts and exact
+  release commit `4218e10ab4ea9dc029c98009f4f142c7bbcc81eb`.
+
+## View-only boundary
+
+The pilot and the represented Leitstand views are **view-only**. They contain no
+capability for task dispatch, source repair, repository mutation, merge,
+deployment or external refresh. Local paths are evidence pointers, not public
+links and not permission grants.
+
+## Does not establish
+
+This pilot does not establish:
+
+- source truth;
+- runtime correctness;
+- comprehensive source coverage;
+- public export safety;
+- visual perfection;
+- future freshness;
+- task readiness.

--- a/tests/visualizationPilot.test.ts
+++ b/tests/visualizationPilot.test.ts
@@ -1,0 +1,229 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+interface PilotArtifact {
+  kind: string;
+  path: string;
+  sha256: string;
+  bytes?: number;
+  generatedAt?: string;
+  sourceRepository?: string;
+  sourceCommit?: string;
+  comparedWithCommit?: string;
+  status?: string;
+  reason?: string;
+}
+
+interface PilotSource {
+  id: string;
+  authority: string;
+  evidenceMode: string;
+  observedState: string;
+  artifact: PilotArtifact;
+  doesNotEstablish: string[];
+}
+
+interface PilotScenario {
+  id: string;
+  state: string;
+  evidenceMode: string;
+  sourceIds: string[];
+  liveIncidentObserved: boolean;
+  artifact?: PilotArtifact;
+  verifier: {
+    testFile: string;
+    assertion: string;
+  };
+}
+
+interface PilotEvidence {
+  schemaVersion: number;
+  kind: string;
+  taskId: string;
+  observedLeitstand: {
+    commit: string;
+    service: {
+      unit: string;
+      activeState: string;
+      subState: string;
+      restartCount: number;
+    };
+  };
+  sourceContract: {
+    mode: string;
+    contentCopied: boolean;
+  };
+  sources: PilotSource[];
+  scenarios: PilotScenario[];
+  validation: {
+    focusedVitest: {
+      tests: number;
+      status: string;
+      receiptSha256: string;
+    };
+    browserShell: {
+      mobile: string;
+      desktop: string;
+      receiptSha256: string;
+    };
+  };
+  boundary: {
+    viewOnly: boolean;
+    mutationsAllowed: boolean;
+    writeCapabilities: string[];
+    forbiddenActions: string[];
+  };
+  doesNotEstablish: string[];
+}
+
+const REPORT_PATH = join(
+  process.cwd(),
+  'docs',
+  'reports',
+  'visualization-pilot-2026-07-20.json',
+);
+const MARKDOWN_PATH = join(
+  process.cwd(),
+  'docs',
+  'reports',
+  'visualization-pilot-2026-07-20.md',
+);
+
+async function readEvidence(): Promise<PilotEvidence> {
+  return JSON.parse(await readFile(REPORT_PATH, 'utf-8')) as PilotEvidence;
+}
+
+describe('LSV-V1-T007 visualization pilot evidence', () => {
+  it('binds the pilot to the exact production Leitstand commit and receipts', async () => {
+    const evidence = await readEvidence();
+
+    expect(evidence.schemaVersion).toBe(1);
+    expect(evidence.kind).toBe('leitstand_visualization_pilot_evidence');
+    expect(evidence.taskId).toBe('LSV-V1-T007');
+    expect(evidence.observedLeitstand.commit).toBe(
+      '4218e10ab4ea9dc029c98009f4f142c7bbcc81eb',
+    );
+    expect(evidence.observedLeitstand.service).toEqual({
+      unit: 'leitstand.service',
+      activeState: 'active',
+      subState: 'running',
+      restartCount: 0,
+    });
+    expect(evidence.validation.focusedVitest).toMatchObject({
+      tests: 37,
+      status: 'pass',
+    });
+    expect(evidence.validation.focusedVitest.receiptSha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(evidence.validation.browserShell.mobile).toContain('21/21');
+    expect(evidence.validation.browserShell.desktop).toContain('13/13');
+    expect(evidence.validation.browserShell.receiptSha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('records all required real source identities without copying source contents', async () => {
+    const evidence = await readEvidence();
+    const sourceIds = evidence.sources.map((source) => source.id).sort();
+
+    expect(sourceIds).toEqual([
+      'chronik',
+      'repoground',
+      'semantah',
+      'systemkatalog',
+      'wgx',
+    ]);
+    expect(evidence.sourceContract).toEqual({
+      mode: 'identity_only',
+      contentCopied: false,
+      description: expect.any(String),
+    });
+
+    for (const source of evidence.sources) {
+      expect(source.evidenceMode).toBe('live_artifact');
+      expect(source.observedState).toBe('valid');
+      expect(source.artifact.path).toMatch(/^\//);
+      expect(source.artifact.sha256).toMatch(/^[0-9a-f]{64}$/);
+      expect(source.artifact.sourceCommit).toMatch(/^[0-9a-f]{40}$/);
+      expect(source.artifact.sourceRepository).toMatch(/^heimgewebe\//);
+      expect(source.doesNotEstablish.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('covers valid, missing, corrupt, stale and export-safety-fail states', async () => {
+    const evidence = await readEvidence();
+    const states = new Set(evidence.scenarios.map((scenario) => scenario.state));
+
+    for (const state of ['valid', 'missing', 'corrupt', 'stale', 'export-safety-fail']) {
+      expect(states.has(state)).toBe(true);
+    }
+
+    for (const scenario of evidence.scenarios) {
+      expect(scenario.sourceIds.length).toBeGreaterThan(0);
+      expect(scenario.verifier.testFile).toMatch(/^tests\//);
+      expect(scenario.verifier.assertion.length).toBeGreaterThan(20);
+    }
+  });
+
+  it('does not disguise synthetic missing or corrupt cases as live incidents', async () => {
+    const evidence = await readEvidence();
+    const injected = evidence.scenarios.filter(
+      (scenario) => scenario.state === 'missing' || scenario.state === 'corrupt',
+    );
+
+    expect(injected.length).toBeGreaterThanOrEqual(3);
+    for (const scenario of injected) {
+      expect(scenario.evidenceMode).toBe('synthetic_fault_injection');
+      expect(scenario.liveIncidentObserved).toBe(false);
+    }
+  });
+
+  it('keeps the real export-safety failure visible and digest-bound', async () => {
+    const evidence = await readEvidence();
+    const scenario = evidence.scenarios.find(
+      (candidate) => candidate.state === 'export-safety-fail',
+    );
+
+    expect(scenario).toBeDefined();
+    expect(scenario?.evidenceMode).toBe('live_artifact');
+    expect(scenario?.liveIncidentObserved).toBe(true);
+    expect(scenario?.artifact).toMatchObject({
+      kind: 'lenskit.export_safety_report',
+      sha256: 'b0cf4ffb2ee6bbbb7277cb5fe70dd48080d212a033d5c156a42dc1e03290af39',
+      status: 'fail',
+      reason: 'agent_export_gate_required_but_missing_or_not_pass',
+    });
+  });
+
+  it('preserves the read-only truth boundary', async () => {
+    const evidence = await readEvidence();
+
+    expect(evidence.boundary.viewOnly).toBe(true);
+    expect(evidence.boundary.mutationsAllowed).toBe(false);
+    expect(evidence.boundary.writeCapabilities).toEqual([]);
+    expect(evidence.boundary.forbiddenActions).toEqual(expect.arrayContaining([
+      'task_dispatch',
+      'source_repair',
+      'repository_mutation',
+      'merge',
+      'deployment',
+      'external_refresh',
+    ]));
+    expect(evidence.doesNotEstablish).toEqual(expect.arrayContaining([
+      'source_truth',
+      'runtime_correctness',
+      'comprehensive_source_coverage',
+      'public_export_safety',
+    ]));
+  });
+
+  it('keeps the human-readable report bound to the machine evidence', async () => {
+    const markdown = await readFile(MARKDOWN_PATH, 'utf-8');
+
+    expect(markdown).toContain('LSV-V1-T007');
+    expect(markdown).toContain('visualization-pilot-2026-07-20.json');
+    expect(markdown).toContain('4218e10ab4ea9dc029c98009f4f142c7bbcc81eb');
+    expect(markdown).toContain('`missing`');
+    expect(markdown).toContain('`corrupt`');
+    expect(markdown).toContain('`export-safety-fail`');
+    expect(markdown).toContain('view-only');
+  });
+});


### PR DESCRIPTION
## Ziel

Vervollständigt den Evidenzteil von `LSV-V1-T007`, ohne Leitstand neue Schreib- oder Quellautorität zu geben.

## Enthalten

- maschinenlesbarer, commitgebundener Pilotbeleg für Systemkatalog, RepoGround, Chronik, WGX und semantAH
- klare Trennung realer Artefakte von synthetischen `missing`-/`corrupt`-Fehlereinspeisungen
- reale Stale- und Export-Safety-Negativbelege
- expliziter view-only Vertrag
- Regressionstest gegen Verwechslung von Testfixtures und Live-Vorfällen

## Prüfung

- `pnpm test`: 229/229
- gezielt: 28/28
- `pnpm run typecheck`: PASS
- `pnpm run lint`: PASS
- `pnpm run build`: PASS
- `pnpm run test:browser-shell`: mobile 21/21, desktop 13/13

## Grenzen

Der Pilot beweist keine Quellwahrheit, Laufzeitkorrektheit, vollständige Quellenabdeckung, öffentliche Exportfreigabe oder spätere Taskbereitschaft.