### PR TITLE
T010: Make Leitstand the single general operator display

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Leitstand is the read-only observation surface for the Heimgewebe operator ecosy
 
 Leitstand has two deliberately separate surfaces.
 
+The canonical general operator status entry is `/`. It is a convenience display over source-owned evidence, not a control plane or a new source of truth. Systemkatalog remains the status-free role catalog; Schauwerk remains the specialized visual/rendering surface.
+
+If Leitstand is unavailable, operators fall back directly to Bureau, Grabowski, runtime health/logs, the Systemkatalog read-only catalog/query surface, RepoGround publications, and specialized Schauwerk views. The outage removes the general display only; it must not block operation.
+
 ### Web runtime
 
 The internal Express service renders current exported evidence:

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -28,7 +28,7 @@ No arrow returns from Leitstand to a source system. Leitstand does not ingest ev
 | `system_catalog_map_artifact_manifest` | `artifacts/ecosystem-map-artifact-manifest.json` | `/ecosystem-map`, `/health` | Systemkatalog publication |
 | RepoGround bundle index | configured RepoGround bundle path | `/repoground` | RepoGround publication |
 
-The dashboard at `/` summarizes these projections. It does not combine them into a new source of truth.
+The dashboard at `/` summarizes these projections. Every general panel must name its primary source, expose freshness, and state that the display is a non-authoritative projection. It does not combine the inputs into a new source of truth.
 
 ## Producer boundary
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ summary: >
 
 # Leitstand Documentation Router
 
-Leitstand is the read-only observation surface for the Heimgewebe operator ecosystem. It renders exported evidence and does not orchestrate, mutate, dispatch tasks, ingest events, or establish source truth.
+Leitstand is the read-only observation surface for the Heimgewebe operator ecosystem. The dashboard at `/` is the single documented general operator status entry. It renders exported evidence and does not orchestrate, mutate, dispatch tasks, ingest events, or establish source truth. Direct source CLIs and specialist Systemkatalog, RepoGround and Schauwerk views remain valid fallbacks when Leitstand is unavailable.
 
 ## Normative boundaries
 

--- a/docs/operator-ecosystem-alignment.md
+++ b/docs/operator-ecosystem-alignment.md
@@ -21,3 +21,29 @@ Leitstand is a read-only observer surface in the Heimgewebe operator ecosystem.
 - Leitstand renders views and digests; it does not execute or orchestrate.
 
 Plexer is not the only communication path. Contracts, GitHub/CI, direct artifact reads, Chronik queries and Plexer events are parallel channels. Use the path that preserves evidence and avoids hidden coupling.
+
+
+## Single general operator entry
+
+The canonical general live-status entry is the Leitstand dashboard at `/`. It is a read-only projection that aggregates attention and freshness signals but never becomes authoritative for the underlying facts. Direct specialist surfaces remain available for diagnosis and source-level verification.
+
+## Duplicate-panel map
+
+| Surface | Classification | Primary source / role | General-status rule |
+| --- | --- | --- | --- |
+| Leitstand `/` | general operator display | derived from all listed source artifacts | the only documented general status entry |
+| Leitstand `/bureau` | specialist projection | Bureau | task/claim detail only; source-linked and non-authoritative |
+| Leitstand `/checkouts` | specialist projection | Grabowski | checkout/worktree detail only; source-linked and non-authoritative |
+| Leitstand `/storage-health` | specialist projection | storage-health producer | storage detail only; source-linked and non-authoritative |
+| Leitstand `/ecosystem-map` | specialist projection | Systemkatalog publication | stable relationships only; not live operational truth |
+| Leitstand `/repoground` | specialist projection | RepoGround publication | repository-grounding detail only |
+| Systemkatalog direct views | stable catalog | Systemkatalog | status-free by contract; no competing general dashboard |
+| Schauwerk live images / operator views | specialist renderer | declared source packages and provider readbacks | visual specialization only; not the general operator entry or source truth |
+
+Remote role evidence was rechecked on 2026-07-21 against Systemkatalog `4d8549965240f50b784e27960d942dc6389f16b3`, whose README states that it is not a control or status system and names Leitstand as the general live display, and Schauwerk `013d6d2c28e6e7eb7109d660e7a133563992c405`, whose README states that source systems remain authoritative and describes its operator/live surfaces as projections and renderers. These observations are evidence for the boundary, not authority over those repositories.
+
+## Failure mode and fallback
+
+Leitstand is not on the execution path. If the web runtime is unavailable, operation continues through the source systems: Bureau for task and claim truth, Grabowski for execution/worktrees/leases/receipts, runtime healthchecks and logs for services, Systemkatalog's static read-only catalog and query surface for stable roles, RepoGround for repository context, and Schauwerk for specialized visual views. A Leitstand outage therefore removes the general convenience display, not the underlying source CLIs, artifacts, or direct specialist views.
+
+No fallback is allowed to silently promote a specialist projection into a new general source of truth.

