### PR TITLE
feat(ui): refine shared shell density and mobile navigation

### DIFF
--- a/scripts/browser-shell-regression.mjs
+++ b/scripts/browser-shell-regression.mjs
@@ -87,6 +87,9 @@ async function readState(page) {
       navRight: navRect?.right ?? null,
       navPosition: nav ? getComputedStyle(nav).position : null,
       navBoxSizing: nav ? getComputedStyle(nav).boxSizing : null,
+      linksPosition: links ? getComputedStyle(links).position : null,
+      linksBottom: links?.getBoundingClientRect().bottom ?? null,
+      innerHeight: window.innerHeight,
     };
   });
 }
@@ -129,6 +132,8 @@ async function runViewport(browser, viewport, html) {
       record(checks, 'mobile opens', state.expanded === 'true' && state.linksHidden === false && state.navExpanded === 'true');
       record(checks, 'open label is explicit', state.toggleLabel === 'Navigation schließen', state.toggleLabel);
       record(checks, 'open menu has no overflow', state.scrollWidth <= state.innerWidth + 1, `${state.scrollWidth}/${state.innerWidth}`);
+      record(checks, 'mobile menu overlays content', state.linksPosition === 'absolute', state.linksPosition);
+      record(checks, 'mobile menu stays inside viewport', state.linksBottom !== null && state.linksBottom <= state.innerHeight + 1, `${state.linksBottom}/${state.innerHeight}`);
 
       await page.keyboard.press('Escape');
       await waitFrames(page);
@@ -138,7 +143,7 @@ async function runViewport(browser, viewport, html) {
 
       await page.locator('[data-leitstand-nav-toggle]').click();
       await waitFrames(page);
-      await page.locator('#outside-target').click();
+      await page.mouse.click(viewport.width - 12, viewport.height - 12);
       await waitFrames(page);
       state = await readState(page);
       record(checks, 'outside click closes', state.expanded === 'false' && state.linksHidden === true);

--- a/src/public/shell.css
+++ b/src/public/shell.css
@@ -40,15 +40,16 @@
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
   align-items: center;
-  gap: 12px;
+  gap: 14px;
   width: 100%;
-  min-height: 52px;
+  min-height: 54px;
   padding: 8px clamp(12px, 2vw, 24px);
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-  background: rgba(10, 14, 26, 0.96);
+  background: rgba(10, 14, 26, 0.94);
   color: #f1f5f9;
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
+  box-shadow: 0 10px 28px rgba(2, 6, 23, 0.16);
+  backdrop-filter: blur(14px) saturate(1.08);
+  -webkit-backdrop-filter: blur(14px) saturate(1.08);
 }
 
 .leitstand-nav__brand,
@@ -60,11 +61,11 @@
 .leitstand-nav__brand {
   display: inline-flex;
   align-items: center;
-  min-height: 36px;
+  min-height: 38px;
   padding: 6px 10px;
-  border-radius: 8px;
+  border-radius: 9px;
   font-size: 0.9rem;
-  font-weight: 750;
+  font-weight: 760;
   letter-spacing: -0.01em;
   white-space: nowrap;
 }
@@ -72,24 +73,26 @@
 .leitstand-nav__links {
   display: flex;
   align-items: center;
-  gap: 3px;
+  gap: 4px;
   min-width: 0;
   overflow-x: auto;
   overscroll-behavior-inline: contain;
   scrollbar-width: thin;
   scrollbar-color: rgba(148, 163, 184, 0.5) transparent;
+  scroll-padding-inline: 8px;
 }
 
 .leitstand-nav__link {
+  position: relative;
   display: inline-flex;
   align-items: center;
-  min-height: 36px;
-  padding: 7px 10px;
+  min-height: 38px;
+  padding: 8px 11px;
   border: 1px solid transparent;
-  border-radius: 8px;
+  border-radius: 9px;
   color: #aab7ca;
   font-size: 0.79rem;
-  font-weight: 600;
+  font-weight: 620;
   line-height: 1;
   white-space: nowrap;
   transition: color 120ms ease, background-color 120ms ease, border-color 120ms ease;
@@ -103,9 +106,22 @@
 
 .leitstand-nav__link.active,
 .leitstand-nav__link[aria-current="page"] {
-  border-color: rgba(96, 165, 250, 0.32);
-  background: rgba(59, 130, 246, 0.14);
-  color: #bfdbfe;
+  border-color: rgba(96, 165, 250, 0.34);
+  background: linear-gradient(180deg, rgba(59, 130, 246, 0.18), rgba(59, 130, 246, 0.1));
+  color: #dbeafe;
+}
+
+.leitstand-nav__link.active::after,
+.leitstand-nav__link[aria-current="page"]::after {
+  position: absolute;
+  right: 10px;
+  bottom: 3px;
+  left: 10px;
+  height: 2px;
+  border-radius: 999px;
+  background: #60a5fa;
+  content: '';
+  opacity: 0.8;
 }
 
 .leitstand-nav__brand:focus-visible,
@@ -120,10 +136,10 @@
   align-items: center;
   justify-content: center;
   gap: 8px;
-  min-height: 38px;
-  padding: 7px 11px;
+  min-height: 42px;
+  padding: 8px 12px;
   border: 1px solid rgba(255, 255, 255, 0.16);
-  border-radius: 8px;
+  border-radius: 9px;
   background: rgba(255, 255, 255, 0.05);
   color: #e2e8f0;
   font: inherit;
@@ -146,6 +162,11 @@
     -webkit-backdrop-filter: none;
   }
 
+  .leitstand-nav[data-expanded="true"] {
+    border-bottom-color: rgba(96, 165, 250, 0.24);
+    box-shadow: 0 16px 34px rgba(2, 6, 23, 0.34);
+  }
+
   .leitstand-nav__toggle {
     display: inline-flex;
   }
@@ -164,14 +185,32 @@
     overflow: visible;
   }
 
