### PR TITLE
fix(map): accept resilience semantics artifact

### DIFF
--- a/scripts/browser-view-regression.mjs
+++ b/scripts/browser-view-regression.mjs
@@ -27,6 +27,7 @@ const ARTIFACT_CONTRACT = [
   ['registry_nodes', 'registry/ecosystem/nodes.json', 'application/json'],
   ['registry_edges', 'registry/ecosystem/edges.json', 'application/json'],
   ['authority_matrix', 'registry/ecosystem/authority-matrix.v1.json', 'application/json'],
+  ['resilience_semantics', 'registry/ecosystem/resilience.v1.json', 'application/json'],
 ];
 const DOES_NOT_ESTABLISH = [
   'claim_truth',
@@ -106,6 +107,7 @@ async function createEcosystemFixture(root) {
     ['registry/ecosystem/nodes.json', '{"schemaVersion":1,"nodes":[]}\n'],
     ['registry/ecosystem/edges.json', '{"schemaVersion":1,"edges":[]}\n'],
     ['registry/ecosystem/authority-matrix.v1.json', '{"schemaVersion":1,"authorities":[]}\n'],
+    ['registry/ecosystem/resilience.v1.json', '{"schema_version":1,"components":[]}\n'],
   ]);
 
   for (const [rel, content] of contents) {

--- a/src/controllers/ecosystemMap.ts
+++ b/src/controllers/ecosystemMap.ts
@@ -41,6 +41,11 @@ const ARTIFACT_CONTRACT = [
     path: 'registry/ecosystem/authority-matrix.v1.json',
     contentType: 'application/json',
   },
+  {
+    role: 'resilience_semantics',
+    path: 'registry/ecosystem/resilience.v1.json',
+    contentType: 'application/json',
+  },
 ] as const;
 
 const DOES_NOT_ESTABLISH_CONTRACT = [
@@ -133,6 +138,7 @@ export interface EcosystemMapViewData {
     alignment_state: EcosystemMapAlignment;
     alignment_reason: string;
     verified_artifact_count: number;
+    declared_artifact_count: number;
     generated_at: string | null;
     data_age_minutes: number | null;
     freshness_state: EcosystemMapFreshness;
@@ -195,6 +201,7 @@ function emptyData(
       alignment_state: 'unverifiable',
       alignment_reason: reason,
       verified_artifact_count: 0,
+      declared_artifact_count: ARTIFACT_CONTRACT.length,
       generated_at: null,
       data_age_minutes: null,
       freshness_state: 'unknown',
@@ -640,6 +647,7 @@ export async function getEcosystemMapData(): Promise<EcosystemMapViewData> {
         alignment_state: alignment.state,
         alignment_reason: alignment.reason,
         verified_artifact_count: alignment.verifiedArtifactCount,
+        declared_artifact_count: manifest.artifactCount,
         generated_at: ageState.generated_at,
         data_age_minutes: ageState.data_age_minutes,
         freshness_state: combinedFreshness.state,

--- a/src/views/ecosystem-map.ejs
+++ b/src/views/ecosystem-map.ejs
@@ -86,7 +86,7 @@
         <p>Der Kartencommit entspricht dem aktuellen Systemkatalog-HEAD. Alle <%= view_meta.verified_artifact_count %> deklarierten Artefakte stimmen mit Manifest, Arbeitsbaum und gebundenem Git-Commit überein.</p>
       <% } else if (view_meta.alignment_state === 'compatible') { %>
         <strong>Inhalt aktuell, Repository weiterentwickelt</strong>
-        <p>Seit dem Kartencommit gibt es <%= view_meta.commits_ahead === null ? 'weitere' : view_meta.commits_ahead %> spätere Commits. Der aktuelle HEAD und der Arbeitsbaum enthalten weiterhin exakt dieselben fünf Kartenartefakte.</p>
+        <p>Seit dem Kartencommit gibt es <%= view_meta.commits_ahead === null ? 'weitere' : view_meta.commits_ahead %> spätere Commits. Der aktuelle HEAD und der Arbeitsbaum enthalten weiterhin exakt dieselben <%= view_meta.declared_artifact_count %> deklarierten Kartenartefakte.</p>
       <% } else if (view_meta.alignment_state === 'drifted') { %>
         <strong>Drift erkannt</strong>
         <p>Mindestens ein Kartenartefakt oder seine Commitbindung stimmt nicht mehr. Technischer Grund: <code><%= view_meta.alignment_reason %></code>.</p>
@@ -143,7 +143,7 @@
 
         <section class="meta-grid" aria-label="Quellenmetadaten">
           <div class="meta-item"><div class="label">Gesamtstatus</div><div class="value" data-state="<%= view_meta.freshness_state %>"><%= view_meta.freshness_state %> · <%= view_meta.freshness_reason %></div></div>
-          <div class="meta-item"><div class="label">Inhaltsabgleich</div><div class="value" data-state="<%= view_meta.alignment_state %>"><%= view_meta.alignment_state %> · <%= view_meta.verified_artifact_count %>/5 Artefakte</div></div>
+          <div class="meta-item"><div class="label">Inhaltsabgleich</div><div class="value" data-state="<%= view_meta.alignment_state %>"><%= view_meta.alignment_state %> · <%= view_meta.verified_artifact_count %>/<%= view_meta.declared_artifact_count %> Artefakte</div></div>
           <div class="meta-item"><div class="label">Quellzustand</div><div class="value"><%= view_meta.source_kind %> / <%= view_meta.missing_reason %></div></div>
           <div class="meta-item"><div class="label">Alter</div><div class="value"><% if (view_meta.data_age_minutes !== null) { %><%= view_meta.data_age_minutes %> min · Grenze <%= view_meta.stale_after_hours %> h<% } else { %>—<% } %></div></div>
           <div class="meta-item">

--- a/tests/controllers/ecosystemMap.test.ts
+++ b/tests/controllers/ecosystemMap.test.ts
@@ -43,6 +43,12 @@ const ARTIFACT_CONTENT = [
     contentType: 'application/json',
     content: '{"authorities":[]}\n',
   },
+  {
+    role: 'resilience_semantics',
+    path: 'registry/ecosystem/resilience.v1.json',
+    contentType: 'application/json',
+    content: '{"schema_version":1,"components":[]}\n',
+  },
 ] as const;
 
 let tempRoots: string[] = [];
@@ -158,7 +164,8 @@ describe('getEcosystemMapData', () => {
     expect(data.view_meta.source_head).toBe(fixture.sourceCommit);
     expect(data.view_meta.source_root).toBe(fixture.sourceRoot);
     expect(data.view_meta.alignment_state).toBe('exact');
-    expect(data.view_meta.verified_artifact_count).toBe(5);
+    expect(data.view_meta.verified_artifact_count).toBe(6);
+    expect(data.view_meta.declared_artifact_count).toBe(6);
     expect(data.view_meta.freshness_state).toBe('fresh');
     expect(data.map?.role).toBe('canonical_ecosystem_map_mermaid');
     expect(data.map?.content).toContain('Systemkatalog');
@@ -245,6 +252,30 @@ describe('getEcosystemMapData', () => {
     const fixture = await makeFixture();
     const manifest = JSON.parse(await readFile(fixture.manifestPath, 'utf-8')) as Record<string, unknown>;
     manifest.unexpected = true;
+    await writeFile(fixture.manifestPath, JSON.stringify(manifest), 'utf-8');
+    process.env.LEITSTAND_ECOSYSTEM_MAP_MANIFEST_PATH = fixture.manifestPath;
+
+    const data = await getEcosystemMapData();
+
+    expect(data.view_meta.source_kind).toBe('corrupt');
+    expect(data.view_meta.missing_reason).toBe('manifest_corrupt');
+    expect(data.map).toBeNull();
+  });
+
+  it('rejects unknown additional artifacts instead of weakening the exact contract', async () => {
+    const fixture = await makeFixture();
+    const manifest = JSON.parse(await readFile(fixture.manifestPath, 'utf-8')) as {
+      artifactCount: number;
+      artifacts: Array<Record<string, unknown>>;
+    };
+    manifest.artifacts.push({
+      role: 'future_unknown_semantics',
+      path: 'registry/ecosystem/future.v1.json',
+      contentType: 'application/json',
+      bytes: 2,
+      sha256: 'a'.repeat(64),
+    });
+    manifest.artifactCount = manifest.artifacts.length;
     await writeFile(fixture.manifestPath, JSON.stringify(manifest), 'utf-8');
     process.env.LEITSTAND_ECOSYSTEM_MAP_MANIFEST_PATH = fixture.manifestPath;
 

--- a/tests/views/ecosystemMap.test.ts
+++ b/tests/views/ecosystemMap.test.ts
@@ -35,7 +35,8 @@ describe('ecosystem-map view', () => {
           commits_ahead: 4,
           alignment_state: 'compatible',
           alignment_reason: 'current_head_preserves_declared_artifact_bytes',
-          verified_artifact_count: 5,
+          verified_artifact_count: 6,
+          declared_artifact_count: 6,
           generated_at: '2026-07-14T00:00:00Z',
           data_age_minutes: 12,
           freshness_state: 'fresh',
@@ -63,8 +64,8 @@ describe('ecosystem-map view', () => {
     expect(html).toContain(head);
     expect(html).toContain('Inhalt aktuell, Repository weiterentwickelt');
     expect(html).toContain('4 spätere Commits');
-    expect(html).toContain('aktuelle HEAD und der Arbeitsbaum enthalten weiterhin exakt dieselben fünf Kartenartefakte');
-    expect(html).toContain('compatible · 5/5 Artefakte');
+    expect(html).toContain('aktuelle HEAD und der Arbeitsbaum enthalten weiterhin exakt dieselben 6 deklarierten Kartenartefakte');
+    expect(html).toContain('compatible · 6/6 Artefakte');
     expect(html).toContain('fresh · artifact_alignment_verified');
     expect(html).toContain('12 min · Grenze 168 h');
     expect(html).not.toContain('cdn.jsdelivr');
@@ -95,7 +96,8 @@ describe('ecosystem-map view', () => {
           commits_ahead: null,
           alignment_state: 'drifted',
           alignment_reason: 'current_artifact_mismatch:rendered/ecosystem-registry-map.mmd',
-          verified_artifact_count: 4,
+          verified_artifact_count: 5,
+          declared_artifact_count: 6,
           generated_at: '2026-07-14T00:00:00Z',
           data_age_minutes: 12,
           freshness_state: 'stale',


### PR DESCRIPTION
## Summary
- extend the exact fail-closed ecosystem-map artifact contract with Systemkatalog's declared `resilience_semantics` artifact
- expose the manifest-declared artifact count to the view instead of hard-coding `/5`
- keep unknown seventh artifacts rejected
- update controller, view and real browser fixtures to the six-artifact contract

## Root cause
The current validated Systemkatalog manifest declares six artifacts. Leitstand still required exactly five and therefore classified the source as `manifest_corrupt`, removing the map canvas and causing immutable-release postflight to fail.

## Validation
- git diff --check
- targeted ecosystem-map controller/view tests
- full `pnpm test`
- `NODE_OPTIONS=--jitless pnpm run typecheck`
- `NODE_OPTIONS=--jitless pnpm run lint`
- `NODE_OPTIONS=--jitless pnpm run build`
- `pnpm run test:browser-shell`
- `pnpm run test:browser-views`
- isolated runtime against exact Systemkatalog release `7447da1f9b481d31fecd28a385ac1c3e27a22bbb`: canvas present, `/assets/ecosystem-map.mjs` present, `6/6 Artefakte`, no `manifest_corrupt`

## Contract choice
This intentionally remains exact and fail-closed. It accepts the known sixth artifact but does not accept arbitrary future extras.