### PR TITLE
feat: centralize Leitstand shared UI system

### DIFF
--- a/docs/runbooks/shared-ui-system.md
+++ b/docs/runbooks/shared-ui-system.md
@@ -1,0 +1,59 @@
+---
+id: runbook.shared-ui-system
+title: Shared UI system
+doc_type: runbook
+status: active
+canonicality: supporting
+summary: >
+  Versioned, read-only Leitstand UI foundations shared by the primary operational views.
+---
+
+# Shared UI system
+
+## Purpose
+
+LSV-V1-T008 centralizes the small set of presentation contracts that should not be redefined by every Leitstand view. The shared layer remains purely presentational: it does not create source truth, task authority, dispatch capability or write paths.
+
+The versioned entry points are:
+
+- `src/public/ui-system.css` for tokens, surfaces, spacing, status colors, tables, focus visibility, action sizing, responsive behavior, provenance disclosure and reduced motion;
+- `src/views/_ui-head.ejs` for the ordered product stylesheet contract: shell first, shared UI second;
+- view-local `<style>` blocks only for bounded view-specific structures such as the Bureau board, checkout flags, storage grids and the ecosystem map workspace.
+
+## Migrated priority views
+
+The dashboard, Bureau task board, RepoGround observability, ecosystem map, checkout health and storage health views all load the shared UI layer. The first four are the explicit T008 priority surfaces; checkout and storage views use the same foundations to avoid a parallel visual dialect.
+
+Bureau, checkout and RepoGround views place their primary operational content before technical source metadata. Source and freshness details remain available in keyboard-accessible native `<details>` elements. The Bureau disclosure summary keeps source kind and freshness visible even while collapsed, because stale data changes how the board must be interpreted.
+
+## Measured consolidation
+
+The measurement compares the six primary EJS views before T008 with the first completed shared-layer migration:
+
+| Measure | Before | After | Change |
+| --- | ---: | ---: | ---: |
+| Inline `<style>` blocks | 6 | 5 | RepoGround needs no view-local CSS |
+| Inline style bytes | 22,671 | 13,362 | -9,309 bytes (-41.1%) |
+| `style="…"` attributes | 3 | 0 | eliminated |
+| View-local plain `body { … }` foundations | 6 | 0 | centralized |
+| View-local plain `main { … }` foundations | 6 | 0 | centralized |
+| Views using `_ui-head` | 0 | 6 | one stylesheet contract |
+
+The remaining five inline style blocks are intentional, bounded exceptions for view-specific layout or interaction. Shared tokens include transitional aliases for existing dashboard-specific rules so the migration does not require a risky all-at-once rewrite.
+
+## Regression contract
+
+`tests/sharedUiSystem.test.ts` checks that all six primary views use the shared head partial, that shared foundations do not reappear in view-local CSS, that inline style attributes stay absent and that primary content precedes collapsible provenance on the migrated operational views.
+
+The build-bound browser matrix additionally requires `/assets/ui-system.css` to be loaded on every real route/viewport pair. The existing 390×844 and 1440×900 regression checks continue to reject horizontal overflow, focus loss, broken mobile navigation, broken fullscreen focus containment, browser errors and active map transitions under reduced motion.
+
+## Boundary
+
+This layer establishes presentation consistency only. It does not establish:
+
+- correctness or freshness of Bureau, RepoGround, checkout, storage or Systemkatalog data;
+- permission to mutate any observed system;
+- task claim, dispatch, merge or deployment authority;
+- a second runtime state or truth model inside Leitstand.
+
+Source adapters and controllers remain responsible for read-only projections; the UI renders their explicit source and degradation states.

