### PR TITLE
OPERATOR-MACHINE-READABILITY-V1-T024: add read-only decision axis

### DIFF
--- a/audit/impl-registry.yaml
+++ b/audit/impl-registry.yaml
@@ -157,3 +157,27 @@ implementations:
       - tests/test_release_runtime.py
     supersedes: []
     deprecated_by: []
+
+  - id: impl.controller.decisionAxis
+    path: src/controllers/decisionAxis.ts
+    impl_type: controller
+    status: active
+    documented_by:
+      - docs/blueprints/operator-decision-axis.md
+    verified_by:
+      - tests/controllers/decisionAxis.test.ts
+      - tests/exportDecisionAxis.test.ts
+    supersedes: []
+    deprecated_by: []
+
+  - id: impl.operatorSnapshots.decisionAxisProducer
+    path: scripts/leitstand-export-operator-snapshots
+    impl_type: bridge
+    status: active
+    documented_by:
+      - docs/blueprints/operator-decision-axis.md
+    verified_by:
+      - tests/operatorSnapshotWrapper.test.ts
+      - tests/exportDecisionAxis.test.ts
+    supersedes: []
+    deprecated_by: []

--- a/docs/blueprints/operator-decision-axis.md
+++ b/docs/blueprints/operator-decision-axis.md
@@ -1,0 +1,72 @@
+---
+id: docs.blueprints.operator-decision-axis
+title: "Blueprint: Operator Decision Axis v1"
+doc_type: architecture
+status: active
+canonicality: supporting
+owner: leitstand
+summary: >
+  Project canonical Bureau and Grabowski decision evidence into five bounded,
+  source-bound, read-only Leitstand sections without creating new authority.
+---
+
+# Operator Decision Axis v1
+
+Task: `OPERATOR-MACHINE-READABILITY-V1-T024`
+
+## Ziel
+
+Der Leitstand zeigt eine read-only Entscheidungsprojektion für fünf Fragen:
+
+- **Jetzt** – der erste aktuell von Bureaus bestehender Statusprojektion aus der kanonischen Registry-Queue vorgeschlagene Task;
+- **Im Fokus** – der jüngste aktive Thread-Fokus aus dem Bureau Live Register;
+- **Blockiert** – explizite `blocked_reasons` beziehungsweise ein belegter blockierter Zustand aus Bureaus Statusprojektion;
+- **Konvergenz** – die bestehende Grabowski-`current_work`-Konvergenzprojektion;
+- **Danach** – weitere von Bureaus bestehender Statusprojektion aus der kanonischen Registry-Queue vorgeschlagene Tasks.
+
+Die Achse ist ausschließlich eine Projektion. Sie erzeugt keine Task-, Queue-, Prioritäts-, Fokus-, Blocking-, Runtime- oder Konvergenzwahrheit.
+
+## Wahrheitsgrenzen
+
+| Abschnitt | Primär-/Projektionsquelle | Leitstand darf nicht |
+| --- | --- | --- |
+| Jetzt | Bureau `status-projection`, Quelle `registry-queue` | Task priorisieren, claimen oder dispatchen |
+| Im Fokus | Bureau Live Register, jüngster aktiver Thread-Fokus | Fokus schreiben, schließen oder als Queue-Wahrheit behandeln |
+| Blockiert | Bureau `status-projection` | Blocker erfinden oder selbst auflösen |
+| Konvergenz | Grabowski `current_work` | Lifecycle-Zustand, Leases oder Prozesse mutieren |
+| Danach | Bureau `status-projection`, Quelle `registry-queue` | eigene Backlog- oder Prioritätsliste führen |
+
+Bureau bleibt Aufgaben- und Prioritätsautorität. Grabowski bleibt Ausführungsoperator. GitHub, CI und Runtime bleiben ihre jeweiligen Primärquellen. Der Leitstand speichert nur ein kurzlebiges Snapshot-Artefakt.
+
+## Datenfluss
+
+1. `scripts/leitstand-export-operator-snapshots` läuft producer-seitig außerhalb des HTTP-Request-Pfads.
+2. Der Producer bindet Bureau-Registry-Daten weiterhin an das digest-validierte kanonische Runtime-Snapshot.
+3. Der Producer liest Bureaus bestehende read-only Projektionen `status-projection` und `live-list`.
+4. Der Producer liest Grabowskis bestehende `current_work`-Projektion für Konvergenzevidenz.
+5. `scripts/export-operator-snapshots.mjs` begrenzt die Abschnitte und schreibt atomar `artifacts/operator-decision-axis.json` mit Contract-Kind `leitstand_operator_decision_axis_snapshot`.
+6. `src/controllers/decisionAxis.ts` liest ausschließlich dieses Artefakt. Es gibt keinen request-time Aufruf von Bureau oder Grabowski.
+7. Das Dashboard rendert Quelle, Frische und einen expliziten Degradierungszustand je Abschnitt.
+
+## Degradierung
+
+Fehlt eine Producer-Quelle, wird der betroffene Abschnitt als `unavailable` mit leerer Item-Liste geschrieben. Liefert eine gültige Quelle aktuell keinen belegten Eintrag, lautet der Status `unknown`; der Leitstand füllt keinen Ersatzwert ein. Ein Abschnitt wird nach 20 Minuten ohne neue Beobachtung als `stale` dargestellt.
+
+## Bounds und Nicht-Ansprüche
+
+Jeder Abschnitt ist auf höchstens acht Items begrenzt. Das Snapshot nennt explizit unter anderem folgende Nicht-Ansprüche:
+
+- keine Task- oder Prioritätsautorität;
+- keine Queue-Wahrheit;
+- keine Fokusautorität;
+- keine Runtime- oder Konvergenzautorität;
+- keine Dispatch- oder Mutationsautorität.
+
+## Verifikation
+
+Verifiziert durch:
+
+- `tests/controllers/decisionAxis.test.ts` – vollständige fünf Abschnitte, stale/missing, keine erfundenen Werte;
+- `tests/exportDecisionAxis.test.ts` – bounded Snapshot und Nicht-Ansprüche;
+- `tests/operatorSnapshotWrapper.test.ts` – kanonisch digest-gebundene Bureau-Quelle;
+- `tests/controllers/dashboardAuthority.test.ts` und Repository-CI – bestehende Observer-Grenzen bleiben erhalten.

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,7 @@ Leitstand is the read-only observation surface for the Heimgewebe operator ecosy
 - [Data Flow](data-flow.md)
 - [Security Policy](../SECURITY.md)
 - [Tracked WGX Profile Decision](decisions/wgx-leitstand.md)