+  html.leitstand-shell-ready .leitstand-nav__links {
+    position: absolute;
+    top: calc(100% + 8px);
+    right: clamp(8px, 2vw, 20px);
+    left: clamp(8px, 2vw, 20px);
+    z-index: 110;
+    max-height: min(70vh, calc(100dvh - 84px));
+    padding: 8px;
+    overflow-x: hidden;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 12px;
+    background: rgba(15, 23, 42, 0.985);
+    box-shadow: 0 22px 50px rgba(2, 6, 23, 0.52);
+    scrollbar-gutter: stable;
+  }
+
   html.leitstand-shell-ready .leitstand-nav__links[hidden] {
     display: none;
   }
 
   .leitstand-nav__link {
     justify-content: flex-start;
-    min-height: 42px;
-    padding: 10px 12px;
+    min-height: 44px;
+    padding: 11px 12px;
     border-color: rgba(255, 255, 255, 0.08);
     background: rgba(255, 255, 255, 0.025);
     font-size: 0.86rem;
@@ -179,8 +218,18 @@
 }
 
 @media (max-width: 520px) {
-  .leitstand-nav__links {
+  .leitstand-nav {
+    padding-inline: 10px;
+  }
+
+  .leitstand-nav__links,
+  html.leitstand-shell-ready .leitstand-nav__links {
     grid-template-columns: 1fr;
+  }
+
+  html.leitstand-shell-ready .leitstand-nav__links {
+    right: 8px;
+    left: 8px;
   }
 }
 

--- a/src/public/shell.mjs
+++ b/src/public/shell.mjs
@@ -2,10 +2,15 @@ const nav = document.querySelector('[data-leitstand-nav]');
 const toggle = nav?.querySelector('[data-leitstand-nav-toggle]');
 const links = nav?.querySelector('[data-leitstand-nav-links]');
 const toggleIcon = toggle?.querySelector('.leitstand-nav__toggle-icon');
+const activeLink = links?.querySelector('[aria-current="page"]');
 
 if (nav && toggle && links) {
   const mobileQuery = window.matchMedia('(max-width: 960px)');
   document.documentElement.classList.add('leitstand-shell-ready');
+
+  const keepActiveLinkVisible = () => {
+    activeLink?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+  };
 
   const setExpanded = (expanded, { restoreFocus = false } = {}) => {
     const mobile = mobileQuery.matches;
@@ -15,6 +20,7 @@ if (nav && toggle && links) {
     toggle.setAttribute('aria-label', next ? 'Navigation schließen' : 'Navigation öffnen');
     links.hidden = mobile && !next;
     if (toggleIcon) toggleIcon.textContent = next ? '×' : '☰';
+    if (!mobile || next) window.requestAnimationFrame(keepActiveLinkVisible);
     if (restoreFocus) toggle.focus();
   };
 

--- a/src/public/ui-system.css
+++ b/src/public/ui-system.css
@@ -49,20 +49,24 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background: var(--ui-bg);
+  background:
+    radial-gradient(circle at 50% -20%, rgba(59, 130, 246, 0.09), transparent 38rem),
+    var(--ui-bg);
   color: var(--ui-text);
   font-family: var(--ui-font-sans);
+  font-synthesis: none;
+  line-height: 1.5;
+  text-rendering: optimizeLegibility;
 }
 
 main {
   width: min(100%, 1180px);
   margin: 0 auto;
-  padding: 42px 24px 80px;
+  padding: clamp(30px, 4vw, 48px) clamp(14px, 3vw, 28px) 88px;
 }
 
 main.ui-main--compact {
-  max-width: 1080px;
-  padding: 48px 24px 96px;
+  max-width: 1120px;
 }
 
 main.ui-main--wide {
@@ -72,6 +76,7 @@ main.ui-main--wide {
 h1,
 h2 {
   letter-spacing: -0.02em;
+  text-wrap: balance;
 }
 
 h1 {
@@ -81,7 +86,11 @@ h1 {
 }
 
 .page-header {
-  margin-bottom: 24px;
+  margin-bottom: clamp(22px, 3vw, 32px);
+}
+
+.page-header .subtitle {
+  max-width: 76ch;
 }
 
 .page-header h1 {
@@ -114,6 +123,7 @@ h1 {
   border: 1px solid var(--ui-border);
   border-radius: var(--ui-radius);
   background: var(--ui-bg-surface);
+  box-shadow: 0 12px 30px rgba(2, 6, 23, 0.12);
 }
 
 .notice,
@@ -167,6 +177,7 @@ code,
 
 .value {
   font-size: 0.82em;
+  font-variant-numeric: tabular-nums;
 }
 
 code {
@@ -179,6 +190,23 @@ ul {
 
 .table-wrap {
   overflow-x: auto;
+  scrollbar-gutter: stable;
+}
+
+.table-wrap thead th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: #111827;
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+tbody tr {
+  transition: background-color 120ms ease;
+}
+
+tbody tr:hover {
+  background: rgba(255, 255, 255, 0.025);
 }
 
 table {
@@ -214,7 +242,9 @@ th {
   padding: 3px 9px;
   border: 1px solid var(--ui-border-strong);
   border-radius: 999px;
+  background: rgba(255, 255, 255, 0.025);
   font-size: 0.78em;
+  font-weight: 600;
 }
 
 .fresh,
@@ -323,7 +353,7 @@ th {
   main,
   main.ui-main--compact,
   main.ui-main--wide {
-    padding: 28px 14px 60px;
+    padding: 26px 12px 58px;
   }
 
   h1 {

--- a/tests/views/navigation.test.ts
+++ b/tests/views/navigation.test.ts
@@ -82,6 +82,10 @@ describe('canonical navigation parity', () => {
     expect(css).toContain('prefers-reduced-motion');
     expect(script).toContain("event.key === 'Escape'");
     expect(script).toContain("window.matchMedia('(max-width: 960px)')");
+    expect(script).toContain("scrollIntoView({ block: 'nearest', inline: 'nearest' })");
+    expect(css).toContain('html.leitstand-shell-ready .leitstand-nav__links');
+    expect(css).toContain('position: absolute');
+    expect(css).toContain('max-height: min(70vh, calc(100dvh - 84px))');
   });
 
   it('binds the real browser shell regression into CI', () => {


### PR DESCRIPTION
## Summary
- turn the mobile navigation into a bounded overlay so opening it no longer pushes page content down
- keep the active navigation entry visible and strengthen current-page affordance
- improve shared scanability with responsive spacing, tabular values, sticky table headers, row hover and restrained surface depth
- extend the real browser-shell regression for overlay geometry, viewport bounds and outside-click behavior

## Validation
- git diff --check
- pnpm test
- pnpm run test:browser-shell
- pnpm run test:browser-views
- NODE_OPTIONS=--jitless pnpm run typecheck
- NODE_OPTIONS=--jitless pnpm run lint
- NODE_OPTIONS=--jitless pnpm run build

## Scope
This intentionally does not touch `src/views/index.ejs`, because the parallel read-only decision-axis work owns that surface. The changes are limited to the shared shell/design layer and its regressions.