### PR TITLE
feat(release): close Systemkatalog deploy loop

### DIFF
--- a/deploy/systemd/runtime-config.example.json
+++ b/deploy/systemd/runtime-config.example.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "kind": "leitstand_local_runtime_config",
   "canonical_origin": "https://leitstand.heimgewebe.home.arpa",
-  "ecosystem_map_manifest_path": "/home/alex/.local/share/systemkatalog/releases/<commit>/rendered/ecosystem-map-artifact-manifest.json",
-  "ecosystem_map_source_root": "/home/alex/.local/share/systemkatalog/releases/<commit>",
+  "ecosystem_map_manifest_path": "/home/alex/.local/share/systemkatalog/releases/<bootstrap-or-rollback-commit>/rendered/ecosystem-map-artifact-manifest.json",
+  "ecosystem_map_source_root": "/home/alex/.local/share/systemkatalog/releases/<bootstrap-or-rollback-commit>",
   "artifact_root": "/home/alex/repos/leitstand/artifacts",
   "heim_pc_root": "/home/alex/repos/heim-pc",
   "storage_state_root": "/home/alex/.local/state/leitstand/storage-health"

--- a/docs/runbooks/local-release-runtime.md
+++ b/docs/runbooks/local-release-runtime.md
@@ -49,12 +49,28 @@ Host-specific source paths are not embedded in the repository. The effect comman
 Start from `deploy/systemd/runtime-config.example.json`. The configuration binds:
 
 - canonical HTTPS origin;
-- exact Systemkatalog release root and map manifest;
+- one exact Systemkatalog release root and map manifest;
 - Leitstand artifact root for Bureau, checkout, decision-axis and storage snapshots;
 - Heim-PC repository root;
 - storage-health state root.
 
 Only an HTTPS origin and absolute whitespace-free paths are accepted. The canonical JSON digest is written into deployment evidence.
+
+### Systemkatalog release closed loop
+
+For `deploy`, the configured exact Systemkatalog release is a bootstrap and release-base anchor, not permission to keep serving stale map artifacts. Before any Leitstand cutover the adapter:
+
+1. derives the Systemkatalog release base from the configured exact commit path;
+2. reads `main` directly from the canonical `git@github.com:heimgewebe/systemkatalog.git` remote;
+3. reuses `<release-base>/<remote-main-commit>` only when its Git `HEAD`, durable `refs/remotes/origin/main`, origin URL and tracked bytes still match that exact commit; unexpected untracked files are rejected, while inert `__pycache__/*.pyc` remnants are tolerated for compatibility with previously verified local releases; otherwise it clones canonical `main` into a temporary sibling and atomically publishes the verified commit directory;
+4. executes that release's own `scripts/write_ecosystem_map_artifact_manifest.py --check --durable-source-ref refs/remotes/origin/main --json` contract under isolated Python path handling and records the manifest digest, artifact count and manifest source commit;
+5. re-reads live Systemkatalog `main` and re-verifies the release immediately before the Leitstand switch transaction.
+
+The published map manifest may legitimately bind an older artifact-producing commit than the Systemkatalog release `HEAD`. The producer's manifest checker owns the durable-ancestry and byte-binding proof; Leitstand must not replace it with an incorrect equality check between manifest source commit and repository head.
+
+The effective deployment configuration is then rewritten in memory to the exact verified Systemkatalog commit directory, and the installed Leitstand units continue to contain only that immutable exact path. No mutable `current` symlink is introduced. A preparation or pre-cutover confirmation failure writes a `deploy-systemkatalog-preflight-failed` receipt with `cutover_started=false`. The receipt deliberately does not claim that no filesystem effect occurred: an immutable Systemkatalog release may have been created or resealed, and by the confirmation phase the immutable Leitstand release may already have been materialized. Unit files, selectors, daemon state and services have not been changed at that point.
+
+`switch` and `rollback` deliberately do **not** auto-follow the newest Systemkatalog `main`. They keep the exact Systemkatalog path supplied by the runtime configuration so an older Leitstand release is not silently coupled to a newer map contract during recovery. Operators should therefore retain a known-good exact Systemkatalog commit in the runtime configuration; normal `deploy` automatically advances from its release-base parent to freshly verified remote `main`.
 
 ## Coupled unit transaction
 