+- [Operator Decision Axis Blueprint](blueprints/operator-decision-axis.md)
 
 ## Operative runbooks
 
@@ -35,7 +36,7 @@ Leitstand is the read-only observation surface for the Heimgewebe operator ecosy
 
 | Route | Purpose | Source truth |
 | --- | --- | --- |
-| `/` | compact source and attention overview | derived only |
+| `/` | compact source, attention and read-only decision-axis overview | derived local snapshot artifacts only |
 | `/health` | in-process runtime and artifact-freshness receipt | current process and local files |
 | `/bureau` | Bureau task and claim projection | Bureau snapshot |
 | `/checkouts` | checkout and worktree projection | Grabowski snapshot |

--- a/scripts/export-operator-snapshots.mjs
+++ b/scripts/export-operator-snapshots.mjs
@@ -7,7 +7,8 @@
  * request time. This script is the deliberate seam that keeps that invariant:
  * the operator runs it (or a cron does) to transform *raw* Grabowski/Bureau
  * output into the contract-shaped snapshot artifacts Leitstand's controllers
- * read (`leitstand_bureau_task_snapshot`, `leitstand_checkout_inventory`).
+ * read (`leitstand_bureau_task_snapshot`, `leitstand_checkout_inventory`,
+ * `leitstand_operator_decision_axis_snapshot`).
  *
  * It only reads raw JSON and writes local snapshot files — no external mutation.
  *
@@ -15,11 +16,12 @@
  *   node scripts/export-operator-snapshots.mjs \
  *     --checkout-raw <grabowski_checkout_inventory.json> \
  *     --bureau-raw   <bureau_task_list.json> \
+ *     --decision-raw <operator_decision_axis.json> \
  *     --out-dir      artifacts
  *
  * Any input may be omitted; only the provided snapshots are (re)written. The
- * raw inputs are whatever `grabowski_checkout_inventory` / the Bureau task
- * listing emit — this bridge is where their vocab is pinned to our contract.
+ * raw inputs are whatever the producer-side source collectors emit — this bridge
+ * is where their vocabulary is pinned to Leitstand's read-only contracts.
  */
 import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { join, resolve, dirname } from 'node:path';