--- a/src/controllers/dashboard.ts
+++ b/src/controllers/dashboard.ts
@@ -9,6 +9,8 @@ export interface DashboardSource {
   title: string;
   description: string;
   href: string;
+  primary_source: string;
+  authority_boundary: string;
   source_kind: 'artifact' | 'fixture' | 'missing' | 'error' | 'corrupt';
   freshness_state: 'fresh' | 'stale' | 'unknown';
   metric: string;
@@ -167,6 +169,8 @@ export async function getDashboardData(): Promise<DashboardData> {
       title: 'Bureau',
       description: 'Task- und Claim-Projektion.',
       href: '/bureau',
+      primary_source: 'Bureau',
+      authority_boundary: 'Nur Projektion; Aufgaben- und Claim-Wahrheit bleibt bei Bureau.',
       source_kind: bureau.error ? 'error' : (bureau.data?.view_meta.source_kind ?? 'missing'),
       freshness_state: bureau.data?.view_meta.freshness_state ?? 'unknown',
       metric: bureau.data ? `${bureau.data.view_meta.task_count} Tasks` : 'keine Tasks',
@@ -177,6 +181,8 @@ export async function getDashboardData(): Promise<DashboardData> {
       title: 'Checkouts',
       description: 'Grabowski-Inventar.',
       href: '/checkouts',
+      primary_source: 'Grabowski',
+      authority_boundary: 'Nur Projektion; Checkout-, Worktree- und Ausführungswahrheit bleibt bei Grabowski.',
       source_kind: checkouts.error ? 'error' : (checkouts.data?.view_meta.source_kind ?? 'missing'),
       freshness_state: checkouts.data?.view_meta.freshness_state ?? 'unknown',
       metric: checkouts.data ? `${checkouts.data.view_meta.checkout_count} Checkouts` : 'keine Checkouts',
@@ -187,6 +193,8 @@ export async function getDashboardData(): Promise<DashboardData> {
       title: 'Speicherzustand',
       description: 'Heim-PC Storage Metriken.',
       href: '/storage-health',
+      primary_source: 'Storage-Health-Producer',
+      authority_boundary: 'Nur Projektion; Mess- und Erzeugerwahrheit bleibt beim Storage-Health-Producer.',
       source_kind: storage.error ? 'error' : (storage.data?.view_meta.source_kind ?? 'missing'),
       freshness_state: storage.data?.view_meta.freshness_state ?? 'unknown',
       metric: storage.data?.current ? `${storage.data.current.summary.producerCount} Producer` : 'kein Storage Zustand',
@@ -197,6 +205,8 @@ export async function getDashboardData(): Promise<DashboardData> {
       title: 'Systemkarte',
       description: 'Systemkatalog Map Manifest.',
       href: '/ecosystem-map',
+      primary_source: 'Systemkatalog',
+      authority_boundary: 'Nur Projektion; stabile Rollen- und Beziehungswahrheit bleibt beim Systemkatalog.',
       source_kind: eco.error ? 'error' : (eco.data?.view_meta.source_kind ?? 'missing'),
       freshness_state: eco.data?.view_meta.freshness_state ?? 'unknown',
       metric: eco.data ? `${eco.data.view_meta.verified_artifact_count} Artefakte` : 'keine Systemkarte',
@@ -207,6 +217,8 @@ export async function getDashboardData(): Promise<DashboardData> {
       title: 'RepoGround',
       description: 'Bundle-Ansicht.',
       href: '/repoground',
+      primary_source: 'RepoGround',
+      authority_boundary: 'Nur Projektion; Repository-Kontext und Publikationswahrheit bleibt bei RepoGround.',
       source_kind: repo.error ? 'error' : (repo.data?.view_meta.source_kind ?? 'missing'),
       freshness_state: repo.data?.view_meta.freshness_state ?? 'unknown',
       metric: repo.data ? `${repo.data.bundles.length} Bundles` : 'keine Repos',

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -273,8 +273,8 @@
     <header class="page-header">
       <h1>Leitstand</h1>
       <p class="subtitle">
-        Beobachtungs- und Verdichtungsmodul der Heimgewebe-Systeme.
-        Strikter Observer: visualisiert Zustände, ohne externe Systeme zu mutieren.
+        Allgemeiner Operator-Einstieg für das aktuelle Lagebild der Heimgewebe-Systeme.
+        Strikter Observer: visualisiert Zustände, ohne externe Systeme zu mutieren oder Primärquellen zu ersetzen.
       </p>
     </header>
 
@@ -370,7 +370,9 @@
                   <% if (p.freshness_state === 'stale') { %>veraltet<% } %>
                   <% if (p.freshness_state === 'unknown') { %>Frische unbekannt<% } %>
                 </span>
+                <span class="primary-source">Primärquelle: <%= p.primary_source %></span>
               </div>
+              <p class="projection-note authority-boundary"><%= p.authority_boundary %></p>
               <% if (p.error_reason) { %>
                 <div class="error-note" role="alert">Lade-Fehler: <%= p.error_reason %></div>
               <% } %>

--- a/tests/controllers/dashboardAuthority.test.ts
+++ b/tests/controllers/dashboardAuthority.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { getDashboardData } from '../../src/controllers/dashboard.js';
+
+describe('dashboard authority boundaries', () => {
+  it('names the primary source and non-authoritative boundary for every general panel', async () => {
+    const { sources } = await getDashboardData();
+    const byId = Object.fromEntries(sources.map((source) => [source.id, source]));
+
+    expect(byId.bureau.primary_source).toBe('Bureau');
+    expect(byId.checkouts.primary_source).toBe('Grabowski');
+    expect(byId.storage_health.primary_source).toBe('Storage-Health-Producer');
+    expect(byId.ecosystem_map.primary_source).toBe('Systemkatalog');
+    expect(byId.repo_ground.primary_source).toBe('RepoGround');
+
+    for (const source of sources) {
+      expect(source.primary_source.length).toBeGreaterThan(0);
+      expect(source.authority_boundary).toContain('Nur Projektion');
+      expect(source.authority_boundary).toContain('bleibt bei');
+    }
+  });
+});

--- a/tests/views/index.test.ts
+++ b/tests/views/index.test.ts
@@ -29,6 +29,8 @@ describe('index.ejs', () => {
             title: 'Bureau',
             description: 'Tasks',
             href: '/bureau',
+            primary_source: 'Bureau',
+            authority_boundary: 'Nur Projektion; Aufgaben- und Claim-Wahrheit bleibt bei Bureau.',
             source_kind: 'artifact',
             freshness_state: 'unknown',
             metric: '3 Tasks',
@@ -62,5 +64,7 @@ describe('index.ejs', () => {
     expect(html).toContain('data-attention-source="bureau"');
     expect(html).toContain('Datenfrische ist nicht belegt');
     expect(html).toContain('Es erzeugt keine eigene Zustandswahrheit.');
+    expect(html).toContain('Primärquelle: Bureau');
+    expect(html).toContain('Nur Projektion; Aufgaben- und Claim-Wahrheit bleibt bei Bureau.');
   });
 });


### PR DESCRIPTION
## Zweck

Leitstand wird als einziger dokumentierter allgemeiner Operator-Status-Einstieg präzisiert, ohne eine neue Zustandswahrheit oder Steuerinstanz zu schaffen.

## Änderungen

- jede allgemeine Dashboard-Karte nennt Primärquelle, Frische und explizite Nicht-Autorität
- `/` wird als allgemeiner Operator-Einstieg dokumentiert
- Systemkatalog bleibt statusfreier stabiler Katalog
- Schauwerk bleibt spezialisierte Visualisierungs- und Projektionsschicht
- Duplikat-/Spezialflächen werden klassifiziert
- Fallback bei Leitstand-Ausfall bleibt direkt über Primärquellen und Spezialansichten möglich
- Regressionstest für Panel-Autoritätsgrenzen ergänzt

## Live-geprüfte Rollenbelege

- Systemkatalog main: `4d8549965240f50b784e27960d942dc6389f16b3`
- Schauwerk main: `013d6d2c28e6e7eb7109d660e7a133563992c405`

## Prüfung

- `git diff --cached --check`
- gezielte Vitest-Suite: 3/3 Tests
- `pnpm lint`
- `pnpm typecheck`
- vollständige Vitest-Suite: 249/249 Tests
- `pnpm build`
- Browser-Shell: mobile 21/21, desktop 13/13
- Vendor-Contracts: PASS
- Release-Runtime: 32/32 Tests
- Observer-Invariant-Guard: PASS
- Repo-Structure-Guard: PASS
- Docs-Relations-Guard: PASS
- Generated-Files-Guard: PASS
- Drift-Gates: PASS

## Reviewbindung

- Commit: `b988568`
- eingefrorener Patch SHA-256: `22990ebe31a3ce60dfda79934db3601b6e48942072f7dfffd118f87c00859a4f`

Bureau: OPERATOR-ECOSYSTEM-REDUNDANCY-V1-T010