--- a/scripts/leitstand-release.py
+++ b/scripts/leitstand-release.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import argparse
 import contextlib
 import dataclasses
+import errno
 import datetime as dt
 import fcntl
 import hashlib
@@ -74,6 +75,11 @@ DEFAULT_STORAGE_UNIT_TARGET = (
 DEFAULT_RUNTIME_CONFIG = Path.home() / ".config" / "leitstand" / "runtime.json"
 RUNTIME_CONFIG_KIND = "leitstand_local_runtime_config"
 RUNTIME_CONFIG_SCHEMA_VERSION = 1
+SYSTEMKATALOG_ORIGIN = "git@github.com:heimgewebe/systemkatalog.git"
+SYSTEMKATALOG_REMOTE_REF = "refs/heads/main"
+SYSTEMKATALOG_TRACKING_REF = "refs/remotes/origin/main"
+SYSTEMKATALOG_MANIFEST_RELATIVE_PATH = Path("rendered/ecosystem-map-artifact-manifest.json")
+SYSTEMKATALOG_MANIFEST_CHECKER_RELATIVE_PATH = Path("scripts/write_ecosystem_map_artifact_manifest.py")
 COMPLETION_KIND = "leitstand_local_deployment_completion"
 ACTIVE_ROUTES = (
     "/",
@@ -1356,6 +1362,307 @@ def load_runtime_config(path: Path) -> RuntimeConfig:
     )
 
 
+def _runtime_config_with_ecosystem_map(
+    config: RuntimeConfig, source_root: Path
+) -> RuntimeConfig:
+    root = Path(os.path.abspath(source_root))
+    manifest = root / SYSTEMKATALOG_MANIFEST_RELATIVE_PATH
+    payload = {
+        "schema_version": RUNTIME_CONFIG_SCHEMA_VERSION,
+        "kind": RUNTIME_CONFIG_KIND,
+        "canonical_origin": config.canonical_origin,
+        "ecosystem_map_manifest_path": str(manifest),
+        "ecosystem_map_source_root": str(root),
+        "artifact_root": str(config.artifact_root),
+        "heim_pc_root": str(config.heim_pc_root),
+        "storage_state_root": str(config.storage_state_root),
+    }
+    return RuntimeConfig(
+        canonical_origin=config.canonical_origin,
+        ecosystem_map_manifest_path=manifest,
+        ecosystem_map_source_root=root,
+        artifact_root=config.artifact_root,
+        heim_pc_root=config.heim_pc_root,
+        storage_state_root=config.storage_state_root,
+        source_path=config.source_path,
+        sha256=sha256_bytes(canonical_json_bytes(payload)),
+    )
+
+
+def _systemkatalog_release_base(config: RuntimeConfig) -> Path:
+    source_root = config.ecosystem_map_source_root
+    expected_manifest = source_root / SYSTEMKATALOG_MANIFEST_RELATIVE_PATH
+    if config.ecosystem_map_manifest_path != expected_manifest:
+        raise ReleaseError(
+            "runtime config Systemkatalog manifest must be inside the exact configured release root"
+        )
+    if not HEAD_RE.fullmatch(source_root.name):
+        raise ReleaseError(
+            "runtime config Systemkatalog source root must end in one exact 40-character commit"
+        )
+    release_base = source_root.parent
+    assert_secure_ancestry(release_base)
+    if release_base.exists() and (release_base.is_symlink() or not release_base.is_dir()):
+        raise ReleaseError(f"Systemkatalog release base is not a directory: {release_base}")
+    return release_base
+
+
+def _systemkatalog_git_env(extra: Mapping[str, str] | None = None) -> dict[str, str]:
+    environment = {
+        "GIT_OPTIONAL_LOCKS": "0",
+        "GIT_TERMINAL_PROMPT": "0",
+        "GIT_SSH_COMMAND": "ssh -o BatchMode=yes",
+    }
+    if extra:
+        environment.update(extra)
+    return environment
+
+
+def _systemkatalog_remote_main() -> str:
+    completed = run(
+        ("git", "ls-remote", "--exit-code", SYSTEMKATALOG_ORIGIN, SYSTEMKATALOG_REMOTE_REF),
+        timeout=60,
+        env=_systemkatalog_git_env(),
+    )
+    lines = [line.split() for line in completed.stdout.splitlines() if line.strip()]
+    if (
+        len(lines) != 1
+        or len(lines[0]) != 2
+        or lines[0][1] != SYSTEMKATALOG_REMOTE_REF
+        or not HEAD_RE.fullmatch(lines[0][0])
+    ):
+        raise ReleaseError("Systemkatalog live remote main readback is invalid")
+    return lines[0][0]
+
+
+def _verify_systemkatalog_release(target: Path, expected_head: str) -> dict[str, Any]:
+    head = validate_head(expected_head)
+    target = Path(os.path.abspath(target))
+    assert_secure_ancestry(target)
+    if target.is_symlink() or not target.is_dir():
+        raise ReleaseError(f"Systemkatalog release root is not a directory: {target}")
+    git_env = _systemkatalog_git_env()
+    actual_head = run(
+        ("git", "rev-parse", "--verify", "HEAD"), cwd=target, env=git_env
+    ).stdout.strip()
+    tracking_head = run(
+        ("git", "rev-parse", "--verify", SYSTEMKATALOG_TRACKING_REF),
+        cwd=target,
+        env=git_env,
+    ).stdout.strip()
+    origin = run(("git", "remote", "get-url", "origin"), cwd=target, env=git_env).stdout.strip()
+    if actual_head != head or tracking_head != head:
+        raise ReleaseError(
+            "Systemkatalog release HEAD or durable origin/main ref does not match expected live remote main"
+        )
+    if origin != SYSTEMKATALOG_ORIGIN:
+        raise ReleaseError(
+            f"Systemkatalog release origin mismatch; expected={SYSTEMKATALOG_ORIGIN}; actual={origin}"
+        )
+    for label, arguments in (
+        ("worktree", ("git", "diff", "--quiet", "HEAD", "--")),
+        ("index", ("git", "diff", "--cached", "--quiet", "HEAD", "--")),
+    ):
+        completed = run(arguments, cwd=target, check=False, env=git_env)
+        if completed.returncode == 1:
+            raise ReleaseError(f"Systemkatalog release tracked {label} content differs from commit")
+        if completed.returncode != 0:
+            detail = (completed.stderr or completed.stdout or "git diff failed").strip()
+            raise ReleaseError(f"could not verify Systemkatalog release {label}: {detail[-1000:]}")
+    untracked_raw = run(
+        ("git", "ls-files", "--others", "--exclude-standard", "-z"),
+        cwd=target,
+        env=git_env,
+    ).stdout
+    untracked = [entry for entry in untracked_raw.split("\0") if entry]
+    unexpected_untracked = [
+        entry
+        for entry in untracked
+        if not ("__pycache__" in Path(entry).parts and entry.endswith(".pyc"))
+    ]
+    if unexpected_untracked:
+        raise ReleaseError(
+            "Systemkatalog release contains unexpected untracked files: "
+            + ", ".join(unexpected_untracked[:10])
+        )
+    manifest_path = target / SYSTEMKATALOG_MANIFEST_RELATIVE_PATH
+    checker = target / SYSTEMKATALOG_MANIFEST_CHECKER_RELATIVE_PATH
+    _require_regular_file(manifest_path, owner_uid=os.getuid(), label="Systemkatalog map manifest")
+    _require_regular_file(checker, owner_uid=os.getuid(), label="Systemkatalog map manifest checker")
+    completed = run(
+        (
+            sys.executable,
+            "-I",
+            str(checker),
+            "--repo-root",
+            str(target),
+            "--check",
+            "--durable-source-ref",
+            SYSTEMKATALOG_TRACKING_REF,
+            "--json",
+        ),
+        cwd=target,
+        timeout=120,
+        env=_systemkatalog_git_env({"PYTHONDONTWRITEBYTECODE": "1"}),
+    )
+    try:
+        result = json.loads(completed.stdout)
+    except json.JSONDecodeError as error:
+        raise ReleaseError("Systemkatalog manifest checker returned invalid JSON") from error
+    manifest_source = result.get("sourceCommit") if isinstance(result, dict) else None
+    artifact_count = result.get("artifactCount") if isinstance(result, dict) else None
+    if (
+        not isinstance(result, dict)
+        or result.get("ok") is not True
+        or not isinstance(manifest_source, str)
+        or not HEAD_RE.fullmatch(manifest_source)
+        or not isinstance(artifact_count, int)
+        or artifact_count < 1
+    ):
+        raise ReleaseError("Systemkatalog manifest checker result violates the published contract")
+    return {
+        "source_repository": "heimgewebe/systemkatalog",
+        "remote_origin": SYSTEMKATALOG_ORIGIN,
+        "release_commit": head,
+        "manifest_source_commit": manifest_source,
+        "artifact_count": artifact_count,
+        "release_path": str(target),
+        "manifest_path": str(manifest_path),
+        "manifest_sha256": sha256_file(manifest_path),
+        "ignored_untracked_cache_file_count": len(untracked),
+    }
+
+
+def _remove_systemkatalog_temporary_release(path: Path) -> None:
+    if not path.exists():
+        return
+    with contextlib.suppress(BaseException):
+        private_release_permissions(path)
+    shutil.rmtree(path, ignore_errors=True)
+
+
+def prepare_systemkatalog_runtime_config(
+    config: RuntimeConfig, *, attempt_id: str | None = None
+) -> tuple[RuntimeConfig, dict[str, Any]]:
+    attempt = attempt_id or new_attempt_id()
+    release_base = _systemkatalog_release_base(config)
+    ensure_directory(release_base, private=False)
+    remote_head = _systemkatalog_remote_main()
+    target = release_base / remote_head
+    created = False
+    if target.exists():
+        _verify_systemkatalog_release(target, remote_head)
+        seal_release(target)
+        evidence = _verify_systemkatalog_release(target, remote_head)
+    else:
+        temporary = release_base / f".{remote_head}.{attempt}.tmp"
+        if temporary.exists() or temporary.is_symlink():
+            raise ReleaseError(f"Systemkatalog temporary release already exists: {temporary}")
+        try:
+            run(
+                (
+                    "git",
+                    "clone",
+                    "--quiet",
+                    "--no-tags",
+                    "--branch",
+                    "main",
+                    "--single-branch",
+                    SYSTEMKATALOG_ORIGIN,
+                    str(temporary),
+                ),
+                cwd=release_base,
+                timeout=180,
+                env=_systemkatalog_git_env(),
+            )
+            _verify_systemkatalog_release(temporary, remote_head)
+            seal_release(temporary)
+            try:
+                os.rename(temporary, target)
+                fsync_directory(release_base)
+                created = True
+            except OSError as error:
+                if error.errno not in (errno.EEXIST, errno.ENOTEMPTY):
+                    raise
+                _remove_systemkatalog_temporary_release(temporary)
+            try:
+                evidence = _verify_systemkatalog_release(target, remote_head)
+            except BaseException:
+                if created:
+                    _remove_systemkatalog_temporary_release(target)
+                raise
+        except BaseException:
+            _remove_systemkatalog_temporary_release(temporary)
+            raise
+    resolved = _runtime_config_with_ecosystem_map(config, target)
+    return resolved, {
+        **evidence,
+        "created": created,
+        "input_runtime_config_sha256": config.sha256,
+        "resolved_runtime_config_sha256": resolved.sha256,
+        "observed_remote_main": remote_head,
+    }
+
+
+def confirm_systemkatalog_runtime_config(
+    config: RuntimeConfig, evidence: Mapping[str, Any]
+) -> dict[str, Any]:
+    expected_head = validate_head(str(evidence.get("release_commit", "")))
+    observed_head = _systemkatalog_remote_main()
+    if observed_head != expected_head:
+        raise ReleaseError(
+            "Systemkatalog live remote main changed after preparation and before Leitstand cutover"
+        )
+    target = Path(str(evidence.get("release_path", "")))
+    verified = _verify_systemkatalog_release(target, expected_head)
+    if (
+        verified["manifest_sha256"] != evidence.get("manifest_sha256")
+        or verified["manifest_source_commit"] != evidence.get("manifest_source_commit")
+        or config.ecosystem_map_source_root != target
+        or config.ecosystem_map_manifest_path != target / SYSTEMKATALOG_MANIFEST_RELATIVE_PATH
+    ):
+        raise ReleaseError("Systemkatalog prepared release identity changed before Leitstand cutover")
+    return {
+        **dict(evidence),
+        "confirmed_remote_main": observed_head,
+        "confirmed_at": utc_now(),
+    }
+
+
+def _write_systemkatalog_preflight_failure(
+    paths: Paths,
+    *,
+    attempt_id: str,
+    phase: str,
+    config: RuntimeConfig,
+    error: BaseException,
+) -> None:
+    write_receipt(
+        paths,
+        "deploy-systemkatalog-preflight-failed",
+        {
+            "success": False,
+            "cutover_started": False,
+            "phase": phase,
+            "runtime_config": config.evidence(),
+            "systemkatalog_release_state_may_have_changed": True,
+            "leitstand_release_materialization_may_have_occurred": (
+                phase == "pre-cutover-confirmation"
+            ),
+            "error_type": type(error).__name__,
+            "error": str(error),
+            "does_not_establish": [
+                "unit_write",
+                "selector_write",
+                "daemon_reload",
+                "service_restart",
+                "leitstand_cutover",
+            ],
+        },
+        attempt_id=attempt_id,
+    )
+
+
 def _template_replacements(target: Path, config: RuntimeConfig) -> dict[str, str]:
     artifact_root = config.artifact_root
     return {
@@ -2393,6 +2700,20 @@ def deploy_release(
     attempt_id: str | None = None,
 ) -> dict[str, Any]:
     attempt = attempt_id or new_attempt_id()
+    input_config = config
+    try:
+        config, systemkatalog_release = prepare_systemkatalog_runtime_config(
+            config, attempt_id=attempt
+        )
+    except (ReleaseError, OSError, subprocess.SubprocessError, ValueError) as error:
+        _write_systemkatalog_preflight_failure(
+            paths,
+            attempt_id=attempt,
+            phase="prepare",
+            config=input_config,
+            error=error,
+        )
+        raise
     target, manifest, created = build_release(
         paths,
         source_repo,
@@ -2415,6 +2736,19 @@ def deploy_release(
     }
     if confirmed_identity != manifest_identity:
         raise ReleaseError("source or remote-main identity changed after release build")
+    try:
+        systemkatalog_release = confirm_systemkatalog_runtime_config(
+            config, systemkatalog_release
+        )
+    except (ReleaseError, OSError, subprocess.SubprocessError, ValueError) as error:
+        _write_systemkatalog_preflight_failure(
+            paths,
+            attempt_id=attempt,
+            phase="pre-cutover-confirmation",
+            config=config,
+            error=error,
+        )
+        raise
     key = _deployment_key(expected_head, config)
     completion = _read_completion(paths, key)
     current = _resolve_link_target(paths.current)
@@ -2439,6 +2773,7 @@ def deploy_release(
             "release_created": False,
             "release_tree_sha256": manifest["release_tree_sha256"],
             "runtime_config": config.evidence(),
+            "systemkatalog_release": systemkatalog_release,
             "completion": completion,
             "postflight": evidence,
         }
@@ -2461,6 +2796,7 @@ def deploy_release(
         "release_created": created,
         "release_tree_sha256": manifest["release_tree_sha256"],
         "runtime_config": config.evidence(),
+        "systemkatalog_release": systemkatalog_release,
         "switch": switch,
     }
     receipt_path, receipt_sha = write_receipt(

--- a/tests/test_release_runtime.py
+++ b/tests/test_release_runtime.py
@@ -41,12 +41,20 @@ class ReleaseRuntimeTest(unittest.TestCase):
         )
         self.config_path = self.root / "config" / "leitstand" / "runtime.json"
         self.config_path.parent.mkdir(parents=True)
+        self.systemkatalog_bootstrap_head = "0" * 40
+        self.systemkatalog_release_base = self.root / "systemkatalog" / "releases"
+        self.systemkatalog_bootstrap_root = (
+            self.systemkatalog_release_base / self.systemkatalog_bootstrap_head
+        )
         self.config_payload = {
             "schema_version": 1,
             "kind": "leitstand_local_runtime_config",
             "canonical_origin": "https://leitstand.example.test",
-            "ecosystem_map_manifest_path": str(self.root / "systemkatalog/rendered/manifest.json"),
-            "ecosystem_map_source_root": str(self.root / "systemkatalog"),
+            "ecosystem_map_manifest_path": str(
+                self.systemkatalog_bootstrap_root
+                / release.SYSTEMKATALOG_MANIFEST_RELATIVE_PATH
+            ),
+            "ecosystem_map_source_root": str(self.systemkatalog_bootstrap_root),
             "artifact_root": str(self.root / "artifacts"),
             "heim_pc_root": str(self.root / "heim-pc"),
             "storage_state_root": str(self.root / "state/storage-health"),
@@ -57,6 +65,80 @@ class ReleaseRuntimeTest(unittest.TestCase):
 
     def tearDown(self) -> None:
         self.temp.cleanup()
+
+    def _create_systemkatalog_remote(self) -> tuple[Path, str, str]:
+        source = self.root / "systemkatalog-source"
+        remote = self.root / "systemkatalog-origin.git"
+        subprocess.run(
+            ["git", "init", "-b", "main", str(source)],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        subprocess.run(["git", "-C", str(source), "config", "user.email", "test@example.invalid"], check=True)
+        subprocess.run(["git", "-C", str(source), "config", "user.name", "Leitstand Test"], check=True)
+        (source / "rendered").mkdir()
+        (source / "scripts").mkdir()
+        checker = source / release.SYSTEMKATALOG_MANIFEST_CHECKER_RELATIVE_PATH
+        checker.write_text(
+            """#!/usr/bin/env python3
+import argparse
+import json
+from pathlib import Path
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--repo-root', required=True)
+parser.add_argument('--check', action='store_true')
+parser.add_argument('--durable-source-ref')
+parser.add_argument('--json', action='store_true')
+args = parser.parse_args()
+manifest = json.loads((Path(args.repo_root) / 'rendered/ecosystem-map-artifact-manifest.json').read_text())
+print(json.dumps({'ok': True, 'sourceCommit': manifest['sourceCommit'], 'artifactCount': manifest['artifactCount']}))
+""",
+            encoding="utf-8",
+        )
+        os.chmod(checker, 0o755)
+        manifest = source / release.SYSTEMKATALOG_MANIFEST_RELATIVE_PATH
+        manifest.write_text(
+            json.dumps({"sourceCommit": "0" * 40, "artifactCount": 6}) + "\n",
+            encoding="utf-8",
+        )
+        subprocess.run(["git", "-C", str(source), "add", "."], check=True)
+        subprocess.run(
+            ["git", "-C", str(source), "commit", "-m", "seed published map contract"],
+            check=True,
+            stdout=subprocess.DEVNULL,
+        )
+        manifest_source = subprocess.check_output(
+            ["git", "-C", str(source), "rev-parse", "HEAD"], text=True
+        ).strip()
+        manifest.write_text(
+            json.dumps({"sourceCommit": manifest_source, "artifactCount": 6}) + "\n",
+            encoding="utf-8",
+        )
+        subprocess.run(["git", "-C", str(source), "add", str(manifest)], check=True)
+        subprocess.run(
+            ["git", "-C", str(source), "commit", "-m", "bind published map manifest"],
+            check=True,
+            stdout=subprocess.DEVNULL,
+        )
+        (source / "README.md").write_text("later repository-only change\n", encoding="utf-8")
+        subprocess.run(["git", "-C", str(source), "add", "README.md"], check=True)
+        subprocess.run(
+            ["git", "-C", str(source), "commit", "-m", "advance repository head"],
+            check=True,
+            stdout=subprocess.DEVNULL,
+        )
+        latest = subprocess.check_output(
+            ["git", "-C", str(source), "rev-parse", "HEAD"], text=True
+        ).strip()
+        subprocess.run(
+            ["git", "clone", "--bare", str(source), str(remote)],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        return remote, latest, manifest_source
 
     def _populate_release(self, target: Path, head: str) -> None:
         (target / "dist").mkdir(parents=True)
@@ -165,6 +247,65 @@ class ReleaseRuntimeTest(unittest.TestCase):
         self.config_path.write_text(json.dumps(changed), encoding="utf-8")
         with self.assertRaisesRegex(release.ReleaseError, "key mismatch"):
             release.load_runtime_config(self.config_path)
+
+    def test_prepare_systemkatalog_runtime_config_materializes_and_reuses_exact_remote_release(self) -> None:
+        remote, latest, manifest_source = self._create_systemkatalog_remote()
+        with patch.object(release, "SYSTEMKATALOG_ORIGIN", str(remote)):
+            resolved, evidence = release.prepare_systemkatalog_runtime_config(
+                self.config, attempt_id=ATTEMPT
+            )
+            self.assertTrue(evidence["created"])
+            self.assertEqual(evidence["release_commit"], latest)
+            self.assertEqual(evidence["observed_remote_main"], latest)
+            self.assertEqual(evidence["manifest_source_commit"], manifest_source)
+            self.assertNotEqual(evidence["manifest_source_commit"], latest)
+            self.assertEqual(evidence["artifact_count"], 6)
+            self.assertEqual(resolved.ecosystem_map_source_root, self.systemkatalog_release_base / latest)
+            self.assertEqual(
+                resolved.ecosystem_map_manifest_path,
+                self.systemkatalog_release_base / latest / release.SYSTEMKATALOG_MANIFEST_RELATIVE_PATH,
+            )
+            self.assertEqual(
+                stat.S_IMODE(os.stat(resolved.ecosystem_map_source_root).st_mode), 0o500
+            )
+
+            release.private_release_permissions(resolved.ecosystem_map_source_root)
+            self.assertEqual(
+                stat.S_IMODE(os.stat(resolved.ecosystem_map_source_root).st_mode), 0o700
+            )
+            resolved_again, evidence_again = release.prepare_systemkatalog_runtime_config(
+                self.config, attempt_id=ATTEMPT
+            )
+            self.assertFalse(evidence_again["created"])
+            self.assertEqual(
+                stat.S_IMODE(os.stat(resolved_again.ecosystem_map_source_root).st_mode), 0o500
+            )
+            self.assertEqual(resolved_again.sha256, resolved.sha256)
+            self.assertEqual(evidence_again["manifest_sha256"], evidence["manifest_sha256"])
+
+    def test_verify_systemkatalog_release_rejects_tracked_drift(self) -> None:
+        remote, latest, _manifest_source = self._create_systemkatalog_remote()
+        with patch.object(release, "SYSTEMKATALOG_ORIGIN", str(remote)):
+            resolved, _evidence = release.prepare_systemkatalog_runtime_config(
+                self.config, attempt_id=ATTEMPT
+            )
+            target = resolved.ecosystem_map_source_root
+            release.private_release_permissions(target)
+            (target / "README.md").write_text("tampered\n", encoding="utf-8")
+            with self.assertRaisesRegex(release.ReleaseError, "tracked worktree content differs"):
+                release._verify_systemkatalog_release(target, latest)
+
+    def test_verify_systemkatalog_release_rejects_unexpected_untracked_files(self) -> None:
+        remote, latest, _manifest_source = self._create_systemkatalog_remote()
+        with patch.object(release, "SYSTEMKATALOG_ORIGIN", str(remote)):
+            resolved, _evidence = release.prepare_systemkatalog_runtime_config(
+                self.config, attempt_id=ATTEMPT
+            )
+            target = resolved.ecosystem_map_source_root
+            release.private_release_permissions(target)
+            (target / "scripts" / "json.py").write_text("raise RuntimeError('shadow')\n", encoding="utf-8")
+            with self.assertRaisesRegex(release.ReleaseError, "unexpected untracked files"):
+                release._verify_systemkatalog_release(target, latest)
 
     def test_runtime_config_rejects_non_https_relative_and_whitespace_paths(self) -> None:
         cases = (
@@ -620,7 +761,18 @@ class ReleaseRuntimeTest(unittest.TestCase):
             receipt_sha256=receipt_sha,
         )
         manifest = release.verify_release_path(self.paths, target)
+        systemkatalog_evidence = {"release_commit": "1" * 40}
         with (
+            patch.object(
+                release,
+                "prepare_systemkatalog_runtime_config",
+                return_value=(self.config, systemkatalog_evidence),
+            ),
+            patch.object(
+                release,
+                "confirm_systemkatalog_runtime_config",
+                return_value=systemkatalog_evidence,
+            ),
             patch.object(release, "build_release", return_value=(target, manifest, False)),
             patch.object(
                 release,
@@ -870,6 +1022,11 @@ class ReleaseRuntimeTest(unittest.TestCase):
         }
         drifted["origin_main"] = "0" * 40
         with (
+            patch.object(
+                release,
+                "prepare_systemkatalog_runtime_config",
+                return_value=(self.config, {"release_commit": "1" * 40}),
+            ),
             patch.object(release, "build_release", return_value=(target, manifest, False)),
             patch.object(release, "source_identity", return_value=drifted),
             patch.object(release, "switch_transaction") as switched,
@@ -877,6 +1034,59 @@ class ReleaseRuntimeTest(unittest.TestCase):
             with self.assertRaisesRegex(release.ReleaseError, "changed after release build"):
                 release.deploy_release(self.paths, self.root, head, self.config, attempt_id=ATTEMPT)
         switched.assert_not_called()
+
+    def test_systemkatalog_remote_drift_before_cutover_fails_without_switch_effect(self) -> None:
+        head = "7" * 40
+        target = self.create_verified_release(head)
+        manifest = release.verify_release_path(self.paths, target)
+        identity = {
+            key: manifest[key]
+            for key in (
+                "source_commit",
+                "source_tree",
+                "source_date_epoch",
+                "origin_main",
+                "required_ref",
+                "required_ref_head",
+                "origin_url",
+            )
+        }
+        prepared = {
+            "release_commit": "1" * 40,
+            "release_path": str(self.systemkatalog_bootstrap_root),
+            "manifest_source_commit": "2" * 40,
+            "manifest_sha256": "3" * 64,
+        }
+        with (
+            patch.object(
+                release,
+                "prepare_systemkatalog_runtime_config",
+                return_value=(self.config, prepared),
+            ),
+            patch.object(release, "build_release", return_value=(target, manifest, False)),
+            patch.object(release, "source_identity", return_value=identity),
+            patch.object(
+                release,
+                "confirm_systemkatalog_runtime_config",
+                side_effect=release.ReleaseError("Systemkatalog live remote main changed"),
+            ),
+            patch.object(release, "switch_transaction") as switched,
+        ):
+            with self.assertRaisesRegex(release.ReleaseError, "live remote main changed"):
+                release.deploy_release(
+                    self.paths, self.root, head, self.config, attempt_id=ATTEMPT
+                )
+        switched.assert_not_called()
+        receipts = sorted(
+            self.paths.receipts.glob("*deploy-systemkatalog-preflight-failed.json")
+        )
+        self.assertEqual(len(receipts), 1)
+        payload = json.loads(receipts[0].read_text("utf-8"))
+        self.assertFalse(payload["success"])
+        self.assertFalse(payload["cutover_started"])
+        self.assertTrue(payload["systemkatalog_release_state_may_have_changed"])
+        self.assertTrue(payload["leitstand_release_materialization_may_have_occurred"])
+        self.assertEqual(payload["phase"], "pre-cutover-confirmation")
 
     def test_cli_exposes_only_managed_lifecycle_commands(self) -> None:
         help_text = release.build_parser().format_help()


### PR DESCRIPTION
## Summary
- implement Bureau task LSV-V1-T011 in the canonical Leitstand release adapter
- resolve live `heimgewebe/systemkatalog` `main` before every normal deploy and materialize or reuse an exact commit-bound local release
- verify exact Git HEAD/tracking ref/origin, tracked bytes, fail closed on unexpected untracked files, and execute the Systemkatalog producer manifest checker under isolated Python path handling
- re-confirm remote main and release identity immediately before Leitstand cutover
- keep installed Leitstand units bound to an immutable exact Systemkatalog path; no mutable `current` symlink
- deliberately keep explicit `switch`/`rollback` on their supplied historical exact Systemkatalog path
- emit truthful pre-cutover failure receipts that do not claim filesystem side effects were impossible

## Validation
- `git diff --check`
- `PYTHONDONTWRITEBYTECODE=1 python3 -B -m unittest tests.test_release_runtime`
- `pnpm test`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test:browser-shell`
- `pnpm run test:browser-views`
- real read-only production contract check against installed Systemkatalog release: remote/release `7447da1f9b481d31fecd28a385ac1c3e27a22bbb`, manifest source `27924b7cd1b2506dae121052efb4a195804d1554`, 6 artifacts, 27 tolerated `__pycache__/*.pyc` remnants, no unexpected untracked content

## Safety / semantics
The map manifest may legitimately bind an older artifact-producing commit than the Systemkatalog release HEAD. The producer checker remains authoritative for durable ancestry and byte binding. The deploy adapter never mutates a dirty Systemkatalog checkout.