@@ -52,6 +54,14 @@ const BUREAU_NON_CLAIMS = [
 const CHECKOUT_NON_CLAIMS = [
   'checkout_ownership', 'cleanup_authority', 'branch_deletion', 'retention_decision', 'process_control',
 ];
+const DECISION_NON_CLAIMS = [
+  'task_or_priority_authority',
+  'queue_truth',
+  'focus_authority',
+  'runtime_or_convergence_authority',
+  'dispatch_or_mutation_authority',
+];
+const DECISION_SECTION_IDS = ['now', 'focus', 'blocked', 'convergence', 'later'];
 
 function normalizeBureauState(value) {
   const v = typeof value === 'string' ? value.toLowerCase() : '';
@@ -129,6 +139,35 @@ function mapCheckout(raw, runtimeHead) {
   };
 }
 
+function mapDecisionItem(raw) {
+  if (!raw || typeof raw !== 'object') throw new Error('decision-axis item must be an object');
+  const id = String(raw.id ?? '');
+  const title = String(raw.title ?? '');
+  if (!id || !title) throw new Error('decision-axis item requires id and title');
+  return {
+    id,
+    title,
+    detail: typeof raw.detail === 'string' ? raw.detail : '',
+    meta: typeof raw.meta === 'string' ? raw.meta : '',
+  };
+}
+
+function mapDecisionSection(raw, id) {
+  if (!raw || typeof raw !== 'object') throw new Error(`decision-axis section ${id} missing`);
+  if (!['available', 'unknown', 'unavailable'].includes(raw.status)) {
+    throw new Error(`decision-axis section ${id} has invalid status`);
+  }
+  if (typeof raw.source !== 'string' || raw.source.length === 0) {
+    throw new Error(`decision-axis section ${id} has no source`);
+  }
+  return {
+    status: raw.status,
+    source: raw.source,
+    observedAt: typeof raw.observedAt === 'string' ? raw.observedAt : null,
+    items: Array.isArray(raw.items) ? raw.items.slice(0, 8).map(mapDecisionItem) : [],
+  };
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const outDir = resolve(args['out-dir'] ?? 'artifacts');
@@ -171,8 +210,26 @@ async function main() {
     wrote += 1;
   }
 
+  if (args['decision-raw']) {
+    const raw = await readJson(resolve(args['decision-raw']));
+    const sections = Object.fromEntries(
+      DECISION_SECTION_IDS.map((id) => [id, mapDecisionSection(raw.sections?.[id], id)]),
+    );
+    const out = join(outDir, 'operator-decision-axis.json');
+    await writeJsonAtomic(out, {
+      schemaVersion: 1,
+      kind: 'leitstand_operator_decision_axis_snapshot',
+      generatedAt,
+      source: 'bureau_and_grabowski_read_only_projections',
+      doesNotEstablish: DECISION_NON_CLAIMS,
+      sections,
+    });
+    console.log(`decision-axis snapshot: ${Object.keys(sections).length} sections → ${out}`);
+    wrote += 1;
+  }
+
   if (wrote === 0) {
-    console.error('No inputs given. Provide --bureau-raw and/or --checkout-raw. See header for usage.');
+    console.error('No inputs given. Provide --bureau-raw, --checkout-raw and/or --decision-raw. See header for usage.');
     process.exit(2);
   }
 }

--- a/scripts/leitstand-export-operator-snapshots
+++ b/scripts/leitstand-export-operator-snapshots
@@ -113,6 +113,7 @@ allowed_snapshot_root = env_path(
     "BUREAU_REGISTRY_SNAPSHOT_ROOT", "/home/alex/.local/share/bureau/registry-snapshots"
 ).resolve()
 grabowski_repo = env_path("GRABOWSKI_REPO", "/home/alex/repos/grabowski")
+bureau_bin = env_path("BUREAU_BIN", "/home/alex/.local/bin/bureau")
 verify_only = os.environ.get("LEITSTAND_SNAPSHOT_VERIFY_ONLY", "").strip().lower() in {
     "1",
     "true",
@@ -260,6 +261,7 @@ if verify_only:
     raise SystemExit(0)
 
 from grabowski_checkouts import grabowski_checkout_inventory
+from grabowski_current_work_surface import grabowski_current_work
 
 artifact_root.mkdir(parents=True, exist_ok=True)
 queue = json.loads(snapshot_contents[queue_relative.as_posix()]).get("lanes", {})
@@ -333,11 +335,173 @@ inventory_result = grabowski_checkout_inventory(
 for worktree in inventory_result.get("worktrees", []):
     worktree.setdefault("repo", "grabowski")
 
+def bureau_read(command: list[str]) -> tuple[dict[str, object] | None, str | None]:
+    try:
+        completed = subprocess.run(
+            [str(bureau_bin), "--json", *command],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=25,
+        )
+        if completed.returncode != 0:
+            return None, f"bureau_exit_{completed.returncode}"
+        envelope = json.loads(completed.stdout)
+        result = envelope.get("result")
+        identity = envelope.get("runtime_identity")
+        if not isinstance(result, dict):
+            return None, "bureau_result_missing"
+        if not isinstance(identity, dict):
+            return None, "bureau_runtime_identity_missing"
+        identity_manifest = identity.get("manifest")
+        if not isinstance(identity_manifest, dict):
+            return None, "bureau_runtime_manifest_missing"
+        canonical_registry = identity_manifest.get("canonical_registry")
+        if not isinstance(canonical_registry, dict):
+            return None, "bureau_runtime_registry_identity_missing"
+        if (
+            identity_manifest.get("source_commit") != source_commit
+            or canonical_registry.get("source_commit") != source_commit
+            or canonical_registry.get("tree_sha256") != expected_tree
+            or canonical_registry.get("valid") is not True
+        ):
+            return None, "bureau_runtime_identity_mismatch"
+        return result, None
+    except (OSError, subprocess.TimeoutExpired, json.JSONDecodeError) as error:
+        return None, error.__class__.__name__
+
+
+def section(status: str, source: str, observed_at: str | None, items: list[dict[str, str]]) -> dict[str, object]:
+    return {
+        "status": status,
+        "source": source,
+        "observedAt": observed_at,
+        "items": items[:8],
+    }
+
+
+observed_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
+task_by_id = {str(task["id"]): task for task in tasks}
+status_projection, status_error = bureau_read(["status-projection", "--skip-github"])
+live_focus, focus_error = bureau_read(["live-list", "--kind", "thread_focus", "--limit", "50"])
+try:
+    convergence_projection = grabowski_current_work(
+        ["grabowski", "bureau", "leitstand", "systemkatalog", "weltgewebe", "repoground", "commonworld", "chronik"],
+        view="current",
+        limit=20,
+    )
+    convergence_error = None
+except Exception as error:
+    convergence_projection = None
+    convergence_error = error.__class__.__name__
+
+next_actions = status_projection.get("next_actions", []) if status_projection else []
+ranked_actions = [item for item in next_actions if isinstance(item, dict) and item.get("task_id")]
+
+def task_action_item(action: dict[str, object]) -> dict[str, str]:
+    task_id = str(action.get("task_id"))
+    task = task_by_id.get(task_id, {})
+    title = str(task.get("title") or task_id)
+    lane = str(action.get("queue_lane") or "unknown")
+    return {"id": task_id, "title": title, "detail": f"Bureau queue lane: {lane}", "meta": "Bureau status-projection"}
+
+now_items = [task_action_item(ranked_actions[0])] if ranked_actions else []
+later_items = [task_action_item(item) for item in ranked_actions[1:6]]
+status_observed_at = str(status_projection.get("generated_at")) if status_projection and status_projection.get("generated_at") else observed_at
+
+blocked_items: list[dict[str, str]] = []
+if status_projection:
+    for raw_task in status_projection.get("tasks", []):
+        if not isinstance(raw_task, dict):
+            continue
+        reasons = raw_task.get("blocked_reasons")
+        state = raw_task.get("effective_state")
+        if state != "blocked" and not (isinstance(reasons, list) and reasons):
+            continue
+        task_id = str(raw_task.get("task_id") or "")
+        if not task_id:
+            continue
+        reason_text = "; ".join(str(value) for value in (reasons or [])[:2]) or "Bureau reports blocked state"
+        blocked_items.append({
+            "id": task_id,
+            "title": str(raw_task.get("title") or task_id),
+            "detail": reason_text,
+            "meta": "Bureau status-projection",
+        })
+        if len(blocked_items) >= 8:
+            break
+
+focus_items: list[dict[str, str]] = []
+if live_focus:
+    active = live_focus.get("summary", {}).get("active_thread_focus", [])
+    if isinstance(active, list):
+        ordered = sorted(
+            (entry for entry in active if isinstance(entry, dict) and isinstance(entry.get("record"), dict)),
+            key=lambda entry: str(entry.get("created_at") or ""),
+            reverse=True,
+        )
+        for entry in ordered[:1]:
+            record = entry["record"]
+            thread_id = str(record.get("thread_id") or entry.get("event_id") or "focus")
+            focus_items.append({
+                "id": thread_id,
+                "title": str(record.get("title") or thread_id),
+                "detail": str(record.get("note") or "Latest active Bureau Live Register thread focus"),
+                "meta": f"{record.get('repo') or 'Bureau Live Register'} · created={entry.get('created_at') or 'unknown'}",
+            })
+
+convergence_items: list[dict[str, str]] = []
+convergence_observed_at = observed_at
+convergence_degraded = False
+if convergence_projection:
+    convergence_degraded = bool(
+        convergence_projection.get("warnings")
+        or convergence_projection.get("source_errors")
+        or any(convergence_projection.get("source_truncation", {}).values())
+    )
+    generated_unix = convergence_projection.get("generated_at_unix")
+    if isinstance(generated_unix, (int, float)):
+        convergence_observed_at = datetime.datetime.fromtimestamp(generated_unix, datetime.timezone.utc).isoformat()
+    summary = convergence_projection.get("convergence_summary", {})
+    if isinstance(summary, dict):
+        convergence_items.append({
+            "id": "convergence-summary",
+            "title": f"Primary stage: {summary.get('primary_stage', 'unknown')}",
+            "detail": str(convergence_projection.get("next_convergence_action") or "No convergence action projected"),
+            "meta": f"blocking={summary.get('blocking_count', 0)} · resumable={summary.get('resumable_count', 0)} · active={summary.get('active_count', 0)} · degraded={str(convergence_degraded).lower()}",
+        })
+    for work in convergence_projection.get("work", [])[:5]:
+        if not isinstance(work, dict):
+            continue
+        convergence_items.append({
+            "id": str(work.get("work_id") or "work"),
+            "title": str(work.get("work_id") or "Operator work"),
+            "detail": str(work.get("next_convergence_action") or ""),
+            "meta": str(work.get("convergence_stage") or work.get("projection_state") or "unknown"),
+        })
+
+decision_payload = {
+    "sections": {
+        "now": section("unavailable" if status_error else ("available" if now_items else "unknown"), "Bureau status-projection / registry queue", status_observed_at if not status_error else None, now_items),
+        "focus": section("unavailable" if focus_error else ("available" if focus_items else "unknown"), "Bureau Live Register", observed_at if not focus_error else None, focus_items),
+        "blocked": section("unavailable" if status_error else ("available" if blocked_items else "unknown"), "Bureau status-projection blocker evidence", status_observed_at if not status_error else None, blocked_items),
+        "convergence": section("unavailable" if convergence_error else ("unknown" if convergence_degraded or not convergence_items else "available"), "Grabowski current_work convergence projection", convergence_observed_at if not convergence_error else None, convergence_items),
+        "later": section("unavailable" if status_error else ("available" if later_items else "unknown"), "Bureau status-projection / registry queue", status_observed_at if not status_error else None, later_items),
+    },
+    "sourceErrors": {
+        "statusProjection": status_error,
+        "liveRegister": focus_error,
+        "convergence": convergence_error,
+    },
+}
+
 with tempfile.TemporaryDirectory(prefix="leitstand-snapshot-raw-") as temporary:
     raw_dir = Path(temporary)
     checkout_raw = raw_dir / "checkout-raw.json"
     bureau_raw = raw_dir / "bureau-raw.json"
+    decision_raw = raw_dir / "decision-raw.json"
     checkout_raw.write_text(json.dumps(inventory_result, indent=2, sort_keys=True) + "\n")
+    decision_raw.write_text(json.dumps(decision_payload, indent=2, sort_keys=True) + "\n")
     bureau_raw.write_text(
         json.dumps(
             {
@@ -370,6 +534,8 @@ with tempfile.TemporaryDirectory(prefix="leitstand-snapshot-raw-") as temporary:
             str(checkout_raw),
             "--bureau-raw",
             str(bureau_raw),
+            "--decision-raw",
+            str(decision_raw),
             "--runtime-head",
             runtime_head,
             "--out-dir",
@@ -380,5 +546,5 @@ with tempfile.TemporaryDirectory(prefix="leitstand-snapshot-raw-") as temporary:
         env={**os.environ, "NODE_OPTIONS": os.environ.get("NODE_OPTIONS", "--jitless")},
     )
 
-print(json.dumps({**evidence, "checkout_raw_count": len(inventory_result.get("worktrees", [])), "bureau_raw_count": len(tasks)}, sort_keys=True))
+print(json.dumps({**evidence, "checkout_raw_count": len(inventory_result.get("worktrees", [])), "bureau_raw_count": len(tasks), "decision_axis_sections": list(decision_payload["sections"]), "decision_axis_source_errors": decision_payload["sourceErrors"]}, sort_keys=True))
 PY

--- a/src/controllers/dashboard.ts
+++ b/src/controllers/dashboard.ts
@@ -1,5 +1,6 @@
 import { getBureauData } from './bureau.js';
 import { getCheckoutData } from './checkouts.js';
+import { getDecisionAxisData, type DecisionAxisViewData } from './decisionAxis.js';
 import { getStorageHealthData } from './storageHealth.js';
 import { getEcosystemMapData } from './ecosystemMap.js';
 import { getRepoBriefData } from './repoBrief.js';
@@ -39,6 +40,7 @@ export interface DashboardSummary {
 export interface DashboardData {
   sources: DashboardSource[];
   summary: DashboardSummary;
+  decision_axis: DecisionAxisViewData;
 }
 
 function publicErrorReason(msg: string): string {
@@ -155,9 +157,10 @@ export function summarizeDashboard(sources: DashboardSource[]): DashboardSummary
 }
 
 export async function getDashboardData(): Promise<DashboardData> {
-  const [bureau, checkouts, storage, eco, repo] = await Promise.all([
+  const [bureau, checkouts, decisionAxis, storage, eco, repo] = await Promise.all([
     safeLoad('Bureau', getBureauData),
     safeLoad('Checkouts', getCheckoutData),
+    safeLoad('DecisionAxis', getDecisionAxisData),
     safeLoad('Storage', getStorageHealthData),
     safeLoad('Ecosystem', getEcosystemMapData),
     safeLoad('RepoGround', getRepoBriefData),
@@ -226,5 +229,20 @@ export async function getDashboardData(): Promise<DashboardData> {
     }
   ];
 
-  return { sources, summary: summarizeDashboard(sources) };
+  return {
+    sources,
+    summary: summarizeDashboard(sources),
+    decision_axis: decisionAxis.data ?? {
+      sections: [],
+      view_meta: {
+        source_kind: 'missing',
+        source_path: '',
+        source_path_display: '<unavailable>',
+        missing_reason: decisionAxis.error ?? 'decision_axis_load_failed',
+        generated_at: null,
+        freshness_state: 'unknown',
+        does_not_establish: ['dispatch_or_mutation_authority'],
+      },
+    },
+  };
 }

--- a/src/controllers/decisionAxis.ts
+++ b/src/controllers/decisionAxis.ts
@@ -1,0 +1,177 @@
+import { readFile } from 'node:fs/promises';
+import { join, relative, resolve } from 'node:path';
+
+export type DecisionSourceKind = 'artifact' | 'missing' | 'corrupt';
+export type DecisionFreshness = 'fresh' | 'stale' | 'unknown';
+export type DecisionSectionStatus = 'available' | 'unknown' | 'unavailable';
+
+export interface DecisionAxisItem {
+  id: string;
+  title: string;
+  detail: string;
+  meta: string;
+}
+
+export interface DecisionAxisSection {
+  id: 'now' | 'focus' | 'blocked' | 'convergence' | 'later';
+  label: 'Jetzt' | 'Im Fokus' | 'Blockiert' | 'Konvergenz' | 'Danach';
+  status: DecisionSectionStatus;
+  source: string;
+  observed_at: string | null;
+  freshness_state: DecisionFreshness;
+  items: DecisionAxisItem[];
+}
+
+export interface DecisionAxisViewData {
+  sections: DecisionAxisSection[];
+  view_meta: {
+    source_kind: DecisionSourceKind;
+    source_path: string;
+    source_path_display: string;
+    missing_reason: string;
+    generated_at: string | null;
+    freshness_state: DecisionFreshness;
+    does_not_establish: string[];
+  };
+}
+
+const CONTRACT_KIND = 'leitstand_operator_decision_axis_snapshot';
+const STALE_AFTER_MS = 20 * 60 * 1000;
+const SECTION_ORDER: Array<{ id: DecisionAxisSection['id']; label: DecisionAxisSection['label'] }> = [
+  { id: 'now', label: 'Jetzt' },
+  { id: 'focus', label: 'Im Fokus' },
+  { id: 'blocked', label: 'Blockiert' },
+  { id: 'convergence', label: 'Konvergenz' },
+  { id: 'later', label: 'Danach' },
+];
+const DEFAULT_NON_CLAIMS = [
+  'task_or_priority_authority',
+  'queue_truth',
+  'focus_authority',
+  'runtime_or_convergence_authority',
+  'dispatch_or_mutation_authority',
+];
+
+function snapshotPath(): string {
+  return process.env.LEITSTAND_DECISION_AXIS_SNAPSHOT_PATH
+    || join(process.cwd(), 'artifacts', 'operator-decision-axis.json');
+}
+
+function freshnessOf(value: string | null): DecisionFreshness {
+  if (!value) return 'unknown';
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) return 'unknown';
+  return Date.now() - timestamp <= STALE_AFTER_MS ? 'fresh' : 'stale';
+}
+
+function displaySourcePath(sourcePath: string): string {
+  const rel = relative(resolve(process.cwd()), resolve(sourcePath));
+  if (rel && !rel.startsWith('..') && !rel.startsWith('/')) return rel;
+  return '<external snapshot>';
+}
+
+function parseItem(raw: unknown): DecisionAxisItem {
+  if (!raw || typeof raw !== 'object') throw new Error('invalid decision-axis item');
+  const item = raw as Record<string, unknown>;
+  const id = typeof item.id === 'string' ? item.id : '';
+  const title = typeof item.title === 'string' ? item.title : '';
+  if (!id || !title) throw new Error('invalid decision-axis item identity');
+  return {
+    id,
+    title,
+    detail: typeof item.detail === 'string' ? item.detail : '',
+    meta: typeof item.meta === 'string' ? item.meta : '',
+  };
+}
+
+function parseSnapshot(raw: unknown): Omit<DecisionAxisViewData, 'view_meta'> & {
+  generatedAt: string | null;
+  doesNotEstablish: string[];
+} {
+  if (!raw || typeof raw !== 'object') throw new Error('invalid decision-axis snapshot');
+  const snapshot = raw as Record<string, unknown>;
+  if (snapshot.schemaVersion !== 1 || snapshot.kind !== CONTRACT_KIND) {
+    throw new Error('invalid decision-axis snapshot contract');
+  }
+  const rawSections = snapshot.sections;
+  if (!rawSections || typeof rawSections !== 'object' || Array.isArray(rawSections)) {
+    throw new Error('invalid decision-axis sections');
+  }
+  const sectionsObject = rawSections as Record<string, unknown>;
+  const sections = SECTION_ORDER.map(({ id, label }) => {
+    const rawSection = sectionsObject[id];
+    if (!rawSection || typeof rawSection !== 'object') throw new Error(`missing decision-axis section ${id}`);
+    const section = rawSection as Record<string, unknown>;
+    const status = section.status;
+    if (status !== 'available' && status !== 'unknown' && status !== 'unavailable') {
+      throw new Error(`invalid decision-axis section status ${id}`);
+    }
+    const observedAt = typeof section.observedAt === 'string' ? section.observedAt : null;
+    const items = Array.isArray(section.items) ? section.items.slice(0, 8).map(parseItem) : [];
+    return {
+      id,
+      label,
+      status,
+      source: typeof section.source === 'string' && section.source ? section.source : 'unknown',
+      observed_at: observedAt,
+      freshness_state: freshnessOf(observedAt),
+      items,
+    } satisfies DecisionAxisSection;
+  });
+  const nonClaims = Array.isArray(snapshot.doesNotEstablish)
+    ? snapshot.doesNotEstablish.filter((item): item is string => typeof item === 'string')
+    : [];
+  return {
+    sections,
+    generatedAt: typeof snapshot.generatedAt === 'string' ? snapshot.generatedAt : null,
+    doesNotEstablish: nonClaims.length > 0 ? nonClaims : DEFAULT_NON_CLAIMS,
+  };
+}
+
+function emptyData(kind: DecisionSourceKind, reason: string, sourcePath: string): DecisionAxisViewData {
+  return {
+    sections: SECTION_ORDER.map(({ id, label }) => ({
+      id,
+      label,
+      status: 'unavailable',
+      source: 'unknown',
+      observed_at: null,
+      freshness_state: 'unknown',
+      items: [],
+    })),
+    view_meta: {
+      source_kind: kind,
+      source_path: sourcePath,
+      source_path_display: displaySourcePath(sourcePath),
+      missing_reason: reason,
+      generated_at: null,
+      freshness_state: 'unknown',
+      does_not_establish: DEFAULT_NON_CLAIMS,
+    },
+  };
+}
+
+export async function getDecisionAxisData(): Promise<DecisionAxisViewData> {
+  const sourcePath = resolve(snapshotPath());
+  try {
+    const parsed = parseSnapshot(JSON.parse(await readFile(sourcePath, 'utf-8')) as unknown);
+    return {
+      sections: parsed.sections,
+      view_meta: {
+        source_kind: 'artifact',
+        source_path: sourcePath,
+        source_path_display: displaySourcePath(sourcePath),
+        missing_reason: 'ok',
+        generated_at: parsed.generatedAt,
+        freshness_state: freshnessOf(parsed.generatedAt),
+        does_not_establish: parsed.doesNotEstablish,
+      },
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+    if (message.includes('enoent') || message.includes('no such file')) {
+      return emptyData('missing', 'decision_axis_snapshot_missing', sourcePath);
+    }
+    return emptyData('corrupt', 'decision_axis_snapshot_corrupt', sourcePath);
+  }
+}

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -2,6 +2,8 @@
   const sourceCards = Array.isArray(locals.sources) ? locals.sources : [];
   const dashboardSummary = locals.summary && typeof locals.summary === 'object' ? locals.summary : null;
   const attentionItems = Array.isArray(dashboardSummary?.attention) ? dashboardSummary.attention : [];
+  const decisionAxis = locals.decision_axis && typeof locals.decision_axis === 'object' ? locals.decision_axis : null;
+  const decisionSections = Array.isArray(decisionAxis?.sections) ? decisionAxis.sections : [];
 %>
 <!DOCTYPE html>
 <html lang="de">
@@ -128,6 +130,23 @@
       font-size: 0.72em;
       line-height: 1.45;
     }
+
+
+    .decision-axis { margin-bottom: 32px; }
+    .decision-axis-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; }
+    .decision-card { padding: 16px; border: 1px solid var(--border-glass); border-radius: 12px; background: var(--bg-card); }
+    .decision-card h3 { margin: 0 0 8px; font-size: 0.95em; }
+    .decision-source { color: var(--text-muted); font-size: 0.7em; line-height: 1.4; margin-bottom: 10px; }
+    .decision-list { display: grid; gap: 8px; list-style: none; padding: 0; margin: 0; }
+    .decision-item { padding-top: 8px; border-top: 1px solid var(--border-glass); }
+    .decision-item:first-child { border-top: 0; padding-top: 0; }
+    .decision-title { font-size: 0.82em; font-weight: 650; }
+    .decision-detail { color: var(--text-secondary); font-size: 0.74em; line-height: 1.4; }
+    .decision-meta { color: var(--text-muted); font-size: 0.68em; margin-top: 4px; }
+    .decision-empty { color: var(--text-muted); font-size: 0.78em; }
+    .decision-status-unavailable { border-left: 3px solid var(--fail); }
+    .decision-status-unknown { border-left: 3px solid var(--warn); }
+    .decision-status-available { border-left: 3px solid var(--ok); }
 
     .source-grid {
       display: grid;
@@ -336,6 +355,33 @@
         </p>
       </section>
     <% } %>
+
+
+    <section class="decision-axis" aria-labelledby="decision-axis-heading">
+      <h2 id="decision-axis-heading" class="section-title ui-section-title">Entscheidungsachse</h2>
+      <p class="projection-note">Read-only-Projektion vorhandener Bureau- und Grabowski-Wahrheiten. Keine lokale Prioritäts-, Queue-, Fokus- oder Konvergenzwahrheit.</p>
+      <div class="decision-axis-grid">
+        <% decisionSections.forEach(function(section) { %>
+          <article class="decision-card decision-status-<%= section.status %>" data-decision-section="<%= section.id %>">
+            <h3><%= section.label %></h3>
+            <p class="decision-source">Quelle: <%= section.source %> · <%= section.freshness_state === 'fresh' ? 'frisch' : section.freshness_state === 'stale' ? 'veraltet' : 'Frische unbekannt' %></p>
+            <% if (section.items.length > 0) { %>
+              <ol class="decision-list">
+                <% section.items.forEach(function(item) { %>
+                  <li class="decision-item">
+                    <div class="decision-title"><%= item.title %></div>
+                    <% if (item.detail) { %><div class="decision-detail"><%= item.detail %></div><% } %>
+                    <% if (item.meta) { %><div class="decision-meta"><%= item.meta %></div><% } %>
+                  </li>
+                <% }); %>
+              </ol>
+            <% } else { %>
+              <p class="decision-empty"><%= section.status === 'unavailable' ? 'Quelle nicht verfügbar.' : 'Aktuell kein belegter Eintrag.' %></p>
+            <% } %>
+          </article>
+        <% }); %>
+      </div>
+    </section>
 
     <section aria-labelledby="quellen-heading">
       <h2 id="quellen-heading" class="section-title ui-section-title">Operative Quellen</h2>

--- a/tests/controllers/decisionAxis.test.ts
+++ b/tests/controllers/decisionAxis.test.ts
@@ -1,0 +1,73 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getDecisionAxisData } from '../../src/controllers/decisionAxis.js';
+
+const roots: string[] = [];
+const previousPath = process.env.LEITSTAND_DECISION_AXIS_SNAPSHOT_PATH;
+
+afterEach(async () => {
+  vi.useRealTimers();
+  if (previousPath === undefined) delete process.env.LEITSTAND_DECISION_AXIS_SNAPSHOT_PATH;
+  else process.env.LEITSTAND_DECISION_AXIS_SNAPSHOT_PATH = previousPath;
+  for (const root of roots) await rm(root, { recursive: true, force: true });
+  roots.length = 0;
+});
+
+async function writeSnapshot(generatedAt: string, overrides: Record<string, unknown> = {}): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'leitstand-decision-axis-'));
+  roots.push(root);
+  const path = join(root, 'operator-decision-axis.json');
+  const section = (source: string, items: unknown[] = []) => ({ status: items.length ? 'available' : 'unknown', source, observedAt: generatedAt, items });
+  await writeFile(path, JSON.stringify({
+    schemaVersion: 1,
+    kind: 'leitstand_operator_decision_axis_snapshot',
+    generatedAt,
+    doesNotEstablish: ['queue_truth', 'dispatch_or_mutation_authority'],
+    sections: {
+      now: section('Bureau status-projection', [{ id: 'T1', title: 'Now', detail: 'ranked', meta: 'now' }]),
+      focus: section('Bureau Live Register', [{ id: 'F1', title: 'Focus', detail: 'active', meta: 'focus' }]),
+      blocked: section('Bureau blocker evidence', [{ id: 'B1', title: 'Blocked', detail: 'reason', meta: 'blocked' }]),
+      convergence: section('Grabowski current_work', [{ id: 'C1', title: 'Convergence', detail: 'action', meta: 'blocking' }]),
+      later: section('Bureau status-projection', [{ id: 'T2', title: 'Later', detail: 'ranked', meta: 'later' }]),
+      ...overrides,
+    },
+  }), 'utf-8');
+  return path;
+}
+
+describe('decision axis controller', () => {
+  it('renders all five read-only source-bound sections from a fresh snapshot', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-23T20:10:00Z'));
+    process.env.LEITSTAND_DECISION_AXIS_SNAPSHOT_PATH = await writeSnapshot('2026-07-23T20:00:00Z');
+
+    const data = await getDecisionAxisData();
+
+    expect(data.sections.map((section) => section.id)).toEqual(['now', 'focus', 'blocked', 'convergence', 'later']);
+    expect(data.sections.every((section) => section.freshness_state === 'fresh')).toBe(true);
+    expect(data.view_meta.source_kind).toBe('artifact');
+    expect(data.view_meta.does_not_establish).toContain('queue_truth');
+  });
+
+  it('marks stale sections stale without inventing replacement values', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-23T21:00:00Z'));
+    process.env.LEITSTAND_DECISION_AXIS_SNAPSHOT_PATH = await writeSnapshot('2026-07-23T20:00:00Z', {
+      now: { status: 'unknown', source: 'Bureau status-projection', observedAt: '2026-07-23T20:00:00Z', items: [] },
+      later: { status: 'unknown', source: 'Bureau status-projection', observedAt: '2026-07-23T20:00:00Z', items: [] },
+    });
+
+    const data = await getDecisionAxisData();
+    expect(data.sections.find((section) => section.id === 'now')).toMatchObject({ status: 'unknown', items: [], freshness_state: 'stale' });
+    expect(data.sections.find((section) => section.id === 'later')).toMatchObject({ status: 'unknown', items: [] });
+  });
+
+  it('degrades every section explicitly when the snapshot is missing', async () => {
+    process.env.LEITSTAND_DECISION_AXIS_SNAPSHOT_PATH = '/definitely/missing/operator-decision-axis.json';
+    const data = await getDecisionAxisData();
+    expect(data.view_meta.source_kind).toBe('missing');
+    expect(data.sections.every((section) => section.status === 'unavailable' && section.items.length === 0)).toBe(true);
+  });
+});

--- a/tests/exportDecisionAxis.test.ts
+++ b/tests/exportDecisionAxis.test.ts
@@ -1,0 +1,69 @@
+import { execFile } from 'node:child_process';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { promisify } from 'node:util';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+const scriptPath = resolve('scripts/export-operator-snapshots.mjs');
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const root of roots) await rm(root, { recursive: true, force: true });
+  roots.length = 0;
+});
+
+it('exports a bounded five-section decision axis without creating local authority', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'leitstand-decision-export-'));
+  roots.push(root);
+  const rawPath = join(root, 'decision.json');
+  const outDir = join(root, 'out');
+  const many = Array.from({ length: 12 }, (_, index) => ({
+    id: `B${index}`,
+    title: `Blocked ${index}`,
+    detail: 'source-bound blocker',
+    meta: 'Bureau',
+  }));
+  const section = (source: string, items: unknown[], status = 'available') => ({
+    status,
+    source,
+    observedAt: '2026-07-23T20:00:00Z',
+    items,
+  });
+  await writeFile(rawPath, JSON.stringify({
+    sections: {
+      now: section('Bureau status-projection / registry queue', [{ id: 'T1', title: 'Now' }]),
+      focus: section('Bureau Live Register', [{ id: 'F1', title: 'Focus' }]),
+      blocked: section('Bureau status-projection blocker evidence', many),
+      convergence: section('Grabowski current_work convergence projection', many),
+      later: section('Bureau status-projection / registry queue', [], 'unknown'),
+    },
+  }), 'utf-8');
+
+  await execFileAsync(process.execPath, [scriptPath, '--decision-raw', rawPath, '--out-dir', outDir]);
+  const snapshot = JSON.parse(await readFile(join(outDir, 'operator-decision-axis.json'), 'utf-8')) as {
+    kind: string;
+    doesNotEstablish: string[];
+    sections: Record<string, { status: string; items: unknown[] }>;
+  };
+
+  expect(snapshot.kind).toBe('leitstand_operator_decision_axis_snapshot');
+  expect(Object.keys(snapshot.sections)).toEqual(['now', 'focus', 'blocked', 'convergence', 'later']);
+  expect(snapshot.sections.blocked.items).toHaveLength(8);
+  expect(snapshot.sections.convergence.items).toHaveLength(8);
+  expect(snapshot.sections.later).toMatchObject({ status: 'unknown', items: [] });
+  expect(snapshot.doesNotEstablish).toContain('task_or_priority_authority');
+  expect(snapshot.doesNotEstablish).toContain('dispatch_or_mutation_authority');
+});
+
+describe('observer boundary', () => {
+  it('keeps Bureau and Grabowski collection out of request-time controller code', async () => {
+    const controller = await readFile(resolve('src/controllers/decisionAxis.ts'), 'utf-8');
+    const dashboard = await readFile(resolve('src/controllers/dashboard.ts'), 'utf-8');
+    expect(controller).not.toContain('child_process');
+    expect(controller).not.toContain('grabowski_current_work');
+    expect(dashboard).not.toContain('child_process');
+    expect(controller).toContain('operator-decision-axis.json');
+  });
+});


### PR DESCRIPTION
Implements OPERATOR-MACHINE-READABILITY-V1-T024.

- adds a five-section read-only decision-axis snapshot: Jetzt, Im Fokus, Blockiert, Konvergenz, Danach
- binds Bureau projections to the verified canonical runtime/registry identity
- reuses Bureau status projection, Bureau Live Register, and Grabowski current_work without request-time calls
- degrades missing, stale, or incomplete evidence instead of inventing values
- documents authority boundaries and adds controller/exporter tests

Validation:
- full local CI + repository/drift/observer guards green
- real producer proof against current Bureau/Grabowski sources green
- no new mutation, task, priority, queue, focus, or convergence authority