--- a/scripts/browser-view-regression.mjs
+++ b/scripts/browser-view-regression.mjs
@@ -321,6 +321,7 @@ async function runView(browser, origin, viewport, view, baseline) {
     assert(layout.mainLeft !== null && layout.mainRight !== null && layout.mainLeft >= -1 && layout.mainRight <= layout.innerWidth + 1, `main outside viewport for ${view.id}`, `${layout.mainLeft}/${layout.mainRight}`);
     assert(layout.navBoxSizing === 'border-box', `product shell does not own border-box sizing for ${view.id}`, layout.navBoxSizing);
     assert(layout.stylesheets.includes('/assets/shell.css'), `product shell stylesheet missing for ${view.id}`, layout.stylesheets.join(','));
+    assert(layout.stylesheets.includes('/assets/ui-system.css'), `shared UI stylesheet missing for ${view.id}`, layout.stylesheets.join(','));
     assert(layout.injectedHarnessStyles === 0, `test harness style detected for ${view.id}`);
     assert(await checkSkipLink(page), `skip link did not focus main for ${view.id}`);
     if (viewport.id === 'mobile' && view.id === 'dashboard') await checkMobileNavigation(page);
@@ -330,7 +331,7 @@ async function runView(browser, origin, viewport, view, baseline) {
       view: view.id,
       path: view.path,
       assetPaths: [...diagnostics.assets.keys()].sort(),
-      checks: 10 + (viewport.id === 'mobile' && view.id === 'dashboard' ? 3 : 0),
+      checks: 11 + (viewport.id === 'mobile' && view.id === 'dashboard' ? 3 : 0),
     };
   } finally {
     await context.close();

--- a/scripts/build-static.mjs
+++ b/scripts/build-static.mjs
@@ -5,7 +5,7 @@ import ejs from 'ejs';
 const ROOT = process.cwd();
 const VIEWS = join(ROOT, 'src', 'views');
 const OUT = join(ROOT, 'dist', 'site');
-const STATIC_ASSETS = ['shell.css', 'shell.mjs'];
+const STATIC_ASSETS = ['shell.css', 'ui-system.css', 'shell.mjs'];
 
 const STATIC_MIRROR_SUPPORTED_ROUTES = [
   { route: '/', output: 'index.html', view: 'index', reason: 'static landing page' },

--- a/src/public/ui-system.css
+++ b/src/public/ui-system.css
@@ -1,0 +1,363 @@
+:root {
+  --ui-bg: #0a0e1a;
+  --ui-bg-surface: rgba(17, 24, 39, 0.88);
+  --ui-bg-subtle: rgba(255, 255, 255, 0.04);
+  --ui-border: rgba(255, 255, 255, 0.08);
+  --ui-border-strong: rgba(255, 255, 255, 0.14);
+  --ui-text: #f1f5f9;
+  --ui-text-secondary: #94a3b8;
+  --ui-text-muted: #64748b;
+  --ui-accent: #3b82f6;
+  --ui-accent-soft: #60a5fa;
+  --ui-ok: #22c55e;
+  --ui-warn: #f59e0b;
+  --ui-fail: #ef4444;
+  --ui-code: #dbeafe;
+  --ui-radius: 14px;
+  --ui-focus: #60a5fa;
+  --ui-font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, sans-serif;
+  --ui-font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+
+  /* Transitional aliases for view-specific rules during the shared-system migration. */
+  --bg-primary: var(--ui-bg);
+  --bg-secondary: #111827;
+  --bg-card: var(--ui-bg-surface);
+  --bg-glass: var(--ui-bg-subtle);
+  --border-glass: var(--ui-border);
+  --text-primary: var(--ui-text);
+  --text-secondary: var(--ui-text-secondary);
+  --text-muted: var(--ui-text-muted);
+  --accent: var(--ui-accent);
+  --ok: var(--ui-ok);
+  --warn: var(--ui-warn);
+  --fail: var(--ui-fail);
+  --unknown: var(--ui-text-muted);
+}
+* ,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+.dashboard-view *,
+.dashboard-view *::before,
+.dashboard-view *::after {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--ui-bg);
+  color: var(--ui-text);
+  font-family: var(--ui-font-sans);
+}
+
+main {
+  width: min(100%, 1180px);
+  margin: 0 auto;
+  padding: 42px 24px 80px;
+}
+
+main.ui-main--compact {
+  max-width: 1080px;
+  padding: 48px 24px 96px;
+}
+
+main.ui-main--wide {
+  max-width: 1600px;
+}
+
+h1,
+h2 {
+  letter-spacing: -0.02em;
+}
+
+h1 {
+  margin-top: 0;
+  margin-bottom: 10px;
+  font-size: 1.9em;
+}
+
+.page-header {
+  margin-bottom: 24px;
+}
+
+.page-header h1 {
+  margin-top: 0;
+}
+
+.subtitle,
+.muted,
+.ui-muted {
+  color: var(--ui-text-secondary);
+  line-height: 1.55;
+}
+
+.ui-section-title {
+  margin: 0 0 16px;
+  color: var(--ui-text-muted);
+  font-size: 0.72em;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.notice,
+.card,
+.panel,
+.meta-item,
+.metric,
+.truth-banner,
+.info-card {
+  border: 1px solid var(--ui-border);
+  border-radius: var(--ui-radius);
+  background: var(--ui-bg-surface);
+}
+
+.notice,
+.card,
+.panel,
+.truth-banner,
+.info-card {
+  padding: 20px 22px;
+  margin-bottom: 18px;
+}
+
+.notice strong {
+  color: var(--ui-accent-soft);
+}
+
+.meta-grid,
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 12px;
+  margin: 22px 0;
+}
+
+.metrics {
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: 14px;
+}
+
+.meta-item,
+.metric {
+  min-width: 0;
+  padding: 18px 20px;
+  margin: 0;
+}
+
+.label {
+  margin-bottom: 5px;
+  color: var(--ui-text-muted);
+  font-size: 0.72em;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.value,
+code,
+.mono {
+  font-family: var(--ui-font-mono);
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.value {
+  font-size: 0.82em;
+}
+
+code {
+  color: var(--ui-code);
+}
+
+ul {
+  margin-left: 20px;
+}
+
+.table-wrap {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.84em;
+}
+
+th,
+td {
+  padding: 10px 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+  text-align: left;
+  vertical-align: top;
+}
+
+th {
+  color: var(--ui-text-muted);
+  font-size: 0.78em;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.pill,
+.ui-pill,
+.state-badge,
+.truth,
+.source-pill,
+.freshness-pill {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  padding: 3px 9px;
+  border: 1px solid var(--ui-border-strong);
+  border-radius: 999px;
+  font-size: 0.78em;
+}
+
+.fresh,
+.status-ok,
+.ok,
+.truth-observed,
+.r-retained {
+  color: var(--ui-ok);
+}
+
+.stale,
+.status-warn,
+.status-unknown,
+.warn,
+.truth-estimated,
+.r-archivable,
+.sprawl-warn,
+.k-fixture .value,
+.source-fixture {
+  color: var(--ui-warn);
+}
+
+.status-fail,
+.bad,
+.truth-unavailable,
+.r-orphan,
+.k-missing .value,
+.source-missing,
+.source-corrupt {
+  color: var(--ui-fail);
+}
+
+.fr-unknown,
+.r-unknown {
+  color: var(--ui-text-muted);
+}
+
+.ui-action,
+.map-action {
+  min-height: 44px;
+  padding: 9px 13px;
+  border: 1px solid rgba(96, 165, 250, 0.55);
+  border-radius: 9px;
+  background: rgba(59, 130, 246, 0.18);
+  color: var(--ui-code);
+  font: inherit;
+  cursor: pointer;
+}
+
+.ui-action:hover,
+.map-action:hover {
+  background: rgba(59, 130, 246, 0.28);
+}
+
+:where(a, button, summary, [tabindex]:not([tabindex="-1"])):focus-visible {
+  outline: 2px solid var(--ui-focus);
+  outline-offset: 2px;
+}
+
+.ui-caption {
+  color: var(--ui-text-secondary);
+  font-size: 0.75em;
+}
+
+.ui-detail {
+  font-size: 0.85em;
+}
+
+.ui-provenance {
+  padding: 0;
+  overflow: hidden;
+}
+
+.ui-provenance > summary {
+  padding: 18px 22px;
+  color: var(--ui-code);
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.ui-provenance > summary:hover {
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.ui-provenance__content {
+  padding: 0 22px 22px;
+}
+
+.ui-provenance__content > :last-child {
+  margin-bottom: 0;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 720px) {
+  main,
+  main.ui-main--compact,
+  main.ui-main--wide {
+    padding: 28px 14px 60px;
+  }
+
+  h1 {
+    font-size: 1.5em;
+  }
+
+  .notice,
+  .card,
+  .panel,
+  .truth-banner,
+  .info-card {
+    padding: 16px;
+  }
+
+  .meta-grid,
+  .metrics {
+    grid-template-columns: 1fr;
+  }
+
+  .ui-provenance > summary {
+    padding: 16px;
+  }
+
+  .ui-provenance__content {
+    padding: 0 16px 16px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ui-action,
+  .map-action,
+  .source-card,
+  .attention-item a {
+    transition: none !important;
+    transform: none !important;
+  }
+}

--- a/src/views/_ui-head.ejs
+++ b/src/views/_ui-head.ejs
@@ -1,0 +1,2 @@
+<link rel="stylesheet" href="/assets/shell.css">
+<link rel="stylesheet" href="/assets/ui-system.css">

--- a/src/views/bureau.ejs
+++ b/src/views/bureau.ejs
@@ -5,39 +5,26 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <style>
-    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0a0e1a; color: #f1f5f9; margin: 0; }
-    main { max-width: 1180px; margin: 0 auto; padding: 42px 24px 80px; }
-    .subtitle, .muted { color: #94a3b8; line-height: 1.55; }
-    .notice, .meta-item, .card { background: rgba(17,24,39,.88); border: 1px solid rgba(255,255,255,.08); border-radius: 14px; padding: 20px 22px; margin-bottom: 18px; }
-    .notice strong { color: #3b82f6; }
-    .meta-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 12px; margin: 22px 0; }
-    .label { color: #64748b; font-size: .72em; text-transform: uppercase; letter-spacing: .08em; margin-bottom: 5px; }
-    .value { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .82em; overflow-wrap: anywhere; }
     .board { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 14px; }
-    .column { background: rgba(17,24,39,.6); border: 1px solid rgba(255,255,255,.08); border-radius: 12px; padding: 12px; }
+    .column { background: rgba(17,24,39,.6); border: 1px solid var(--ui-border); border-radius: 12px; padding: 12px; }
     .column h3 { font-size: .8em; margin: 0 0 10px; display: flex; justify-content: space-between; }
-    .count { color: #64748b; font-weight: 400; }
+    .count { color: var(--ui-text-muted); font-weight: 400; }
     .task { background: rgba(255,255,255,.03); border: 1px solid rgba(255,255,255,.07); border-left-width: 3px; border-radius: 8px; padding: 10px 12px; margin-bottom: 8px; }
     .task .t-title { font-size: .88em; font-weight: 600; margin-bottom: 4px; }
-    .task .t-meta { font-size: .72em; color: #64748b; font-family: ui-monospace, monospace; overflow-wrap: anywhere; }
-    .task .t-note { font-size: .74em; color: #94a3b8; margin-top: 5px; }
-    .st-queued { border-left-color: #64748b; }
-    .st-claimed { border-left-color: #3b82f6; }
-    .st-running { border-left-color: #22c55e; }
-    .st-blocked { border-left-color: #f59e0b; }
+    .task .t-meta { font-size: .72em; color: var(--ui-text-muted); font-family: var(--ui-font-mono); overflow-wrap: anywhere; }
+    .task .t-note { font-size: .74em; color: var(--ui-text-secondary); margin-top: 5px; }
+    .st-queued { border-left-color: var(--ui-text-muted); }
+    .st-claimed { border-left-color: var(--ui-accent); }
+    .st-running { border-left-color: var(--ui-ok); }
+    .st-blocked { border-left-color: var(--ui-warn); }
     .st-done { border-left-color: #16a34a; }
-    .st-failed { border-left-color: #ef4444; }
+    .st-failed { border-left-color: var(--ui-fail); }
     .st-unknown { border-left-color: #475569; }
-    .fresh { color: #22c55e; } .stale { color: #f59e0b; } .fr-unknown { color: #64748b; }
-    .k-missing .value { color: #ef4444; }
-    .k-fixture .value { color: #f59e0b; }
-    code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: #dbeafe; }
-    ul { margin-left: 20px; color: #94a3b8; }
   </style>
-  <link rel="stylesheet" href="/assets/shell.css">
+  <%- include('_ui-head') %>
   <script type="module" src="/assets/shell.mjs"></script>
 </head>
-<body>
+<body class="bureau-view">
   <%- include('_nav') %>
 
   <main>
@@ -48,14 +35,6 @@
       <strong>View only.</strong> Der Task-Zustand stammt aus einem Snapshot-Artefakt eines separaten Producers. Fällt Leitstand aus, läuft die Ausführungswahrheit ungestört weiter.
     </section>
 
-    <section class="meta-grid" aria-label="Bureau source metadata">
-      <div class="meta-item <%= view_meta.source_kind === 'artifact' ? '' : view_meta.source_kind === 'fixture' ? 'k-fixture' : 'k-missing' %>"><div class="label">Source state</div><div class="value"><%= view_meta.source_kind %> / <%= view_meta.missing_reason %></div></div>
-      <div class="meta-item"><div class="label">Generated</div><div class="value"><%= view_meta.generated_at || '—' %></div></div>
-      <div class="meta-item"><div class="label">Freshness</div><div class="value <%= view_meta.freshness_state === 'fresh' ? 'fresh' : view_meta.freshness_state === 'stale' ? 'stale' : 'fr-unknown' %>"><%= view_meta.freshness_state %></div></div>
-      <div class="meta-item"><div class="label">Tasks</div><div class="value"><%= view_meta.task_count %></div></div>
-      <div class="meta-item"><div class="label">Offen</div><div class="value"><%= view_meta.open_count %></div></div>
-      <div class="meta-item"><div class="label">Blocked / Failed</div><div class="value"><%= view_meta.blocked_count %> / <%= view_meta.failed_count %></div></div>
-    </section>
 
     <% if (view_meta.source_kind === 'fixture') { %>
       <section class="card"><p class="muted">Fixture-Fallback aktiv (<code><%= view_meta.missing_reason %></code>). Dies ist Demo-/Preview-Datenmaterial, kein operativer grüner Status. Pfad: <code><%= view_meta.source_path_display %></code></p></section>
@@ -75,10 +54,24 @@
               <% if (task.receipt_ref) { %><div class="t-meta">receipt: <%= task.receipt_ref %></div><% } %>
             </div>
           <% }); %>
-          <% if (col.tasks.length === 0) { %><p class="muted" style="font-size:.75em;">—</p><% } %>
+          <% if (col.tasks.length === 0) { %><p class="ui-caption">—</p><% } %>
         </div>
       <% }); %>
     </section>
+
+    <details class="card ui-provenance">
+      <summary>Quelle und Aktualität: <%= view_meta.source_kind %> · <%= view_meta.freshness_state %></summary>
+      <div class="ui-provenance__content">
+        <section class="meta-grid" aria-label="Bureau source metadata">
+          <div class="meta-item <%= view_meta.source_kind === 'artifact' ? '' : view_meta.source_kind === 'fixture' ? 'k-fixture' : 'k-missing' %>"><div class="label">Source state</div><div class="value"><%= view_meta.source_kind %> / <%= view_meta.missing_reason %></div></div>
+          <div class="meta-item"><div class="label">Generated</div><div class="value"><%= view_meta.generated_at || '—' %></div></div>
+          <div class="meta-item"><div class="label">Freshness</div><div class="value <%= view_meta.freshness_state === 'fresh' ? 'fresh' : view_meta.freshness_state === 'stale' ? 'stale' : 'fr-unknown' %>"><%= view_meta.freshness_state %></div></div>
+          <div class="meta-item"><div class="label">Tasks</div><div class="value"><%= view_meta.task_count %></div></div>
+          <div class="meta-item"><div class="label">Offen</div><div class="value"><%= view_meta.open_count %></div></div>
+          <div class="meta-item"><div class="label">Blocked / Failed</div><div class="value"><%= view_meta.blocked_count %> / <%= view_meta.failed_count %></div></div>
+        </section>
+      </div>
+    </details>
 
     <section class="card">
       <h2>Does not establish</h2>

--- a/src/views/checkouts.ejs
+++ b/src/views/checkouts.ejs
@@ -5,37 +5,18 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <style>
-    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0a0e1a; color: #f1f5f9; margin: 0; }
-    main { max-width: 1180px; margin: 0 auto; padding: 42px 24px 80px; }
-    .subtitle, .muted { color: #94a3b8; line-height: 1.55; }
-    .notice, .meta-item, .card { background: rgba(17,24,39,.88); border: 1px solid rgba(255,255,255,.08); border-radius: 14px; padding: 20px 22px; margin-bottom: 18px; }
-    .notice strong { color: #3b82f6; }
-    .meta-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; margin: 22px 0; }
-    .label { color: #64748b; font-size: .72em; text-transform: uppercase; letter-spacing: .08em; margin-bottom: 5px; }
-    .value { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .82em; overflow-wrap: anywhere; }
-    .table-wrap { overflow-x: auto; }
-    table { border-collapse: collapse; width: 100%; font-size: .82em; }
-    th, td { text-align: left; padding: 9px 12px; border-bottom: 1px solid rgba(255,255,255,.07); vertical-align: top; }
-    th { color: #64748b; font-size: .82em; text-transform: uppercase; letter-spacing: .06em; }
-    td.path { font-family: ui-monospace, monospace; overflow-wrap: anywhere; max-width: 380px; }
-    .pill { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: .9em; border: 1px solid transparent; }
-    .r-orphan { color: #ef4444; border-color: rgba(239,68,68,.3); }
-    .r-archivable { color: #f59e0b; border-color: rgba(245,158,11,.3); }
-    .r-retained { color: #22c55e; border-color: rgba(34,197,94,.3); }
-    .r-unknown { color: #64748b; border-color: rgba(100,116,139,.3); }
-    .flag { color: #94a3b8; font-family: ui-monospace, monospace; }
-    .flag.on { color: #3b82f6; }
-    .fresh { color: #22c55e; } .stale { color: #f59e0b; } .fr-unknown { color: #64748b; }
-    .k-missing .value { color: #ef4444; }
-    .k-fixture .value { color: #f59e0b; }
-    .sprawl-warn { color: #f59e0b; }
-    code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: #dbeafe; }
-    ul { margin-left: 20px; color: #94a3b8; }
+    td.path { font-family: var(--ui-font-mono); overflow-wrap: anywhere; max-width: 380px; }
+    .r-orphan { border-color: rgba(239,68,68,.3); }
+    .r-archivable { border-color: rgba(245,158,11,.3); }
+    .r-retained { border-color: rgba(34,197,94,.3); }
+    .r-unknown { border-color: rgba(100,116,139,.3); }
+    .flag { color: var(--ui-text-secondary); font-family: var(--ui-font-mono); }
+    .flag.on { color: var(--ui-accent); }
   </style>
-  <link rel="stylesheet" href="/assets/shell.css">
+  <%- include('_ui-head') %>
   <script type="module" src="/assets/shell.mjs"></script>
 </head>
-<body>
+<body class="checkouts-view">
   <%- include('_nav') %>
 
   <main>
@@ -46,14 +27,6 @@
       <strong>View only.</strong> Retention-/Cleanup-Entscheidungen gehören Grabowski. Leitstand liest ein Snapshot-Artefakt und stellt es dar.
     </section>
 
-    <section class="meta-grid" aria-label="Checkout source metadata">
-      <div class="meta-item <%= view_meta.source_kind === 'artifact' ? '' : view_meta.source_kind === 'fixture' ? 'k-fixture' : 'k-missing' %>"><div class="label">Source state</div><div class="value"><%= view_meta.source_kind %> / <%= view_meta.missing_reason %></div></div>
-      <div class="meta-item"><div class="label">Generated</div><div class="value"><%= view_meta.generated_at || '—' %></div></div>
-      <div class="meta-item"><div class="label">Freshness</div><div class="value <%= view_meta.freshness_state === 'fresh' ? 'fresh' : view_meta.freshness_state === 'stale' ? 'stale' : 'fr-unknown' %>"><%= view_meta.freshness_state %></div></div>
-      <div class="meta-item"><div class="label">Checkouts</div><div class="value"><%= view_meta.checkout_count %></div></div>
-      <div class="meta-item"><div class="label">Retained / Archivable / Orphan</div><div class="value"><%= view_meta.retained_count %> / <%= view_meta.archivable_count %> / <%= view_meta.orphan_count %></div></div>
-      <div class="meta-item"><div class="label">Sprawl-Kandidaten</div><div class="value <%= view_meta.sprawl_count > 0 ? 'sprawl-warn' : '' %>"><%= view_meta.sprawl_count %></div></div>
-    </section>
 
     <% if (view_meta.source_kind === 'fixture') { %>
       <section class="card"><p class="muted">Fixture-Fallback aktiv (<code><%= view_meta.missing_reason %></code>). Dies ist Demo-/Preview-Datenmaterial, kein operativer grüner Status. Pfad: <code><%= view_meta.source_path_display %></code></p></section>
@@ -71,8 +44,8 @@
           <% checkouts.forEach(function(c) { %>
             <tr data-path="<%= c.path %>">
               <td><span class="pill r-<%= c.retention %>"><%= c.retention %></span></td>
-              <td class="path"><%= c.path %><% if (c.note) { %><div class="muted" style="font-size:.85em;"><%= c.note %></div><% } %></td>
-              <td><%= c.repo || '—' %><% if (c.branch) { %><div class="muted" style="font-size:.85em;"><%= c.branch %></div><% } %></td>
+              <td class="path"><%= c.path %><% if (c.note) { %><div class="muted ui-detail"><%= c.note %></div><% } %></td>
+              <td><%= c.repo || '—' %><% if (c.branch) { %><div class="muted ui-detail"><%= c.branch %></div><% } %></td>
               <td class="value"><%= c.head || '—' %></td>
               <td><span class="flag <%= c.has_process ? 'on' : '' %>"><%= c.has_process ? '●' : '○' %></span></td>
               <td><span class="flag <%= c.has_resource_lease ? 'on' : '' %>"><%= c.has_resource_lease ? '●' : '○' %></span></td>
@@ -83,6 +56,20 @@
       </table>
     </section>
     <% } %>
+
+    <details class="card ui-provenance">
+      <summary>Quelle, Aktualität und Inventarzählwerte</summary>
+      <div class="ui-provenance__content">
+        <section class="meta-grid" aria-label="Checkout source metadata">
+          <div class="meta-item <%= view_meta.source_kind === 'artifact' ? '' : view_meta.source_kind === 'fixture' ? 'k-fixture' : 'k-missing' %>"><div class="label">Source state</div><div class="value"><%= view_meta.source_kind %> / <%= view_meta.missing_reason %></div></div>
+          <div class="meta-item"><div class="label">Generated</div><div class="value"><%= view_meta.generated_at || '—' %></div></div>
+          <div class="meta-item"><div class="label">Freshness</div><div class="value <%= view_meta.freshness_state === 'fresh' ? 'fresh' : view_meta.freshness_state === 'stale' ? 'stale' : 'fr-unknown' %>"><%= view_meta.freshness_state %></div></div>
+          <div class="meta-item"><div class="label">Checkouts</div><div class="value"><%= view_meta.checkout_count %></div></div>
+          <div class="meta-item"><div class="label">Retained / Archivable / Orphan</div><div class="value"><%= view_meta.retained_count %> / <%= view_meta.archivable_count %> / <%= view_meta.orphan_count %></div></div>
+          <div class="meta-item"><div class="label">Sprawl-Kandidaten</div><div class="value <%= view_meta.sprawl_count > 0 ? 'sprawl-warn' : '' %>"><%= view_meta.sprawl_count %></div></div>
+        </section>
+      </div>
+    </details>
 
     <section class="card">
       <h2>Does not establish</h2>

--- a/src/views/ecosystem-map.ejs
+++ b/src/views/ecosystem-map.ejs
@@ -5,30 +5,16 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <style>
-    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0a0e1a; color: #f1f5f9; margin: 0; }
     body.map-fullscreen-open { overflow: hidden; }
-    a { color: #60a5fa; }
-    code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
-    main { max-width: 1600px; margin: 0 auto; padding: 42px 24px 80px; }
-    .page-header { margin-bottom: 20px; }
-    .page-header h1 { margin-top: 0; }
-    h1 { font-size: 1.9em; margin-bottom: 10px; }
-    h2 { margin-top: 0; }
-    .subtitle, .empty, .artifact-meta, li, summary { color: #94a3b8; line-height: 1.55; }
+    a { color: var(--ui-accent-soft); }
     .artifact-meta { min-width: 0; overflow-wrap: anywhere; }
-    .notice, .panel, .meta-item, .truth-banner { background: rgba(17,24,39,.88); border: 1px solid rgba(255,255,255,.08); border-radius: 14px; padding: 20px 22px; margin-bottom: 18px; }
-    .notice strong { color: #3b82f6; }
     .truth-banner { border-left-width: 5px; }
     .truth-banner strong { display: block; margin-bottom: 6px; }
     .truth-banner p { margin: 0; color: #cbd5e1; line-height: 1.55; }
-    .truth-banner[data-state="exact"] { border-left-color: #22c55e; }
-    .truth-banner[data-state="compatible"] { border-left-color: #60a5fa; }
-    .truth-banner[data-state="drifted"] { border-left-color: #ef4444; }
-    .truth-banner[data-state="unverifiable"] { border-left-color: #f59e0b; }
-    .meta-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; margin-bottom: 22px; }
-    .meta-item { margin-bottom: 0; }
-    .label { color: #64748b; font-size: .72em; text-transform: uppercase; letter-spacing: .08em; margin-bottom: 5px; }
-    .value { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .82em; overflow-wrap: anywhere; }
+    .truth-banner[data-state="exact"] { border-left-color: var(--ui-ok); }
+    .truth-banner[data-state="compatible"] { border-left-color: var(--ui-accent-soft); }
+    .truth-banner[data-state="drifted"] { border-left-color: var(--ui-fail); }
+    .truth-banner[data-state="unverifiable"] { border-left-color: var(--ui-warn); }
     .value[data-state="fresh"], .value[data-state="exact"] { color: #86efac; }
     .value[data-state="compatible"] { color: #93c5fd; }
     .value[data-state="stale"], .value[data-state="drifted"] { color: #fca5a5; }
@@ -37,9 +23,6 @@
     .map-header-copy { display: grid; gap: 6px; }
     .map-header-copy h2 { margin: 0; }
     .map-header-actions { display: flex; flex-wrap: wrap; gap: 10px; }
-    .map-action { border: 1px solid rgba(96,165,250,.55); border-radius: 9px; background: rgba(59,130,246,.18); color: #dbeafe; padding: 9px 13px; font: inherit; cursor: pointer; }
-    .map-action:hover { background: rgba(59,130,246,.28); }
-    .map-action:focus { outline: 2px solid #60a5fa; outline-offset: 2px; }
     .map-workspace { position: relative; }
     .map-workspace-toolbar { display: none; align-items: center; justify-content: space-between; gap: 16px; padding: 0 2px; }
     .map-workspace-title { font-weight: 700; }
@@ -50,36 +33,33 @@
     .map-workspace.is-map-fullscreen .map-canvas { min-height: 0; height: 100%; overflow: hidden; }
     .map-workspace.is-map-fullscreen .map-canvas svg { width: 100%; height: 100%; min-width: 0; max-height: none; }
     .source-details { padding: 0; overflow: hidden; }
-    .source-details > summary { padding: 18px 22px; font-weight: 700; color: #dbeafe; }
+    .source-details > summary { padding: 18px 22px; font-weight: 700; color: var(--ui-code); }
     .source-details > summary:hover { background: rgba(255,255,255,.025); }
     .source-details-content { padding: 0 22px 22px; }
     .source-details .notice { margin-top: 0; }
-    .render-status { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .78em; color: #94a3b8; }
+    .render-status { font-family: var(--ui-font-mono); font-size: .78em; color: var(--ui-text-secondary); }
     .render-status[data-state="ready"] { color: #86efac; }
     .render-status[data-state="warning"] { color: #fde68a; }
     .render-status[data-state="error"] { color: #fca5a5; }
-    .map-canvas { min-height: 620px; overflow: hidden; padding: 18px; background: rgba(2,6,23,.72); border: 1px solid rgba(255,255,255,.08); border-radius: 12px; }
-    .map-canvas[data-render-state="loading"] { display: grid; place-items: center; color: #64748b; }
+    .map-canvas { min-height: 620px; overflow: hidden; padding: 18px; background: rgba(2,6,23,.72); border: 1px solid var(--ui-border); border-radius: 12px; }
+    .map-canvas[data-render-state="loading"] { display: grid; place-items: center; color: var(--ui-text-muted); }
     .map-canvas svg { display: block; min-width: 980px; width: 100%; height: auto; margin: 0 auto; }
     .map-canvas g.node.navigable-node { cursor: pointer; }
     .map-canvas g.node.navigable-node:hover > rect,
     .map-canvas g.node.navigable-node:hover > polygon,
     .map-canvas g.node.navigable-node:focus > rect,
-    .map-canvas g.node.navigable-node:focus > polygon { stroke: #60a5fa !important; stroke-width: 3px !important; }
+    .map-canvas g.node.navigable-node:focus > polygon { stroke: var(--ui-accent-soft) !important; stroke-width: 3px !important; }
     .map-canvas g.node.navigable-node:focus { outline: none; }
     details { margin-top: 16px; }
     summary { cursor: pointer; }
-    pre { background: rgba(2,6,23,.72); color: #dbeafe; border: 1px solid rgba(255,255,255,.08); border-radius: 10px; padding: 16px; overflow: auto; font-size: .78em; line-height: 1.45; max-height: 520px; }
-    .link-note { margin: 0 0 14px; color: #94a3b8; line-height: 1.5; }
+    pre { background: rgba(2,6,23,.72); color: var(--ui-code); border: 1px solid var(--ui-border); border-radius: 10px; padding: 16px; overflow: auto; font-size: .78em; line-height: 1.45; max-height: 520px; }
+    .link-note { margin: 0 0 14px; color: var(--ui-text-secondary); line-height: 1.5; }
     @media (max-width: 1100px) {
       .map-workspace-content { grid-template-columns: 1fr; }
       .map-canvas { min-height: 520px; }
     }
     @media (max-width: 720px) {
-      main { padding: 28px 14px 60px; }
-      .notice, .panel, .meta-item, .truth-banner { padding: 16px; }
       .map-header-actions, .map-action { width: 100%; }
-      .map-action { min-height: 44px; }
       .map-workspace.is-map-fullscreen { padding: 10px; }
       .map-workspace.is-map-fullscreen .map-workspace-content { grid-template-rows: minmax(0, auto) minmax(260px, 1fr); overflow: auto; }
       .source-details { padding: 0; }
@@ -88,13 +68,13 @@
       .map-canvas { padding: 10px; min-height: 420px; }
     }
   </style>
-  <link rel="stylesheet" href="/assets/shell.css">
+  <%- include('_ui-head') %>
   <script type="module" src="/assets/shell.mjs"></script>
 </head>
-<body>
+<body class="ecosystem-map-view">
   <%- include('_nav') %>
 
-  <main>
+  <main class="ui-main--wide">
     <header class="page-header">
       <h1>Ökosystemkarte</h1>
       <p class="subtitle">Grafische, ausschließlich lesende Projektion der vom Systemkatalog verantworteten Ökosystemsemantik.</p>

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -11,65 +11,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Leitstand – Beobachtungs- und Verdichtungsmodul der Heimgewebe-Systeme.">
   <style>
-    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-
-    :root {
-      --bg-primary: #0a0e1a;
-      --bg-secondary: #111827;
-      --bg-card: rgba(17, 24, 39, 0.85);
-      --bg-glass: rgba(255, 255, 255, 0.04);
-      --border-glass: rgba(255, 255, 255, 0.08);
-      --text-primary: #f1f5f9;
-      --text-secondary: #94a3b8;
-      --text-muted: #64748b;
-      --accent: #3b82f6;
-      --ok: #22c55e;
-      --warn: #f59e0b;
-      --fail: #ef4444;
-      --unknown: #64748b;
-    }
-
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
-      background: var(--bg-primary);
-      color: var(--text-primary);
-      min-height: 100vh;
-    }
-
-    .main {
-      max-width: 1080px;
-      margin: 0 auto;
-      padding: 48px 24px 96px;
-    }
-
-    .page-header {
-      margin-bottom: 30px;
-    }
-
-    .page-header h1 {
-      font-size: 1.9em;
-      font-weight: 700;
-      letter-spacing: -0.02em;
-      margin-bottom: 10px;
-    }
-
-    .page-header .subtitle {
-      color: var(--text-secondary);
-      font-size: 0.95em;
-      max-width: 720px;
-      line-height: 1.55;
-    }
-
-    .section-title {
-      font-size: 0.72em;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.1em;
-      color: var(--text-muted);
-      margin-bottom: 16px;
-    }
-
-    .situation {
+.situation {
       display: grid;
       gap: 20px;
       padding: 24px;
@@ -104,19 +46,7 @@
       font-size: 1.25em;
       line-height: 1.35;
     }
-
-    .state-badge {
-      flex: 0 0 auto;
-      display: inline-flex;
-      align-items: center;
-      padding: 6px 11px;
-      border: 1px solid currentColor;
-      border-radius: 999px;
-      font-size: 0.76em;
-      font-weight: 700;
-    }
-
-    .situation-healthy .state-badge { color: var(--ok); }
+.situation-healthy .state-badge { color: var(--ok); }
     .situation-attention .state-badge { color: var(--warn); }
     .situation-critical .state-badge { color: var(--fail); }
 
@@ -279,21 +209,7 @@
       font-size: 0.72em;
       color: var(--text-muted);
     }
-
-    .source-pill,
-    .freshness-pill {
-      display: inline-flex;
-      align-items: center;
-      gap: 4px;
-      padding: 2px 8px;
-      border-radius: 10px;
-      border: 1px solid var(--border-glass);
-      background: var(--bg-glass);
-      font-weight: 500;
-      letter-spacing: 0.02em;
-    }
-
-    .source-pill.source-artifact { color: var(--ok); border-color: rgba(34, 197, 94, 0.25); }
+.source-pill.source-artifact { color: var(--ok); border-color: rgba(34, 197, 94, 0.25); }
     .source-pill.source-fixture { color: var(--warn); border-color: rgba(245, 158, 11, 0.25); }
     .source-pill.source-missing,
     .source-pill.source-error,
@@ -346,26 +262,14 @@
       .attention-item a { grid-template-columns: auto 1fr; }
       .attention-arrow { display: none; }
     }
-
-    .sr-only {
-      position: absolute;
-      width: 1px;
-      height: 1px;
-      padding: 0;
-      margin: -1px;
-      overflow: hidden;
-      clip: rect(0, 0, 0, 0);
-      white-space: nowrap;
-      border: 0;
-    }
   </style>
-  <link rel="stylesheet" href="/assets/shell.css">
+  <%- include('_ui-head') %>
   <script type="module" src="/assets/shell.mjs"></script>
 </head>
-<body>
+<body class="dashboard-view">
   <%- include('_nav') %>
 
-  <main class="main" id="main">
+  <main class="main ui-main--compact" id="main">
     <header class="page-header">
       <h1>Leitstand</h1>
       <p class="subtitle">
@@ -434,7 +338,7 @@
     <% } %>
 
     <section aria-labelledby="quellen-heading">
-      <h2 id="quellen-heading" class="section-title">Operative Quellen</h2>
+      <h2 id="quellen-heading" class="section-title ui-section-title">Operative Quellen</h2>
 
       <% if (sourceCards.length === 0) { %>
         <div class="info-card" role="status">

--- a/src/views/repobriefs.ejs
+++ b/src/views/repobriefs.ejs
@@ -4,25 +4,10 @@
   <title>RepoGround – Leitstand</title>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <style>
-    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0a0e1a; color: #f1f5f9; margin: 0; }
-    main { max-width: 1180px; margin: 0 auto; padding: 42px 24px 80px; }
-    .subtitle, .muted, li { color: #94a3b8; line-height: 1.55; }
-    .notice, .card, .meta-item { background: rgba(17,24,39,.88); border: 1px solid rgba(255,255,255,.08); border-radius: 14px; padding: 20px 22px; margin-bottom: 18px; }
-    .notice strong { color: #3b82f6; }
-    .meta-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; margin: 22px 0; }
-    .label { color: #64748b; font-size: .72em; text-transform: uppercase; letter-spacing: .08em; margin-bottom: 5px; }
-    .value { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .82em; overflow-wrap: anywhere; }
-    .status-ok { color: #22c55e; }
-    .status-warn, .status-unknown { color: #f59e0b; }
-    .status-fail { color: #ef4444; }
-    code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: #dbeafe; overflow-wrap: anywhere; word-break: break-word; }
-    ul { margin-left: 20px; }
-  </style>
-  <link rel="stylesheet" href="/assets/shell.css">
+  <%- include('_ui-head') %>
   <script type="module" src="/assets/shell.mjs"></script>
 </head>
-<body>
+<body class="repoground-view">
   <%- include('_nav') %>
 
   <main>
@@ -33,14 +18,6 @@
       <strong>View only.</strong> Local bundle paths are operator pointers. Export-safety failures must remain visible and block public-share framing.
     </section>
 
-    <section class="meta-grid" aria-label="RepoGround source metadata">
-      <div class="meta-item"><div class="label">Source state</div><div class="value"><%= view_meta.source_kind %> / <%= view_meta.missing_reason %></div></div>
-      <div class="meta-item"><div class="label">Source path</div><div class="value"><%= view_meta.source_path %></div></div>
-      <div class="meta-item"><div class="label">Generated</div><div class="value"><%= view_meta.generated_at || '—' %></div></div>
-      <div class="meta-item"><div class="label">Bundles</div><div class="value"><%= view_meta.bundle_count %></div></div>
-      <div class="meta-item"><div class="label">Public export ready</div><div class="value"><%= view_meta.public_export_ready_count %></div></div>
-      <div class="meta-item"><div class="label">Warnings</div><div class="value"><%= view_meta.warning_count %></div></div>
-    </section>
 
     <% if (bundles.length === 0) { %>
       <section class="card"><p class="muted">No RepoGround bundle index is available. This is a degraded read-only state, not a green status.</p></section>
@@ -76,6 +53,20 @@
         <% } %>
       </section>
     <% } %>
+
+    <details class="card ui-provenance">
+      <summary>Quelle und Bundle-Zählwerte</summary>
+      <div class="ui-provenance__content">
+        <section class="meta-grid" aria-label="RepoGround source metadata">
+          <div class="meta-item"><div class="label">Source state</div><div class="value"><%= view_meta.source_kind %> / <%= view_meta.missing_reason %></div></div>
+          <div class="meta-item"><div class="label">Source path</div><div class="value"><%= view_meta.source_path %></div></div>
+          <div class="meta-item"><div class="label">Generated</div><div class="value"><%= view_meta.generated_at || '—' %></div></div>
+          <div class="meta-item"><div class="label">Bundles</div><div class="value"><%= view_meta.bundle_count %></div></div>
+          <div class="meta-item"><div class="label">Public export ready</div><div class="value"><%= view_meta.public_export_ready_count %></div></div>
+          <div class="meta-item"><div class="label">Warnings</div><div class="value"><%= view_meta.warning_count %></div></div>
+        </section>
+      </div>
+    </details>
 
     <section class="card">
       <h2>Does not establish</h2>

--- a/src/views/storage-health.ejs
+++ b/src/views/storage-health.ejs
@@ -19,37 +19,19 @@ const statusClass = (status) => ['critical', 'hard_limit'].includes(status) ? 'b
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <style>
-    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0a0e1a; color: #f1f5f9; margin: 0; }
-    main { max-width: 1180px; margin: 0 auto; padding: 42px 24px 80px; }
-    h1, h2 { letter-spacing: -.02em; }
-    .subtitle, .muted { color: #94a3b8; line-height: 1.55; }
-    .notice, .card, .metric { background: rgba(17,24,39,.88); border: 1px solid rgba(255,255,255,.08); border-radius: 14px; }
-    .notice, .card { padding: 20px 22px; margin-bottom: 18px; }
-    .notice strong { color: #60a5fa; }
-    .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap: 14px; margin: 22px 0; }
-    .metric { padding: 18px 20px; }
-    .label { color: #64748b; font-size: .72em; text-transform: uppercase; letter-spacing: .08em; margin-bottom: 7px; }
-    .value { font-size: 1.35em; font-weight: 650; overflow-wrap: anywhere; }
-    .detail { color: #94a3b8; font-size: .82em; margin-top: 7px; }
-    .truth { display: inline-block; margin-top: 8px; padding: 2px 8px; border-radius: 999px; font-size: .72em; border: 1px solid rgba(255,255,255,.14); }
-    .truth-observed { color: #22c55e; } .truth-estimated { color: #f59e0b; } .truth-unavailable { color: #ef4444; }
-    .ok { color: #22c55e; } .warn { color: #f59e0b; } .bad { color: #ef4444; }
+    .metric .value { font-size: 1.35em; font-weight: 650; }
+    .detail { color: var(--ui-text-secondary); font-size: .82em; margin-top: 7px; }
     .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(330px, 1fr)); gap: 18px; }
-    .table-wrap { overflow-x: auto; }
-    table { width: 100%; border-collapse: collapse; font-size: .84em; }
-    th, td { text-align: left; padding: 10px 12px; border-bottom: 1px solid rgba(255,255,255,.07); vertical-align: top; }
-    th { color: #64748b; font-size: .78em; text-transform: uppercase; letter-spacing: .06em; }
-    code, .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; overflow-wrap: anywhere; }
-    ul { margin: 10px 0 0 20px; padding: 0; }
-    li { margin: 8px 0; color: #cbd5e1; }
-    .empty { color: #64748b; font-style: italic; }
-    .source-fixture { color: #f59e0b; } .source-missing, .source-corrupt { color: #ef4444; }
-    .pill { display: inline-block; padding: 2px 8px; border: 1px solid rgba(255,255,255,.12); border-radius: 999px; font-size: .78em; }
+    .empty { color: var(--ui-text-muted); font-style: italic; }
+    .storage-view li { margin: 8px 0; color: #cbd5e1; }
+    @media (max-width: 720px) {
+      .grid { grid-template-columns: 1fr; }
+    }
   </style>
-  <link rel="stylesheet" href="/assets/shell.css">
+  <%- include('_ui-head') %>
   <script type="module" src="/assets/shell.mjs"></script>
 </head>
-<body>
+<body class="storage-view">
   <%- include('_nav') %>
   <main>
     <h1>Speicherzustand</h1>

--- a/tests/sharedUiSystem.test.ts
+++ b/tests/sharedUiSystem.test.ts
@@ -1,0 +1,74 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = process.cwd();
+const VIEWS = [
+  'index.ejs',
+  'bureau.ejs',
+  'checkouts.ejs',
+  'repobriefs.ejs',
+  'storage-health.ejs',
+  'ecosystem-map.ejs',
+] as const;
+
+async function readView(name: (typeof VIEWS)[number]): Promise<string> {
+  return readFile(join(ROOT, 'src', 'views', name), 'utf-8');
+}
+
+function inlineCss(view: string): string {
+  return [...view.matchAll(/<style>([\s\S]*?)<\/style>/g)].map((match) => match[1]).join('\n');
+}
+
+describe('LSV-V1-T008 shared UI system', () => {
+  it('loads the shared shell and UI assets through one versioned head partial', async () => {
+    const head = await readFile(join(ROOT, 'src', 'views', '_ui-head.ejs'), 'utf-8');
+    expect(head).toContain('/assets/shell.css');
+    expect(head).toContain('/assets/ui-system.css');
+    expect(head.indexOf('/assets/shell.css')).toBeLessThan(head.indexOf('/assets/ui-system.css'));
+
+    for (const name of VIEWS) {
+      const view = await readView(name);
+      expect(view).toContain("include('_ui-head')");
+      expect(view).not.toContain('href="/assets/shell.css"');
+      expect(view).not.toMatch(/style="[^"]+"/);
+    }
+  });
+
+  it('keeps shared foundations out of view-specific style blocks', async () => {
+    for (const name of VIEWS) {
+      const css = inlineCss(await readView(name));
+      expect(css, name).not.toMatch(/(^|\n)\s*body\s*\{/);
+      expect(css, name).not.toMatch(/(^|\n)\s*main\s*\{/);
+      expect(css, name).not.toMatch(/(^|\n)\s*\.meta-grid\s*\{/);
+      expect(css, name).not.toMatch(/(^|\n)\s*\.label\s*\{/);
+    }
+    expect(inlineCss(await readView('repobriefs.ejs'))).toBe('');
+  });
+
+  it('defines focus, action sizing, responsive and reduced-motion contracts centrally', async () => {
+    const css = await readFile(join(ROOT, 'src', 'public', 'ui-system.css'), 'utf-8');
+    expect(css).toContain('--ui-bg:');
+    expect(css).toContain('--ui-border:');
+    expect(css).toContain(':focus-visible');
+    expect(css).toContain('min-height: 44px');
+    expect(css).toContain('@media (max-width: 720px)');
+    expect(css).toContain('@media (prefers-reduced-motion: reduce)');
+    expect(css).toContain('.ui-provenance');
+  });
+
+  it('places primary operational content before collapsible technical provenance', async () => {
+    const cases = [
+      ['bureau.ejs', '<section class="board"'],
+      ['checkouts.ejs', '<section class="card table-wrap"'],
+      ['repobriefs.ejs', 'data-repo="<%= bundle.repo %>"'],
+    ] as const;
+
+    for (const [name, marker] of cases) {
+      const view = await readView(name);
+      expect(view.indexOf(marker), name).toBeGreaterThan(-1);
+      expect(view.indexOf('.ui-provenance'), name).toBe(-1);
+      expect(view.indexOf('ui-provenance'), name).toBeGreaterThan(view.indexOf(marker));
+    }
+  });
+});

--- a/tests/views/navigation.test.ts
+++ b/tests/views/navigation.test.ts
@@ -23,6 +23,7 @@ const navViews = [
 
 const viewsRoot = join(process.cwd(), 'src', 'views');
 const navPartial = join(viewsRoot, '_nav.ejs');
+const uiHeadPartial = join(viewsRoot, '_ui-head.ejs');
 
 function readView(file: string): string {
   return readFileSync(join(viewsRoot, file), 'utf-8');
@@ -36,10 +37,18 @@ describe('canonical navigation parity', () => {
   it.each(navViews)('%s consumes only the shared shell navigation', (file) => {
     const view = readView(file);
     expect(view).toContain("<%- include('_nav') %>");
-    expect(view).toContain('href="/assets/shell.css"');
+    expect(view).toContain("<%- include('_ui-head') %>");
+    expect(view).not.toContain('href="/assets/shell.css"');
     expect(view).toContain('src="/assets/shell.mjs"');
     expect(view).not.toContain('<nav aria-label="Hauptnavigation">');
     expect(inlineStyles(view)).not.toMatch(/(^|\n)\s*nav(?:\s|[.#:[>+~])/m);
+  });
+
+  it('the shared UI head owns the ordered product stylesheet contract', () => {
+    const partial = readFileSync(uiHeadPartial, 'utf-8');
+    expect(partial).toContain('href="/assets/shell.css"');
+    expect(partial).toContain('href="/assets/ui-system.css"');
+    expect(partial.indexOf('/assets/shell.css')).toBeLessThan(partial.indexOf('/assets/ui-system.css'));
   });
 
   it('the shared partial exposes the canonical read-only route set', () => {
@@ -96,7 +105,7 @@ describe('canonical navigation parity', () => {
   it('copies the shared shell and emits the bounded static route manifest', () => {
     const buildScript = readFileSync(join(process.cwd(), 'scripts', 'build-static.mjs'), 'utf-8');
 
-    expect(buildScript).toMatch(/const STATIC_ASSETS = \[['"]shell\.css['"], ['"]shell\.mjs['"]\]/);
+    expect(buildScript).toContain("const STATIC_ASSETS = ['shell.css', 'ui-system.css', 'shell.mjs'];");
     expect(buildScript).toMatch(/copyFile\(join\(ROOT, ['"]src['"], ['"]public['"], name\), join\(assetsOut, name\)\)/);
     expect(buildScript).toContain('await copyStaticAssets()');
     expect(buildScript).toMatch(/currentPath:\s*['"]\/['"]/);


### PR DESCRIPTION
## Zweck

Implementiert LSV-V1-T008 als kleine gemeinsame, versionierte und weiterhin strikt read-only Leitstand-UI-Schicht.

## Änderungen

- gemeinsame UI-Tokens, Oberflächen, Abstände, Statusfarben, Fokus, Aktionsgrößen, Responsive- und Reduced-Motion-Verträge in `ui-system.css`
- gemeinsamer `_ui-head` für Shell- und UI-Stylesheets
- Migration der sechs primären Leitstand-Ansichten; RepoGround benötigt kein lokales Style-Block mehr
- primärer Inhalt vor technischer Provenienz bei Bureau, Checkouts und RepoGround; Quellen bleiben über native Details vollständig erreichbar
- statischer Build liefert `ui-system.css` mit aus
- reale Browsermatrix verlangt das gemeinsame UI-Asset auf allen Route-/Viewport-Paaren

## Messbare Konsolidierung

- Inline-Style-Blöcke: 6 → 5
- Inline-Style-Bytes: 22.671 → 13.362 (-41,1 %)
- Inline-`style`-Attribute: 3 → 0
- lokale plain `body`-/`main`-Grundregeln: je 6 → 0
- `_ui-head`-Nutzung: 0 → 6 Ansichten

## Finaler lokaler Stand

- Head: `8a20f546c1e8acdc816282589d63524d581c042f`
- Base: `d0cee76e69fe5f6a1fd74f321165c47d6f3872c7`
- Vitest: 242/242
- Release-Runtime: 32/32
- Browser-Shell: mobil 21/21, Desktop 13/13
- Browsermatrix: 197 Prüfungen, 12 Route-/Viewport-Paare, 2 Vollbildprüfungen, 6 Szenarien
- Lint, Typecheck, Vendor-, Struktur-, Dokument-, Generated-, Drift- und Observer-Gates: PASS
- statischer Build enthält `ui-system.css`

Vor Merge werden Head, Base, Remote-Diff, Diff-SHA-256, vollständige CI und Self-Review erneut gebunden.