### PR TITLE
Harden operator snapshot source binding

### DIFF
--- a/docs/runbooks/local-release-runtime.md
+++ b/docs/runbooks/local-release-runtime.md
@@ -36,6 +36,7 @@ Release directory:
 ```
 
 Every release manifest binds source commit, source tree, origin URL, validation commands, release-tree digest and critical artifact digests.
+The critical-artifact set includes the versioned operator-snapshot launcher `scripts/leitstand-export-operator-snapshots`; its exact bytes are therefore sealed and digest-bound with the release before the host-local installed copy may be updated. The launcher resolves the format bridge from that same immutable release rather than from a mutable checkout.
 
 ## Runtime configuration
 

--- a/docs/runbooks/operator-snapshots.md
+++ b/docs/runbooks/operator-snapshots.md
@@ -23,6 +23,10 @@ Leitstand consumes two local, contract-shaped artifacts:
 
 The bridge implementation in this repository is `scripts/export-operator-snapshots.mjs`. It is a format bridge only: it reads already-exported raw JSON and writes Leitstand-local artifacts. It does not claim tasks, dispatch agents, clean checkouts, push branches, merge pull requests, restart services, or mutate Bureau/Grabowski state.
 
+The operator-side launcher is versioned as `scripts/leitstand-export-operator-snapshots`. The installed local wrapper must be copied from an immutable Leitstand release, not from a mutable checkout. It resolves the release-bound format bridge, reads the runtime `artifact_root`, and accepts Bureau task truth only from the canonical runtime registry snapshot named by `/home/alex/.local/share/bureau/deployment-manifest.json`. Before exporting it verifies the deployment manifest, inventory SHA-256, source commit, allowed snapshot root, and the complete declared registry-tree SHA-256. Any mismatch fails closed before artifact generation.
+
+For a source-only validation that performs no Grabowski import and writes no snapshots, run the installed wrapper with `LEITSTAND_SNAPSHOT_VERIFY_ONLY=1`. A successful result is evidence about source binding only; it does not establish current task truth, checkout truth, or successful artifact publication.
+
 ## Producer ownership
 
 Bureau remains the source of truth for:

--- a/scripts/leitstand-export-operator-snapshots
+++ b/scripts/leitstand-export-operator-snapshots
@@ -1,0 +1,384 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GRABOWSKI_PYTHON="${GRABOWSKI_PYTHON:-/home/alex/.local/share/grabowski-mcp/.venv/bin/python}"
+exec "$GRABOWSKI_PYTHON" - "$@" <<'PY'
+from __future__ import annotations
+
+import datetime
+import hashlib
+import json
+import os
+from pathlib import Path
+import stat
+import subprocess
+import tempfile
+
+
+def require_text(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise RuntimeError(f"{field} is missing or invalid")
+    return value.strip()
+
+
+def env_path(name: str, default: str) -> Path:
+    value = os.environ.get(name, default)
+    if not value or "\x00" in value or "\n" in value or "\r" in value:
+        raise RuntimeError(f"environment path {name} is invalid")
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        raise RuntimeError(f"environment path {name} must be absolute")
+    return path
+
+
+def require_regular(path: Path, label: str) -> os.stat_result:
+    try:
+        metadata = os.lstat(path)
+    except OSError as error:
+        raise RuntimeError(f"cannot inspect {label} {path}: {error}") from error
+    if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+        raise RuntimeError(f"{label} must be one regular file: {path}")
+    return metadata
+
+
+def sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def require_declared_file(root: Path, relative: Path) -> Path:
+    candidate = root
+    for index, part in enumerate(relative.parts):
+        candidate = candidate / part
+        try:
+            metadata = os.lstat(candidate)
+        except OSError as error:
+            raise RuntimeError(
+                f"cannot inspect Bureau canonical registry path {relative}: {error}"
+            ) from error
+        if stat.S_ISLNK(metadata.st_mode):
+            raise RuntimeError(
+                f"Bureau canonical registry path contains a symlink component: {relative}"
+            )
+        if index < len(relative.parts) - 1 and not stat.S_ISDIR(metadata.st_mode):
+            raise RuntimeError(
+                f"Bureau canonical registry path has a non-directory parent: {relative}"
+            )
+    require_regular(candidate, f"Bureau canonical registry path {relative}")
+    return candidate
+
+
+def read_snapshot_tree(
+    root: Path, paths: list[Path]
+) -> tuple[str, dict[str, bytes]]:
+    digest = hashlib.sha256()
+    contents: dict[str, bytes] = {}
+    for relative in paths:
+        path = require_declared_file(root, relative)
+        key = relative.as_posix()
+        encoded = key.encode()
+        content = path.read_bytes()
+        contents[key] = content
+        digest.update(len(encoded).to_bytes(4, "big"))
+        digest.update(encoded)
+        digest.update(len(content).to_bytes(8, "big"))
+        digest.update(content)
+    return digest.hexdigest(), contents
+
+
+def load_json_file(path: Path, label: str) -> tuple[bytes, dict[str, object]]:
+    require_regular(path, label)
+    try:
+        raw = path.read_bytes()
+        value = json.loads(raw)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise RuntimeError(f"cannot read {label} {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise RuntimeError(f"{label} must contain one JSON object")
+    return raw, value
+
+
+release_selector = env_path(
+    "LEITSTAND_RELEASE_ROOT", "/home/alex/.local/lib/leitstand/current"
+)
+allowed_releases_root = env_path(
+    "LEITSTAND_RELEASES_ROOT", "/home/alex/.local/lib/leitstand/releases"
+).resolve()
+runtime_config_path = env_path(
+    "LEITSTAND_RUNTIME_CONFIG", "/home/alex/.config/leitstand/runtime.json"
+)
+bureau_manifest_path = env_path(
+    "BUREAU_DEPLOYMENT_MANIFEST", "/home/alex/.local/share/bureau/deployment-manifest.json"
+)
+allowed_snapshot_root = env_path(
+    "BUREAU_REGISTRY_SNAPSHOT_ROOT", "/home/alex/.local/share/bureau/registry-snapshots"
+).resolve()
+grabowski_repo = env_path("GRABOWSKI_REPO", "/home/alex/repos/grabowski")
+verify_only = os.environ.get("LEITSTAND_SNAPSHOT_VERIFY_ONLY", "").strip().lower() in {
+    "1",
+    "true",
+    "yes",
+}
+
+try:
+    release_root = release_selector.resolve(strict=True)
+except OSError as error:
+    raise RuntimeError(f"Leitstand release selector is unavailable: {release_selector}: {error}") from error
+if release_root.parent != allowed_releases_root:
+    raise RuntimeError(
+        f"Leitstand release escapes the allowed release directory: {release_root}"
+    )
+
+_release_manifest_bytes, release_manifest = load_json_file(
+    release_root / "release-manifest.json", "Leitstand release manifest"
+)
+if (
+    release_manifest.get("schema_version") != 2
+    or release_manifest.get("kind") != "leitstand_local_release_manifest"
+):
+    raise RuntimeError("Leitstand release manifest contract is unsupported")
+release_commit = require_text(release_manifest.get("source_commit"), "Leitstand release source_commit")
+if release_root.name != f"{release_commit}-runtime-v1":
+    raise RuntimeError("Leitstand release path and source commit disagree")
+bridge_path = release_root / "scripts" / "export-operator-snapshots.mjs"
+require_regular(bridge_path, "versioned Leitstand snapshot bridge")
+
+_runtime_bytes, runtime_config = load_json_file(runtime_config_path, "Leitstand runtime config")
+if (
+    runtime_config.get("schema_version") != 1
+    or runtime_config.get("kind") != "leitstand_local_runtime_config"
+):
+    raise RuntimeError("Leitstand runtime config contract is unsupported")
+artifact_root = Path(
+    require_text(runtime_config.get("artifact_root"), "Leitstand runtime artifact_root")
+).expanduser()
+if not artifact_root.is_absolute():
+    raise RuntimeError("Leitstand runtime artifact_root must be absolute")
+
+manifest_bytes, manifest = load_json_file(bureau_manifest_path, "Bureau deployment manifest")
+if manifest.get("schema_version") != 1 or manifest.get("kind") != "bureau_runtime_deployment":
+    raise RuntimeError("Bureau deployment manifest contract is unsupported")
+
+source_commit = require_text(manifest.get("source_commit"), "Bureau deployment source_commit")
+expected_tree = require_text(
+    manifest.get("canonical_registry_tree_sha256"),
+    "Bureau deployment canonical_registry_tree_sha256",
+)
+expected_inventory_sha = require_text(
+    manifest.get("canonical_registry_inventory_sha256"),
+    "Bureau deployment canonical_registry_inventory_sha256",
+)
+declared_root = Path(
+    require_text(manifest.get("canonical_registry_root"), "Bureau deployment canonical_registry_root")
+).expanduser()
+declared_inventory = Path(
+    require_text(
+        manifest.get("canonical_registry_inventory_path"),
+        "Bureau deployment canonical_registry_inventory_path",
+    )
+).expanduser()
+if declared_root.is_symlink() or declared_inventory.is_symlink():
+    raise RuntimeError("Bureau canonical registry paths must not be symlinks")
+root = declared_root.resolve()
+inventory_path = declared_inventory.resolve()
+if root.parent != allowed_snapshot_root:
+    raise RuntimeError(
+        f"Bureau canonical registry root escapes the allowed snapshot directory: {root}"
+    )
+if inventory_path.parent != root or inventory_path.name != ".bureau-runtime-snapshot.json":
+    raise RuntimeError("Bureau canonical registry inventory is not rooted in the selected snapshot")
+if not (root / "registry" / "tasks").is_dir():
+    raise RuntimeError(f"Bureau canonical registry task directory is unavailable: {root}")
+
+inventory_bytes, inventory = load_json_file(
+    inventory_path, "Bureau canonical registry inventory"
+)
+observed_inventory_sha = sha256_bytes(inventory_bytes)
+if observed_inventory_sha != expected_inventory_sha:
+    raise RuntimeError(
+        "Bureau canonical registry inventory digest mismatch: "
+        f"expected {expected_inventory_sha}, observed {observed_inventory_sha}"
+    )
+if inventory.get("schema_version") != 1 or inventory.get("kind") != "bureau_registry_snapshot":
+    raise RuntimeError("Bureau canonical registry inventory contract is unsupported")
+if inventory.get("source_commit") != source_commit:
+    raise RuntimeError("Bureau canonical registry source commit disagrees with deployment manifest")
+if inventory.get("tree_sha256") != expected_tree:
+    raise RuntimeError("Bureau canonical registry tree digest disagrees with deployment manifest")
+
+inventory_paths = inventory.get("paths")
+if not isinstance(inventory_paths, list) or not inventory_paths:
+    raise RuntimeError("Bureau canonical registry inventory has no file paths")
+paths: list[Path] = []
+seen: set[str] = set()
+for item in inventory_paths:
+    if not isinstance(item, str):
+        raise RuntimeError("Bureau canonical registry inventory path is not a string")
+    relative = Path(item)
+    key = relative.as_posix()
+    if relative.is_absolute() or ".." in relative.parts or key in seen:
+        raise RuntimeError(f"Bureau canonical registry inventory contains an unsafe path: {item}")
+    seen.add(key)
+    paths.append(relative)
+observed_tree, snapshot_contents = read_snapshot_tree(root, paths)
+if observed_tree != expected_tree:
+    raise RuntimeError(
+        "Bureau canonical registry tree digest mismatch: "
+        f"expected {expected_tree}, observed {observed_tree}"
+    )
+queue_relative = Path("registry/queue.json")
+if queue_relative not in paths:
+    raise RuntimeError("Bureau canonical registry inventory does not declare registry/queue.json")
+declared_task_paths = sorted(
+    relative
+    for relative in paths
+    if len(relative.parts) == 3
+    and relative.parts[:2] == ("registry", "tasks")
+    and relative.suffix == ".json"
+)
+actual_task_paths = sorted(
+    path.relative_to(root) for path in (root / "registry" / "tasks").glob("*.json")
+)
+if actual_task_paths != declared_task_paths:
+    raise RuntimeError(
+        "Bureau canonical registry task set disagrees with the declared inventory"
+    )
+
+evidence = {
+    "schema_version": 1,
+    "kind": "leitstand_operator_snapshot_source_verification",
+    "leitstand_release_commit": release_commit,
+    "leitstand_release_root": str(release_root),
+    "bureau_source_commit": source_commit,
+    "bureau_source_tree_sha256": observed_tree,
+    "bureau_inventory_sha256": observed_inventory_sha,
+    "bureau_source_root": str(root),
+    "artifact_root": str(artifact_root),
+    "bureau_deployment_manifest_sha256": sha256_bytes(manifest_bytes),
+}
+if verify_only:
+    print(json.dumps(evidence, sort_keys=True))
+    raise SystemExit(0)
+
+from grabowski_checkouts import grabowski_checkout_inventory
+
+artifact_root.mkdir(parents=True, exist_ok=True)
+queue = json.loads(snapshot_contents[queue_relative.as_posix()]).get("lanes", {})
+lane_by_id = {
+    task_id: (lane, rank)
+    for lane, ids in queue.items()
+    if isinstance(ids, list)
+    for rank, task_id in enumerate(ids, 1)
+}
+state_map = {
+    "planned": "queued",
+    "todo": "queued",
+    "ready": "queued",
+    "open": "queued",
+    "queued": "queued",
+    "verified": "done",
+    "accepted": "done",
+    "done": "done",
+    "completed": "done",
+    "in_progress": "running",
+    "running": "running",
+    "active": "running",
+    "blocked": "blocked",
+    "failed": "failed",
+}
+tasks = []
+for relative in declared_task_paths:
+    raw = json.loads(snapshot_contents[relative.as_posix()])
+    task_id = str(raw.get("id") or relative.stem)
+    lane, rank = lane_by_id.get(
+        task_id,
+        (raw.get("priority", {}).get("lane"), raw.get("priority", {}).get("rank")),
+    )
+    execution = raw.get("execution") if isinstance(raw.get("execution"), dict) else {}
+    working = execution.get("working_repository")
+    repository = raw.get("repo") or raw.get("repository") or (
+        Path(working).name if isinstance(working, str) else None
+    )
+    source_state = str(raw.get("state") or raw.get("status") or "").lower()
+    note = []
+    if lane:
+        note.append(f"lane={lane}")
+    if rank:
+        note.append(f"rank={rank}")
+    if raw.get("goal"):
+        note.append(str(raw.get("goal"))[:180])
+    tasks.append(
+        {
+            "id": task_id,
+            "title": raw.get("title") or raw.get("name") or task_id,
+            "state": state_map.get(source_state, source_state or "unknown"),
+            "claimant": raw.get("claimant") or raw.get("owner") or raw.get("assignee"),
+            "repo": repository,
+            "created_at": raw.get("created_at")
+            or raw.get("createdAt")
+            or raw.get("metadata", {}).get("created_at"),
+            "updated_at": raw.get("updated_at")
+            or raw.get("updatedAt")
+            or raw.get("metadata", {}).get("updated_at"),
+            "receipt_ref": raw.get("receipt_ref") or raw.get("receiptRef"),
+            "note": " | ".join(note),
+        }
+    )
+
+inventory_result = grabowski_checkout_inventory(
+    str(grabowski_repo),
+    include_processes=True,
+    include_tasks=True,
+    include_resources=True,
+)
+for worktree in inventory_result.get("worktrees", []):
+    worktree.setdefault("repo", "grabowski")
+
+with tempfile.TemporaryDirectory(prefix="leitstand-snapshot-raw-") as temporary:
+    raw_dir = Path(temporary)
+    checkout_raw = raw_dir / "checkout-raw.json"
+    bureau_raw = raw_dir / "bureau-raw.json"
+    checkout_raw.write_text(json.dumps(inventory_result, indent=2, sort_keys=True) + "\n")
+    bureau_raw.write_text(
+        json.dumps(
+            {
+                "generated_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                "source": {
+                    "kind": "bureau_canonical_runtime_snapshot",
+                    "commit": source_commit,
+                    "tree_sha256": observed_tree,
+                    "inventory_sha256": observed_inventory_sha,
+                    "root": str(root),
+                },
+                "tasks": tasks,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+    runtime_head = subprocess.run(
+        ["git", "-C", str(grabowski_repo), "rev-parse", "HEAD"],
+        check=False,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    subprocess.run(
+        [
+            "node",
+            str(bridge_path),
+            "--checkout-raw",
+            str(checkout_raw),
+            "--bureau-raw",
+            str(bureau_raw),
+            "--runtime-head",
+            runtime_head,
+            "--out-dir",
+            str(artifact_root),
+        ],
+        check=True,
+        cwd=str(release_root),
+        env={**os.environ, "NODE_OPTIONS": os.environ.get("NODE_OPTIONS", "--jitless")},
+    )
+
+print(json.dumps({**evidence, "checkout_raw_count": len(inventory_result.get("worktrees", [])), "bureau_raw_count": len(tasks)}, sort_keys=True))
+PY

--- a/scripts/leitstand-release.py
+++ b/scripts/leitstand-release.py
@@ -109,6 +109,7 @@ CRITICAL_ARTIFACTS: tuple[str, ...] = (
     WEB_UNIT_RELATIVE_PATH.as_posix(),
     STORAGE_UNIT_RELATIVE_PATH.as_posix(),
     "scripts/collect-storage-health-runtime",
+    "scripts/leitstand-export-operator-snapshots",
     "scripts/leitstand-release.py",
 )
 

--- a/tests/operatorSnapshotWrapper.test.ts
+++ b/tests/operatorSnapshotWrapper.test.ts
@@ -1,0 +1,215 @@
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { mkdtemp, mkdir, readFile, rename, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const wrapperPath = join(repoRoot, 'scripts', 'leitstand-export-operator-snapshots');
+
+function sha256(payload: Buffer | string): string {
+  return createHash('sha256').update(payload).digest('hex');
+}
+
+function treeSha256(root: string, entries: Array<{ path: string; content: string }>): string {
+  const digest = createHash('sha256');
+  for (const entry of entries) {
+    const encoded = Buffer.from(entry.path);
+    const content = Buffer.from(entry.content);
+    const nameLength = Buffer.alloc(4);
+    nameLength.writeUInt32BE(encoded.length);
+    const contentLength = Buffer.alloc(8);
+    contentLength.writeBigUInt64BE(BigInt(content.length));
+    digest.update(nameLength);
+    digest.update(encoded);
+    digest.update(contentLength);
+    digest.update(content);
+  }
+  return digest.digest('hex');
+}
+
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), 'leitstand-snapshot-wrapper-'));
+  const releasesRoot = join(root, 'releases');
+  const commit = 'a'.repeat(40);
+  const releaseRoot = join(releasesRoot, `${commit}-runtime-v1`);
+  const snapshotRoot = join(root, 'bureau-snapshots');
+  const canonicalRoot = join(snapshotRoot, 'snapshot-1');
+  const artifactRoot = join(root, 'artifacts');
+  const runtimeConfig = join(root, 'runtime.json');
+  const bureauManifest = join(root, 'bureau-deployment.json');
+
+  await mkdir(join(releaseRoot, 'scripts'), { recursive: true });
+  await mkdir(join(canonicalRoot, 'registry', 'tasks'), { recursive: true });
+  await mkdir(artifactRoot, { recursive: true });
+  await writeFile(
+    join(releaseRoot, 'release-manifest.json'),
+    `${JSON.stringify({
+      schema_version: 2,
+      kind: 'leitstand_local_release_manifest',
+      source_commit: commit,
+    })}\n`,
+  );
+  await writeFile(join(releaseRoot, 'scripts', 'export-operator-snapshots.mjs'), '// bridge\n');
+  await writeFile(
+    runtimeConfig,
+    `${JSON.stringify({
+      schema_version: 1,
+      kind: 'leitstand_local_runtime_config',
+      artifact_root: artifactRoot,
+    })}\n`,
+  );
+
+  const entries = [
+    {
+      path: 'registry/queue.json',
+      content: `${JSON.stringify({ lanes: { later: ['TEST-T001'] } })}\n`,
+    },
+    {
+      path: 'registry/tasks/TEST-T001.json',
+      content: `${JSON.stringify({ id: 'TEST-T001', state: 'planned', title: 'Test' })}\n`,
+    },
+  ];
+  for (const entry of entries) {
+    await writeFile(join(canonicalRoot, entry.path), entry.content);
+  }
+  const treeDigest = treeSha256(canonicalRoot, entries);
+  const inventoryPath = join(canonicalRoot, '.bureau-runtime-snapshot.json');
+  const inventoryBytes = `${JSON.stringify({
+    schema_version: 1,
+    kind: 'bureau_registry_snapshot',
+    source_commit: 'b'.repeat(40),
+    tree_sha256: treeDigest,
+    paths: entries.map((entry) => entry.path),
+  })}\n`;
+  await writeFile(inventoryPath, inventoryBytes);
+  await writeFile(
+    bureauManifest,
+    `${JSON.stringify({
+      schema_version: 1,
+      kind: 'bureau_runtime_deployment',
+      source_commit: 'b'.repeat(40),
+      canonical_registry_tree_sha256: treeDigest,
+      canonical_registry_inventory_sha256: sha256(inventoryBytes),
+      canonical_registry_root: canonicalRoot,
+      canonical_registry_inventory_path: inventoryPath,
+    })}\n`,
+  );
+
+  return {
+    root,
+    releaseRoot,
+    releasesRoot,
+    snapshotRoot,
+    canonicalRoot,
+    artifactRoot,
+    runtimeConfig,
+    bureauManifest,
+    taskPath: join(canonicalRoot, 'registry', 'tasks', 'TEST-T001.json'),
+  };
+}
+
+function verify(env: Record<string, string>) {
+  return spawnSync('bash', [wrapperPath], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      GRABOWSKI_PYTHON: 'python3',
+      LEITSTAND_SNAPSHOT_VERIFY_ONLY: '1',
+      ...env,
+    },
+  });
+}
+
+describe('leitstand-export-operator-snapshots', () => {
+  it('binds Bureau input to the canonical digest-validated runtime snapshot', async () => {
+    const value = await fixture();
+    const result = verify({
+      LEITSTAND_RELEASE_ROOT: value.releaseRoot,
+      LEITSTAND_RELEASES_ROOT: value.releasesRoot,
+      LEITSTAND_RUNTIME_CONFIG: value.runtimeConfig,
+      BUREAU_DEPLOYMENT_MANIFEST: value.bureauManifest,
+      BUREAU_REGISTRY_SNAPSHOT_ROOT: value.snapshotRoot,
+    });
+    expect(result.status, result.stderr).toBe(0);
+    const evidence = JSON.parse(result.stdout.trim());
+    expect(evidence.kind).toBe('leitstand_operator_snapshot_source_verification');
+    expect(evidence.leitstand_release_root).toBe(value.releaseRoot);
+    expect(evidence.bureau_source_root).toBe(value.canonicalRoot);
+    expect(evidence.bureau_source_tree_sha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('fails closed when a canonical snapshot file changes after inventory binding', async () => {
+    const value = await fixture();
+    await writeFile(value.taskPath, '{"id":"TEST-T001","state":"verified"}\n');
+    const result = verify({
+      LEITSTAND_RELEASE_ROOT: value.releaseRoot,
+      LEITSTAND_RELEASES_ROOT: value.releasesRoot,
+      LEITSTAND_RUNTIME_CONFIG: value.runtimeConfig,
+      BUREAU_DEPLOYMENT_MANIFEST: value.bureauManifest,
+      BUREAU_REGISTRY_SNAPSHOT_ROOT: value.snapshotRoot,
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('Bureau canonical registry tree digest mismatch');
+  });
+
+  it('rejects a Bureau snapshot outside the configured canonical snapshot root', async () => {
+    const value = await fixture();
+    const otherRoot = join(value.root, 'other-snapshots');
+    await mkdir(otherRoot);
+    const result = verify({
+      LEITSTAND_RELEASE_ROOT: value.releaseRoot,
+      LEITSTAND_RELEASES_ROOT: value.releasesRoot,
+      LEITSTAND_RUNTIME_CONFIG: value.runtimeConfig,
+      BUREAU_DEPLOYMENT_MANIFEST: value.bureauManifest,
+      BUREAU_REGISTRY_SNAPSHOT_ROOT: otherRoot,
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('escapes the allowed snapshot directory');
+  });
+
+  it('rejects task files that are not declared in the canonical inventory', async () => {
+    const value = await fixture();
+    await writeFile(
+      join(value.canonicalRoot, 'registry', 'tasks', 'EXTRA.json'),
+      '{"id":"EXTRA","state":"planned"}\n',
+    );
+    const result = verify({
+      LEITSTAND_RELEASE_ROOT: value.releaseRoot,
+      LEITSTAND_RELEASES_ROOT: value.releasesRoot,
+      LEITSTAND_RUNTIME_CONFIG: value.runtimeConfig,
+      BUREAU_DEPLOYMENT_MANIFEST: value.bureauManifest,
+      BUREAU_REGISTRY_SNAPSHOT_ROOT: value.snapshotRoot,
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('task set disagrees with the declared inventory');
+  });
+
+  it('rejects symlink components inside declared registry paths', async () => {
+    const value = await fixture();
+    const tasks = join(value.canonicalRoot, 'registry', 'tasks');
+    const realTasks = join(value.canonicalRoot, 'registry', 'tasks-real');
+    await rename(tasks, realTasks);
+    await symlink('tasks-real', tasks);
+    const result = verify({
+      LEITSTAND_RELEASE_ROOT: value.releaseRoot,
+      LEITSTAND_RELEASES_ROOT: value.releasesRoot,
+      LEITSTAND_RUNTIME_CONFIG: value.runtimeConfig,
+      BUREAU_DEPLOYMENT_MANIFEST: value.bureauManifest,
+      BUREAU_REGISTRY_SNAPSHOT_ROOT: value.snapshotRoot,
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('contains a symlink component');
+  });
+
+  it('does not read Bureau truth from a repository checkout', async () => {
+    const source = await readFile(wrapperPath, 'utf8');
+    expect(source).not.toContain('/home/alex/repos/bureau');
+    expect(source).toContain('canonical_registry_inventory_sha256');
+    expect(source).toContain('canonical_registry_tree_sha256');
+    expect(source).toContain('export-operator-snapshots.mjs');
+    expect(source).toContain('raw = json.loads(snapshot_contents[relative.as_posix()])');
+    expect(source).not.toContain('raw = json.loads(path.read_text())');
+  });
+});

--- a/tests/test_release_runtime.py
+++ b/tests/test_release_runtime.py
@@ -76,6 +76,9 @@ class ReleaseRuntimeTest(unittest.TestCase):
         collector = target / "scripts/collect-storage-health-runtime"
         collector.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
         os.chmod(collector, 0o755)
+        snapshot_wrapper = target / "scripts/leitstand-export-operator-snapshots"
+        snapshot_wrapper.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        os.chmod(snapshot_wrapper, 0o755)
         (target / ".git/HEAD").write_text(f"{head}\n", encoding="ascii")
 
     def create_verified_release(self, head: str, *, seal: bool = True) -> Path:


### PR DESCRIPTION
## Zweck

Versioniert und härtet den lokalen Operator-Snapshot-Wrapper, damit Leitstand Bureau-Taskwahrheit ausschließlich aus dem kanonischen, digest-validierten Bureau-Runtime-Snapshot bezieht und den Format-Bridge-Code aus demselben immutable Leitstand-Release lädt.

## Sicherheitsvertrag

- kein Lesen von Bureau-Taskwahrheit aus einem Repository-Checkout
- Bindung an Bureau-Deployment-Manifest, Inventory-SHA-256, Source-Commit und vollständigen Registry-Tree-SHA-256
- Fail-closed bei manipulierten Dateien, nicht deklarierten Taskdateien, Symlink-Komponenten und Snapshot-Root-Ausbruch
- Queue und Tasks werden aus exakt den bereits gehashten Bytes weiterverarbeitet
- Wrapper wird als kritisches Leitstand-Release-Artefakt versiegelt
- `LEITSTAND_SNAPSHOT_VERIFY_ONLY=1` prüft die Quellenbindung ohne Grabowski-Import oder Snapshot-Schreibeffekt

## Prüfung

- 6/6 fokussierte Wrapper-Regressionsfälle grün
- 32/32 Release-Runtime-Tests grün
- reale Verify-only-Probe gegen installierte Leitstand-/Bureau-Releases grün
- vollständige Leitstand-Gate-Kette grün: Vendor-Verträge, Lint, Typecheck, Release-Runtime, gesamte Vitest-Suite, Browser-Shell, Build, Static Build, Repository-, Dokument-, Generated-, Runbook-, Drift- und Observer-Invariant-Gates

Der Wrapper schreibt im Normalbetrieb weiterhin ausschließlich Leitstand-lokale Snapshot-Artefakte; Bureau/Grabowski bleiben read-only.