### PR TITLE
Expose stable ecosystem lifecycle semantics

### DIFF
--- a/src/controllers/ecosystemMap.ts
+++ b/src/controllers/ecosystemMap.ts
@@ -401,6 +401,7 @@ function inspectSemanticNodes(artifact: EcosystemMapArtifactView | undefined): S
       if (!isRecord(item)
         || typeof item.id !== 'string'
         || item.id.trim().length === 0
+        || item.id !== item.id.trim()
         || typeof item.name !== 'string'
         || item.name.trim().length === 0
         || typeof item.type !== 'string'
@@ -420,7 +421,9 @@ function inspectSemanticNodes(artifact: EcosystemMapArtifactView | undefined): S
         || !isExactCalendarDate(reviewedAt)
         || !Array.isArray(evidenceRefs)
         || evidenceRefs.length === 0
-        || evidenceRefs.some((value) => typeof value !== 'string' || value.trim().length === 0)
+        || evidenceRefs.some((value) => typeof value !== 'string'
+          || value.trim().length === 0
+          || value !== value.trim())
         || new Set(evidenceRefs).size !== evidenceRefs.length) {
         throw new Error(`registry node ${index} lifecycle mismatch`);
       }

--- a/src/controllers/ecosystemMap.ts
+++ b/src/controllers/ecosystemMap.ts
@@ -60,6 +60,16 @@ const DOES_NOT_ESTABLISH_CONTRACT = [
 export type EcosystemMapSourceKind = 'artifact' | 'missing' | 'corrupt';
 export type EcosystemMapFreshness = 'fresh' | 'stale' | 'unknown';
 export type EcosystemMapAlignment = 'exact' | 'compatible' | 'drifted' | 'unverifiable';
+export type EcosystemMapLifecycleState = 'active' | 'transition' | 'reference' | 'archived' | 'retired';
+export type EcosystemMapSemanticReviewState = 'declared' | 'unavailable';
+
+const LIFECYCLE_STATES: readonly EcosystemMapLifecycleState[] = [
+  'active',
+  'transition',
+  'reference',
+  'archived',
+  'retired',
+];
 
 interface MapManifestArtifact {
   role: string;
@@ -107,6 +117,25 @@ interface AlignmentInspection {
   verifiedArtifactCount: number;
 }
 
+export interface EcosystemMapNodeSemantics {
+  node_id: string;
+  name: string;
+  type: string;
+  purpose: string;
+  lifecycle_state: EcosystemMapLifecycleState;
+  lifecycle_reviewed_at: string;
+  lifecycle_evidence_refs: string[];
+}
+
+interface SemanticInspection {
+  nodes: EcosystemMapNodeSemantics[];
+  declaredNodeCount: number;
+  reviewState: EcosystemMapSemanticReviewState;
+  reviewReason: string;
+  reviewedAt: string | null;
+  lifecycleCounts: Record<EcosystemMapLifecycleState, number>;
+}
+
 export interface EcosystemMapArtifactView {
   role: string;
   path: string;
@@ -119,6 +148,7 @@ export interface EcosystemMapArtifactView {
 
 export interface EcosystemMapViewData {
   map: EcosystemMapArtifactView | null;
+  nodes: EcosystemMapNodeSemantics[];
   cross_links: EcosystemCrossViewLink[];
   cross_link_meta: {
     source_kind: string;
@@ -144,6 +174,12 @@ export interface EcosystemMapViewData {
     freshness_state: EcosystemMapFreshness;
     freshness_reason: string;
     stale_after_hours: number;
+    semantic_review_state: EcosystemMapSemanticReviewState;
+    semantic_review_reason: string;
+    semantic_reviewed_at: string | null;
+    semantic_reviewed_node_count: number;
+    semantic_node_count: number;
+    lifecycle_counts: Record<EcosystemMapLifecycleState, number>;
     does_not_establish: string[];
   };
 }
@@ -187,6 +223,7 @@ function emptyData(
 ): EcosystemMapViewData {
   return {
     map: null,
+    nodes: [],
     cross_links: crossLinks.links,
     cross_link_meta: crossLinks.meta,
     view_meta: {
@@ -207,6 +244,12 @@ function emptyData(
       freshness_state: 'unknown',
       freshness_reason: reason,
       stale_after_hours: configuredStaleAfterHours(),
+      semantic_review_state: 'unavailable',
+      semantic_review_reason: reason,
+      semantic_reviewed_at: null,
+      semantic_reviewed_node_count: 0,
+      semantic_node_count: 0,
+      lifecycle_counts: { active: 0, transition: 0, reference: 0, archived: 0, retired: 0 },
       does_not_establish: [
         'claim_truth',
         'runtime_correctness',
@@ -316,6 +359,97 @@ function parseManifest(raw: unknown): MapManifest {
     artifacts,
     doesNotEstablish: [...DOES_NOT_ESTABLISH_CONTRACT],
   };
+}
+
+function emptyLifecycleCounts(): Record<EcosystemMapLifecycleState, number> {
+  return { active: 0, transition: 0, reference: 0, archived: 0, retired: 0 };
+}
+
+function isExactCalendarDate(value: string): boolean {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) return false;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  if (year < 1 || month < 1 || month > 12 || day < 1) return false;
+  const leap = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [31, leap ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  return day <= daysInMonth[month - 1];
+}
+
+function inspectSemanticNodes(artifact: EcosystemMapArtifactView | undefined): SemanticInspection {
+  let declaredNodeCount = 0;
+  const unavailable = (reason: string): SemanticInspection => ({
+    nodes: [],
+    declaredNodeCount,
+    reviewState: 'unavailable',
+    reviewReason: reason,
+    reviewedAt: null,
+    lifecycleCounts: emptyLifecycleCounts(),
+  });
+  if (!artifact?.content) return unavailable(artifact?.missing_reason || 'registry_nodes_unavailable');
+
+  try {
+    const raw = JSON.parse(artifact.content) as unknown;
+    if (!isRecord(raw) || !Array.isArray(raw.nodes) || raw.nodes.length === 0) {
+      return unavailable('registry_nodes_contract_mismatch');
+    }
+    declaredNodeCount = raw.nodes.length;
+    const counts = emptyLifecycleCounts();
+    const seenNodeIds = new Set<string>();
+    const nodes = raw.nodes.map((item, index): EcosystemMapNodeSemantics => {
+      if (!isRecord(item)
+        || typeof item.id !== 'string'
+        || item.id.trim().length === 0
+        || typeof item.name !== 'string'
+        || item.name.trim().length === 0
+        || typeof item.type !== 'string'
+        || item.type.trim().length === 0
+        || typeof item.purpose !== 'string'
+        || item.purpose.trim().length === 0
+        || !isRecord(item.lifecycle)
+        || seenNodeIds.has(item.id)) {
+        throw new Error(`registry node ${index} fields mismatch`);
+      }
+      seenNodeIds.add(item.id);
+      const state = item.lifecycle.state;
+      const reviewedAt = item.lifecycle.reviewedAt;
+      const evidenceRefs = item.lifecycle.evidenceRefs;
+      if (!LIFECYCLE_STATES.includes(state as EcosystemMapLifecycleState)
+        || typeof reviewedAt !== 'string'
+        || !isExactCalendarDate(reviewedAt)
+        || !Array.isArray(evidenceRefs)
+        || evidenceRefs.length === 0
+        || evidenceRefs.some((value) => typeof value !== 'string' || value.trim().length === 0)
+        || new Set(evidenceRefs).size !== evidenceRefs.length) {
+        throw new Error(`registry node ${index} lifecycle mismatch`);
+      }
+      const lifecycleState = state as EcosystemMapLifecycleState;
+      counts[lifecycleState] += 1;
+      return {
+        node_id: item.id,
+        name: item.name,
+        type: item.type,
+        purpose: item.purpose,
+        lifecycle_state: lifecycleState,
+        lifecycle_reviewed_at: reviewedAt,
+        lifecycle_evidence_refs: [...evidenceRefs] as string[],
+      };
+    });
+    const reviewedAt = nodes
+      .map((node) => node.lifecycle_reviewed_at)
+      .sort((left, right) => left.localeCompare(right))[0] || null;
+    return {
+      nodes,
+      declaredNodeCount,
+      reviewState: 'declared',
+      reviewReason: 'registry_lifecycle_contract_verified',
+      reviewedAt,
+      lifecycleCounts: counts,
+    };
+  } catch {
+    return unavailable('registry_lifecycle_contract_unavailable');
+  }
 }
 
 function ageFreshness(generatedAt: string | null, staleAfterHours: number): {
@@ -627,12 +761,17 @@ export async function getEcosystemMapData(): Promise<EcosystemMapViewData> {
       (item) => item.artifact.role === 'canonical_ecosystem_map_mermaid',
     );
     const map = mapInspection?.view || null;
+    const nodeInspection = currentArtifacts.find(
+      (item) => item.artifact.role === 'registry_nodes',
+    );
+    const semantics = inspectSemanticNodes(nodeInspection?.view);
     const missingReason = map?.missing_reason || (map ? 'ok' : 'artifact_role_missing');
     const alignment = await inspectAlignment(sourceRoot, manifest, currentArtifacts);
     const combinedFreshness = combineFreshness(ageState.freshness_state, alignment);
 
     return {
       map,
+      nodes: semantics.nodes,
       cross_links: crossLinks.links,
       cross_link_meta: crossLinks.meta,
       view_meta: {
@@ -653,6 +792,12 @@ export async function getEcosystemMapData(): Promise<EcosystemMapViewData> {
         freshness_state: combinedFreshness.state,
         freshness_reason: combinedFreshness.reason,
         stale_after_hours: staleAfterHours,
+        semantic_review_state: semantics.reviewState,
+        semantic_review_reason: semantics.reviewReason,
+        semantic_reviewed_at: semantics.reviewedAt,
+        semantic_reviewed_node_count: semantics.nodes.length,
+        semantic_node_count: semantics.declaredNodeCount,
+        lifecycle_counts: semantics.lifecycleCounts,
         does_not_establish: manifest.doesNotEstablish,
       },
     };

--- a/src/controllers/ecosystemMapNavigation.ts
+++ b/src/controllers/ecosystemMapNavigation.ts
@@ -1,6 +1,14 @@
 import type { EcosystemCrossViewLink } from './ecosystemMapLinks.js';
 
 export type EcosystemMapNavigationTargetKind = 'leitstand' | 'systemkatalog';
+export type EcosystemMapNavigationLifecycleState = 'active' | 'transition' | 'reference' | 'archived' | 'retired' | 'unknown';
+
+export interface EcosystemMapNodeSemanticInput {
+  node_id: string;
+  purpose: string;
+  lifecycle_state: Exclude<EcosystemMapNavigationLifecycleState, 'unknown'>;
+  lifecycle_reviewed_at: string;
+}
 
 export interface EcosystemMapNodeNavigation {
   mermaid_id: string;
@@ -10,6 +18,9 @@ export interface EcosystemMapNodeNavigation {
   title: string;
   target_kind: EcosystemMapNavigationTargetKind;
   source_href: string;
+  purpose: string;
+  lifecycle_state: EcosystemMapNavigationLifecycleState;
+  lifecycle_reviewed_at: string | null;
 }
 
 interface MermaidNodeIdentity {
@@ -74,8 +85,10 @@ export function buildEcosystemMapNavigation(
   sourceRepository: string,
   sourceCommit: string,
   mapPath: string,
+  nodeSemantics: EcosystemMapNodeSemanticInput[] = [],
 ): EcosystemMapNodeNavigation[] {
   const linkByNodeId = new Map(crossLinks.map((link) => [link.node_id, link]));
+  const semanticsByNodeId = new Map(nodeSemantics.map((node) => [node.node_id, node]));
 
   return extractMermaidNodeIdentities(mapContent).map((identity) => {
     const sourceHref = canonicalSourceHref(
@@ -86,6 +99,7 @@ export function buildEcosystemMapNavigation(
     );
     const mapped = linkByNodeId.get(identity.nodeId);
     const target = mapped?.status === 'linked' ? mapped.links[0] : undefined;
+    const semantics = semanticsByNodeId.get(identity.nodeId);
 
     return {
       mermaid_id: identity.mermaidId,
@@ -95,6 +109,9 @@ export function buildEcosystemMapNavigation(
       title: target?.title || `${identity.label} im kanonischen Systemkatalog öffnen`,
       target_kind: target ? 'leitstand' : 'systemkatalog',
       source_href: sourceHref,
+      purpose: semantics?.purpose || '',
+      lifecycle_state: semantics?.lifecycle_state || 'unknown',
+      lifecycle_reviewed_at: semantics?.lifecycle_reviewed_at || null,
     };
   });
 }

--- a/src/public/ecosystem-map.mjs
+++ b/src/public/ecosystem-map.mjs
@@ -8,6 +8,14 @@ const TYPE_LABELS = {
   concept: 'Konzepte',
   actor: 'Menschen',
 };
+const LIFECYCLE_LABELS = {
+  active: 'Aktiv',
+  transition: 'Übergang',
+  reference: 'Referenz',
+  archived: 'Archiviert',
+  retired: 'Außer Betrieb',
+  unknown: 'Unbekannt',
+};
 const EDGE_DEFINITION = /^\s*([A-Za-z][A-Za-z0-9_]*)\s*-->\|([^|\n]+)\|\s*([A-Za-z][A-Za-z0-9_]*)\s*$/;
 const VIEWBOX_MIN_SCALE = 0.08;
 const VIEWBOX_MAX_SCALE = 4;
@@ -131,6 +139,7 @@ function createExplorer(canvas, navigation) {
       <input id="ecosystem-map-search" class="map-search" type="search" autocomplete="off" placeholder="Name, ID oder Beschreibung" aria-describedby="ecosystem-map-result-count">
     </div>
     <div class="map-explorer-row" data-map-filters role="group" aria-label="Nach Systemart filtern"></div>
+    <div class="map-explorer-row" data-map-lifecycle-filters role="group" aria-label="Nach Lebenszyklus filtern"></div>
     <div class="map-explorer-row" data-map-controls role="group" aria-label="Kartenausschnitt steuern">
       <button type="button" class="map-control" data-map-view-action="zoom-in" aria-label="Karte vergrößern">Vergrößern</button>
       <button type="button" class="map-control" data-map-view-action="zoom-out" aria-label="Karte verkleinern">Verkleinern</button>
@@ -159,7 +168,7 @@ function createExplorer(canvas, navigation) {
 
   const types = [...new Set(navigation.map((item) => nodeType(item.node_id)))].filter((type) => TYPE_LABELS[type]);
   const filters = explorer.querySelector('[data-map-filters]');
-  for (const [type, label] of [['all', 'Alle'], ...types.map((type) => [type, TYPE_LABELS[type]])]) {
+  for (const [type, label] of [['all', 'Alle Arten'], ...types.map((type) => [type, TYPE_LABELS[type]])]) {
     const button = document.createElement('button');
     button.type = 'button';
     button.className = 'map-filter';
@@ -167,6 +176,18 @@ function createExplorer(canvas, navigation) {
     button.setAttribute('aria-pressed', type === 'all' ? 'true' : 'false');
     button.textContent = label;
     filters.append(button);
+  }
+  const lifecycleStates = [...new Set(navigation.map((item) => item.lifecycle_state || 'unknown'))]
+    .filter((state) => LIFECYCLE_LABELS[state]);
+  const lifecycleFilters = explorer.querySelector('[data-map-lifecycle-filters]');
+  for (const [state, label] of [['all', 'Alle Lebenszyklen'], ...lifecycleStates.map((state) => [state, LIFECYCLE_LABELS[state]])]) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'map-filter';
+    button.dataset.mapLifecycle = state;
+    button.setAttribute('aria-pressed', state === 'all' ? 'true' : 'false');
+    button.textContent = label;
+    lifecycleFilters.append(button);
   }
   return explorer;
 }
@@ -558,11 +579,13 @@ function bindExplorer(svgRoot, navigation, explorer, definition) {
   const detailClear = explorer.querySelector('[data-map-detail-clear]');
   const fitFocusButton = explorer.querySelector('[data-map-view-action="fit-focus"]');
   const filters = [...explorer.querySelectorAll('[data-map-type]')];
+  const lifecycleFilters = [...explorer.querySelectorAll('[data-map-lifecycle]')];
   const records = navigation.map((target) => ({
     target,
     type: nodeType(target.node_id),
+    lifecycle: target.lifecycle_state || 'unknown',
     node: findRenderedNode(svgRoot, target.mermaid_id),
-    haystack: normalize(`${target.label} ${target.node_id} ${target.title}`),
+    haystack: normalize(`${target.label} ${target.node_id} ${target.title} ${target.purpose || ''} ${target.lifecycle_state || ''}`),
   })).filter((record) => record.node);
   const recordsByMermaidId = new Map(records.map((record) => [record.target.mermaid_id, record]));
   const relationships = parseRelationships(definition, recordsByMermaidId);
@@ -572,6 +595,9 @@ function bindExplorer(svgRoot, navigation, explorer, definition) {
   let activeType = filters.some((filter) => filter.dataset.mapType === initialParameters.get('type'))
     ? initialParameters.get('type')
     : 'all';
+  let activeLifecycle = lifecycleFilters.some((filter) => filter.dataset.mapLifecycle === initialParameters.get('lifecycle'))
+    ? initialParameters.get('lifecycle')
+    : 'all';
   let selected = null;
   let focusDepth = initialParameters.get('depth') === '2' ? 2 : 1;
   let viewport = null;
@@ -579,6 +605,7 @@ function bindExplorer(svgRoot, navigation, explorer, definition) {
 
   search.value = initialParameters.get('q') || '';
   for (const filter of filters) filter.setAttribute('aria-pressed', filter.dataset.mapType === activeType ? 'true' : 'false');
+  for (const filter of lifecycleFilters) filter.setAttribute('aria-pressed', filter.dataset.mapLifecycle === activeLifecycle ? 'true' : 'false');
 
   function focusSet(record, depth = focusDepth) {
     if (!record) return new Set();
@@ -614,6 +641,7 @@ function bindExplorer(svgRoot, navigation, explorer, definition) {
     const query = search.value.trim();
     if (query) url.searchParams.set('q', query); else url.searchParams['delete']('q');
     if (activeType !== 'all') url.searchParams.set('type', activeType); else url.searchParams['delete']('type');
+    if (activeLifecycle !== 'all') url.searchParams.set('lifecycle', activeLifecycle); else url.searchParams['delete']('lifecycle');
     if (selected) url.searchParams.set('node', selected.target.node_id); else url.searchParams['delete']('node');
     if (selected && focusDepth === 2) url.searchParams.set('depth', '2'); else url.searchParams['delete']('depth');
     const currentView = viewport?.current();
@@ -661,7 +689,7 @@ function bindExplorer(svgRoot, navigation, explorer, definition) {
       title.textContent = record.target.label;
       const meta = document.createElement('span');
       meta.className = 'map-result-meta';
-      meta.textContent = `${record.target.node_id} · ${TYPE_LABELS[record.type] || record.type}`;
+      meta.textContent = `${record.target.node_id} · ${TYPE_LABELS[record.type] || record.type} · ${LIFECYCLE_LABELS[record.lifecycle] || record.lifecycle}`;
       const relationMeta = document.createElement('span');
       relationMeta.className = 'map-result-relations';
       relationMeta.textContent = `${relationCount} ${relationCount === 1 ? 'Beziehung' : 'Beziehungen'}`;
@@ -717,8 +745,9 @@ function bindExplorer(svgRoot, navigation, explorer, definition) {
     const incoming = entries.filter((entry) => entry.direction === 'incoming');
     const visibleFocus = focusSet(selected);
     detailLabel.textContent = selected.target.label;
-    detailMeta.textContent = `${selected.target.node_id} · ${selected.type} · Ziel: ${selected.target.target_kind} · ${outgoing.length} ausgehend · ${incoming.length} eingehend`;
-    detailDescription.textContent = selected.target.title;
+    const reviewLabel = selected.target.lifecycle_reviewed_at ? ` · geprüft ${selected.target.lifecycle_reviewed_at}` : '';
+    detailMeta.textContent = `${selected.target.node_id} · ${selected.type} · ${LIFECYCLE_LABELS[selected.lifecycle] || selected.lifecycle}${reviewLabel} · Ziel: ${selected.target.target_kind} · ${outgoing.length} ausgehend · ${incoming.length} eingehend`;
+    detailDescription.textContent = selected.target.purpose || selected.target.title;
     detailOpen.href = selected.target.href;
     detailSource.href = selected.target.source_href;
     detailDepth.textContent = focusDepth === 1 ? 'Umfeld erweitern' : 'Nur direkte Beziehungen';
@@ -737,7 +766,9 @@ function bindExplorer(svgRoot, navigation, explorer, definition) {
   function applyVisualState() {
     const query = normalize(search.value.trim());
     const baseVisible = new Set(records
-      .filter((record) => (activeType === 'all' || record.type === activeType) && (!query || record.haystack.includes(query)))
+      .filter((record) => (activeType === 'all' || record.type === activeType)
+        && (activeLifecycle === 'all' || record.lifecycle === activeLifecycle)
+        && (!query || record.haystack.includes(query)))
       .map((record) => record.target.mermaid_id));
     if (selected && !baseVisible.has(selected.target.mermaid_id)) selected = null;
     const focused = selected ? focusSet(selected) : baseVisible;
@@ -786,6 +817,10 @@ function bindExplorer(svgRoot, navigation, explorer, definition) {
       activeType = 'all';
       for (const filter of filters) filter.setAttribute('aria-pressed', filter.dataset.mapType === 'all' ? 'true' : 'false');
     }
+    if (activeLifecycle !== 'all' && record.lifecycle !== activeLifecycle) {
+      activeLifecycle = 'all';
+      for (const filter of lifecycleFilters) filter.setAttribute('aria-pressed', filter.dataset.mapLifecycle === 'all' ? 'true' : 'false');
+    }
     if (query && !record.haystack.includes(query)) search.value = '';
     selected = record;
     applyVisualState();
@@ -822,6 +857,14 @@ function bindExplorer(svgRoot, navigation, explorer, definition) {
     filter.addEventListener('click', () => {
       activeType = filter.dataset.mapType;
       for (const candidate of filters) candidate.setAttribute('aria-pressed', candidate === filter ? 'true' : 'false');
+      applyVisualState();
+      scheduleUrlUpdate();
+    });
+  }
+  for (const filter of lifecycleFilters) {
+    filter.addEventListener('click', () => {
+      activeLifecycle = filter.dataset.mapLifecycle;
+      for (const candidate of lifecycleFilters) candidate.setAttribute('aria-pressed', candidate === filter ? 'true' : 'false');
       applyVisualState();
       scheduleUrlUpdate();
     });

--- a/src/server.ts
+++ b/src/server.ts
@@ -136,6 +136,7 @@ app.get('/ecosystem-map', async (_req, res) => {
         data.view_meta.source_repository,
         data.view_meta.source_commit,
         data.map.path,
+        data.nodes,
       )
       : [];
     res.render('ecosystem-map', {

--- a/src/views/ecosystem-map.ejs
+++ b/src/views/ecosystem-map.ejs
@@ -80,13 +80,13 @@
       <p class="subtitle">Grafische, ausschließlich lesende Projektion der vom Systemkatalog verantworteten Ökosystemsemantik.</p>
     </header>
 
-    <section class="truth-banner" data-state="<%= view_meta.alignment_state %>" aria-label="Inhaltlicher Quellenabgleich">
+    <section class="truth-banner" data-state="<%= view_meta.alignment_state %>" aria-label="Technischer Artefaktabgleich">
       <% if (view_meta.alignment_state === 'exact') { %>
-        <strong>Exakt gebunden</strong>
-        <p>Der Kartencommit entspricht dem aktuellen Systemkatalog-HEAD. Alle <%= view_meta.verified_artifact_count %> deklarierten Artefakte stimmen mit Manifest, Arbeitsbaum und gebundenem Git-Commit überein.</p>
+        <strong>Exakt gebunden – technische Artefakte</strong>
+        <p>Der Kartencommit entspricht dem aktuellen Systemkatalog-HEAD. Alle <%= view_meta.verified_artifact_count %> deklarierten Artefakte stimmen mit Manifest, Arbeitsbaum und gebundenem Git-Commit überein. Das belegt technische Konsistenz, nicht Runtime-Gesundheit oder eine neue semantische Prüfung.</p>
       <% } else if (view_meta.alignment_state === 'compatible') { %>
-        <strong>Inhalt aktuell, Repository weiterentwickelt</strong>
-        <p>Seit dem Kartencommit gibt es <%= view_meta.commits_ahead === null ? 'weitere' : view_meta.commits_ahead %> spätere Commits. Der aktuelle HEAD und der Arbeitsbaum enthalten weiterhin exakt dieselben <%= view_meta.declared_artifact_count %> deklarierten Kartenartefakte.</p>
+        <strong>Artefakte technisch konsistent, Repository weiterentwickelt</strong>
+        <p>Seit dem Kartencommit gibt es <%= view_meta.commits_ahead === null ? 'weitere' : view_meta.commits_ahead %> spätere Commits. Der aktuelle HEAD und der Arbeitsbaum enthalten weiterhin exakt dieselben <%= view_meta.declared_artifact_count %> deklarierten Kartenartefakte. Das belegt unveränderte Bytes, nicht automatisch aktuelle Semantik.</p>
       <% } else if (view_meta.alignment_state === 'drifted') { %>
         <strong>Drift erkannt</strong>
         <p>Mindestens ein Kartenartefakt oder seine Commitbindung stimmt nicht mehr. Technischer Grund: <code><%= view_meta.alignment_reason %></code>.</p>
@@ -113,7 +113,7 @@
           <a href="https://github.com/<%= view_meta.source_repository %>/blob/<%= view_meta.source_commit %>/<%= map.path %>"><%= map.path %></a>
           · <%= map.bytes %> Bytes · sha256 <%= map.sha256 %>
         </p>
-        <p class="link-note">Knoten mit einer passenden Leitstand-Ansicht öffnen diese Ansicht. Alle übrigen Knoten führen zur exakten Definitionszeile im gebundenen Systemkatalog-Commit. Tastatur: / sucht, F schaltet Vollbild, Esc beendet Vollbild oder Auswahl.</p>
+        <p class="link-note">Knoten lassen sich unabhängig nach Systemart und stabilem Lebenszyklus filtern. Eine passende Leitstand-Ansicht öffnet die jeweilige Ansicht; alle übrigen Knoten führen zur exakten Definitionszeile im gebundenen Systemkatalog-Commit. Lebenszyklus ist kein Runtime-Status. Tastatur: / sucht, F schaltet Vollbild, Esc beendet Vollbild oder Auswahl.</p>
         <div id="ecosystem-map-workspace" class="map-workspace" data-ecosystem-map-workspace tabindex="-1">
           <div class="map-workspace-toolbar">
             <span class="map-workspace-title">Ökosystemkarte</span>
@@ -138,13 +138,27 @@
       <summary>Quellen-, Prüf- und Zuständigkeitsdetails</summary>
       <div class="source-details-content">
         <section class="notice" aria-label="Zuständigkeitsgrenze">
-          <strong>Nur Ansicht.</strong> Der Systemkatalog besitzt Systeme, Beziehungen und Bedeutungen. Leitstand rendert das geprüfte, commit- und hashgebundene Artefakt als SVG. Er bearbeitet die Karte nicht, leitet keine neue Wahrheit ab und löst keine Aufgaben oder Änderungen aus.
+          <strong>Nur Ansicht.</strong> Der Systemkatalog besitzt Systeme, stabile Lebenszyklen, Beziehungen und Bedeutungen. Leitstand rendert die commit- und hashgebundenen Artefakte und zeigt die darin deklarierte Semantik getrennt von Artefaktalter und Runtime-Zustand. Er bearbeitet die Karte nicht, leitet keine neue Wahrheit ab und löst keine Aufgaben oder Änderungen aus.
         </section>
 
         <section class="meta-grid" aria-label="Quellenmetadaten">
-          <div class="meta-item"><div class="label">Gesamtstatus</div><div class="value" data-state="<%= view_meta.freshness_state %>"><%= view_meta.freshness_state %> · <%= view_meta.freshness_reason %></div></div>
-          <div class="meta-item"><div class="label">Inhaltsabgleich</div><div class="value" data-state="<%= view_meta.alignment_state %>"><%= view_meta.alignment_state %> · <%= view_meta.verified_artifact_count %>/<%= view_meta.declared_artifact_count %> Artefakte</div></div>
+          <div class="meta-item"><div class="label">Technische Freshness</div><div class="value" data-state="<%= view_meta.freshness_state %>"><%= view_meta.freshness_state %> · <%= view_meta.freshness_reason %></div></div>
+          <div class="meta-item"><div class="label">Artefaktabgleich</div><div class="value" data-state="<%= view_meta.alignment_state %>"><%= view_meta.alignment_state %> · <%= view_meta.verified_artifact_count %>/<%= view_meta.declared_artifact_count %> Artefakte</div></div>
           <div class="meta-item"><div class="label">Quellzustand</div><div class="value"><%= view_meta.source_kind %> / <%= view_meta.missing_reason %></div></div>
+          <div class="meta-item">
+            <div class="label">Semantikprüfung</div>
+            <div class="value" data-state="<%= view_meta.semantic_review_state === 'declared' ? 'exact' : 'unverifiable' %>">
+              <% if (view_meta.semantic_review_state === 'declared') { %>
+                deklariert · <%= view_meta.semantic_reviewed_node_count %>/<%= view_meta.semantic_node_count %> Knoten · ältestes Prüfdatum <%= view_meta.semantic_reviewed_at || '—' %>
+              <% } else { %>
+                nicht verfügbar · <%= view_meta.semantic_review_reason %>
+              <% } %>
+            </div>
+          </div>
+          <div class="meta-item">
+            <div class="label">Lebenszyklen</div>
+            <div class="value">aktiv <%= view_meta.lifecycle_counts.active %> · Übergang <%= view_meta.lifecycle_counts.transition %> · Referenz <%= view_meta.lifecycle_counts.reference %> · archiviert <%= view_meta.lifecycle_counts.archived %> · außer Betrieb <%= view_meta.lifecycle_counts.retired %></div>
+          </div>
           <div class="meta-item"><div class="label">Alter</div><div class="value"><% if (view_meta.data_age_minutes !== null) { %><%= view_meta.data_age_minutes %> min · Grenze <%= view_meta.stale_after_hours %> h<% } else { %>—<% } %></div></div>
           <div class="meta-item">
             <div class="label">Gebundener Commit</div>

--- a/tests/controllers/ecosystemMap.test.ts
+++ b/tests/controllers/ecosystemMap.test.ts
@@ -235,20 +235,76 @@ describe('getEcosystemMapData', () => {
     },
   );
 
-  it('rejects duplicate node identities and duplicate lifecycle evidence references', async () => {
-    const duplicateNode = {
-      id: 'repo:heimserver',
-      name: 'Heimserver',
-      type: 'repository',
-      purpose: 'retired historical reference',
-      lifecycle: {
-        state: 'retired',
-        reviewedAt: '2026-07-26',
-        evidenceRefs: ['bureau:T032', 'bureau:T032'],
-      },
-    };
+  it.each([
+    {
+      label: 'duplicate node identities',
+      nodes: [
+        {
+          id: 'repo:heimserver',
+          name: 'Heimserver',
+          type: 'repository',
+          purpose: 'retired historical reference',
+          lifecycle: { state: 'retired', reviewedAt: '2026-07-26', evidenceRefs: ['bureau:T032'] },
+        },
+        {
+          id: 'repo:heimserver',
+          name: 'Heimserver duplicate',
+          type: 'repository',
+          purpose: 'duplicate reference',
+          lifecycle: { state: 'retired', reviewedAt: '2026-07-26', evidenceRefs: ['bureau:T063'] },
+        },
+      ],
+    },
+    {
+      label: 'node identities with surrounding whitespace',
+      nodes: [
+        {
+          id: 'repo:heimserver',
+          name: 'Heimserver',
+          type: 'repository',
+          purpose: 'retired historical reference',
+          lifecycle: { state: 'retired', reviewedAt: '2026-07-26', evidenceRefs: ['bureau:T032'] },
+        },
+        {
+          id: ' repo:heimserver ',
+          name: 'Heimserver spaced',
+          type: 'repository',
+          purpose: 'non-canonical reference',
+          lifecycle: { state: 'retired', reviewedAt: '2026-07-26', evidenceRefs: ['bureau:T063'] },
+        },
+      ],
+    },
+    {
+      label: 'duplicate lifecycle evidence references',
+      nodes: [{
+        id: 'repo:heimserver',
+        name: 'Heimserver',
+        type: 'repository',
+        purpose: 'retired historical reference',
+        lifecycle: {
+          state: 'retired',
+          reviewedAt: '2026-07-26',
+          evidenceRefs: ['bureau:T032', 'bureau:T032'],
+        },
+      }],
+    },
+    {
+      label: 'lifecycle evidence references with surrounding whitespace',
+      nodes: [{
+        id: 'repo:heimserver',
+        name: 'Heimserver',
+        type: 'repository',
+        purpose: 'retired historical reference',
+        lifecycle: {
+          state: 'retired',
+          reviewedAt: '2026-07-26',
+          evidenceRefs: ['bureau:T032', ' bureau:T063 '],
+        },
+      }],
+    },
+  ])('rejects $label', async ({ nodes }) => {
     const fixture = await makeFixture(new Date().toISOString(), {
-      nodesContent: `${JSON.stringify({ nodes: [duplicateNode, duplicateNode] })}\n`,
+      nodesContent: `${JSON.stringify({ nodes })}\n`,
     });
     process.env.LEITSTAND_ECOSYSTEM_MAP_MANIFEST_PATH = fixture.manifestPath;
 
@@ -256,7 +312,7 @@ describe('getEcosystemMapData', () => {
 
     expect(data.view_meta.alignment_state).toBe('exact');
     expect(data.view_meta.semantic_review_state).toBe('unavailable');
-    expect(data.view_meta.semantic_node_count).toBe(2);
+    expect(data.view_meta.semantic_node_count).toBe(nodes.length);
     expect(data.view_meta.semantic_reviewed_node_count).toBe(0);
     expect(data.nodes).toEqual([]);
   });

--- a/tests/controllers/ecosystemMap.test.ts
+++ b/tests/controllers/ecosystemMap.test.ts
@@ -29,7 +29,7 @@ const ARTIFACT_CONTENT = [
     role: 'registry_nodes',
     path: 'registry/ecosystem/nodes.json',
     contentType: 'application/json',
-    content: '{"nodes":[]}\n',
+    content: '{"nodes":[{"id":"repo:systemkatalog","name":"Systemkatalog","type":"repository","purpose":"stable catalog semantics","lifecycle":{"state":"active","reviewedAt":"2026-07-26","evidenceRefs":["policy/system-catalog.v1.json"]}},{"id":"repo:heimserver","name":"Heimserver","type":"repository","purpose":"retired historical reference","lifecycle":{"state":"retired","reviewedAt":"2026-07-25","evidenceRefs":["bureau:T032"]}}]}\n',
   },
   {
     role: 'registry_edges',
@@ -96,14 +96,20 @@ async function initializeRepository(sourceRoot: string): Promise<string> {
 
 async function makeFixture(
   generatedAt = new Date().toISOString(),
-  options: { initializeGit?: boolean } = {},
+  options: { initializeGit?: boolean; nodesContent?: string } = {},
 ) {
   const root = await mkdtemp(join(tmpdir(), 'leitstand-map-'));
   tempRoots.push(root);
   const sourceRoot = join(root, 'systemkatalog');
   await mkdir(sourceRoot, { recursive: true });
 
-  for (const artifact of ARTIFACT_CONTENT) {
+  const artifacts = ARTIFACT_CONTENT.map((artifact) => (
+    artifact.role === 'registry_nodes' && options.nodesContent !== undefined
+      ? { ...artifact, content: options.nodesContent }
+      : artifact
+  ));
+
+  for (const artifact of artifacts) {
     const target = join(sourceRoot, artifact.path);
     await mkdir(dirname(target), { recursive: true });
     await writeFile(target, artifact.content, 'utf-8');
@@ -125,8 +131,8 @@ async function makeFixture(
       commit: sourceCommit,
       generatedAt,
     },
-    artifactCount: ARTIFACT_CONTENT.length,
-    artifacts: ARTIFACT_CONTENT.map((artifact) => ({
+    artifactCount: artifacts.length,
+    artifacts: artifacts.map((artifact) => ({
       role: artifact.role,
       path: artifact.path,
       contentType: artifact.contentType,
@@ -167,9 +173,92 @@ describe('getEcosystemMapData', () => {
     expect(data.view_meta.verified_artifact_count).toBe(6);
     expect(data.view_meta.declared_artifact_count).toBe(6);
     expect(data.view_meta.freshness_state).toBe('fresh');
+    expect(data.view_meta.semantic_review_state).toBe('declared');
+    expect(data.view_meta.semantic_reviewed_at).toBe('2026-07-25');
+    expect(data.view_meta.semantic_reviewed_node_count).toBe(2);
+    expect(data.view_meta.lifecycle_counts).toEqual({
+      active: 1, transition: 0, reference: 0, archived: 0, retired: 1,
+    });
+    expect(data.nodes).toMatchObject([
+      { node_id: 'repo:systemkatalog', lifecycle_state: 'active' },
+      { node_id: 'repo:heimserver', lifecycle_state: 'retired' },
+    ]);
     expect(data.map?.role).toBe('canonical_ecosystem_map_mermaid');
     expect(data.map?.content).toContain('Systemkatalog');
     expect(data.view_meta.does_not_establish).toContain('runtime_correctness');
+  });
+
+  it('keeps technical artifact truth fresh when lifecycle semantics are unavailable', async () => {
+    const fixture = await makeFixture(new Date().toISOString(), {
+      nodesContent: '{"nodes":[{"id":"repo:systemkatalog","name":"Systemkatalog","type":"repository","purpose":"catalog","lifecycle":{"state":"running","reviewedAt":"not-a-date","evidenceRefs":[]}}]}\n',
+    });
+    process.env.LEITSTAND_ECOSYSTEM_MAP_MANIFEST_PATH = fixture.manifestPath;
+
+    const data = await getEcosystemMapData();
+
+    expect(data.view_meta.alignment_state).toBe('exact');
+    expect(data.view_meta.freshness_state).toBe('fresh');
+    expect(data.view_meta.semantic_review_state).toBe('unavailable');
+    expect(data.view_meta.semantic_review_reason).toBe('registry_lifecycle_contract_unavailable');
+    expect(data.view_meta.semantic_reviewed_node_count).toBe(0);
+    expect(data.view_meta.semantic_node_count).toBe(1);
+    expect(data.nodes).toEqual([]);
+    expect(data.view_meta.lifecycle_counts).toEqual({
+      active: 0, transition: 0, reference: 0, archived: 0, retired: 0,
+    });
+  });
+
+  it.each(['2026-02-30', '2025-02-29', '0000-01-01', '2026-2-03'])(
+    'rejects non-canonical or impossible lifecycle date %s without degrading artifact freshness',
+    async (reviewedAt) => {
+      const fixture = await makeFixture(new Date().toISOString(), {
+        nodesContent: `${JSON.stringify({
+          nodes: [{
+            id: 'repo:heimserver',
+            name: 'Heimserver',
+            type: 'repository',
+            purpose: 'retired historical reference',
+            lifecycle: { state: 'retired', reviewedAt, evidenceRefs: ['bureau:T032'] },
+          }],
+        })}\n`,
+      });
+      process.env.LEITSTAND_ECOSYSTEM_MAP_MANIFEST_PATH = fixture.manifestPath;
+
+      const data = await getEcosystemMapData();
+
+      expect(data.view_meta.alignment_state).toBe('exact');
+      expect(data.view_meta.freshness_state).toBe('fresh');
+      expect(data.view_meta.semantic_review_state).toBe('unavailable');
+      expect(data.view_meta.semantic_node_count).toBe(1);
+      expect(data.view_meta.semantic_reviewed_node_count).toBe(0);
+      expect(data.nodes).toEqual([]);
+    },
+  );
+
+  it('rejects duplicate node identities and duplicate lifecycle evidence references', async () => {
+    const duplicateNode = {
+      id: 'repo:heimserver',
+      name: 'Heimserver',
+      type: 'repository',
+      purpose: 'retired historical reference',
+      lifecycle: {
+        state: 'retired',
+        reviewedAt: '2026-07-26',
+        evidenceRefs: ['bureau:T032', 'bureau:T032'],
+      },
+    };
+    const fixture = await makeFixture(new Date().toISOString(), {
+      nodesContent: `${JSON.stringify({ nodes: [duplicateNode, duplicateNode] })}\n`,
+    });
+    process.env.LEITSTAND_ECOSYSTEM_MAP_MANIFEST_PATH = fixture.manifestPath;
+
+    const data = await getEcosystemMapData();
+
+    expect(data.view_meta.alignment_state).toBe('exact');
+    expect(data.view_meta.semantic_review_state).toBe('unavailable');
+    expect(data.view_meta.semantic_node_count).toBe(2);
+    expect(data.view_meta.semantic_reviewed_node_count).toBe(0);
+    expect(data.nodes).toEqual([]);
   });
 
   it('reports compatible newer commits when declared artifacts remain byte-identical', async () => {

--- a/tests/controllers/ecosystemMapNavigation.test.ts
+++ b/tests/controllers/ecosystemMapNavigation.test.ts
@@ -41,6 +41,11 @@ describe('ecosystem map node navigation', () => {
       'heimgewebe/systemkatalog',
       COMMIT,
       'rendered/ecosystem-registry-map.mmd',
+      [
+        { node_id: 'repo:bureau', purpose: 'task truth', lifecycle_state: 'active', lifecycle_reviewed_at: '2026-07-26' },
+        { node_id: 'repo:systemkatalog', purpose: 'catalog truth', lifecycle_state: 'active', lifecycle_reviewed_at: '2026-07-25' },
+        { node_id: 'service:github', purpose: 'repository truth', lifecycle_state: 'active', lifecycle_reviewed_at: '2026-07-24' },
+      ],
     );
 
     expect(navigation).toHaveLength(3);
@@ -48,11 +53,16 @@ describe('ecosystem map node navigation', () => {
       node_id: 'repo:bureau',
       href: '/bureau',
       target_kind: 'leitstand',
+      purpose: 'task truth',
+      lifecycle_state: 'active',
+      lifecycle_reviewed_at: '2026-07-26',
     });
     expect(navigation[1]).toMatchObject({
       node_id: 'repo:systemkatalog',
       target_kind: 'systemkatalog',
       href: `https://github.com/heimgewebe/systemkatalog/blob/${COMMIT}/rendered/ecosystem-registry-map.mmd?plain=1#L3`,
+      purpose: 'catalog truth',
+      lifecycle_state: 'active',
     });
     expect(navigation[2].source_href).toContain(`/${COMMIT}/rendered/ecosystem-registry-map.mmd?plain=1#L4`);
   });

--- a/tests/views/ecosystemMap.test.ts
+++ b/tests/views/ecosystemMap.test.ts
@@ -42,6 +42,12 @@ describe('ecosystem-map view', () => {
           freshness_state: 'fresh',
           freshness_reason: 'artifact_alignment_verified',
           stale_after_hours: 168,
+          semantic_review_state: 'declared',
+          semantic_review_reason: 'registry_lifecycle_contract_verified',
+          semantic_reviewed_at: '2026-07-25',
+          semantic_reviewed_node_count: 2,
+          semantic_node_count: 2,
+          lifecycle_counts: { active: 1, transition: 0, reference: 0, archived: 0, retired: 1 },
           does_not_establish: ['runtime_correctness'],
         },
         node_navigation_json: '[{"mermaid_id":"repo_bureau","href":"/bureau"}]',
@@ -62,10 +68,14 @@ describe('ecosystem-map view', () => {
     expect(html).toContain('/assets/ecosystem-map.mjs');
     expect(html).toContain(commit);
     expect(html).toContain(head);
-    expect(html).toContain('Inhalt aktuell, Repository weiterentwickelt');
+    expect(html).toContain('Artefakte technisch konsistent, Repository weiterentwickelt');
     expect(html).toContain('4 spätere Commits');
     expect(html).toContain('aktuelle HEAD und der Arbeitsbaum enthalten weiterhin exakt dieselben 6 deklarierten Kartenartefakte');
     expect(html).toContain('compatible · 6/6 Artefakte');
+    expect(html).toContain('Semantikprüfung');
+    expect(html).toContain('ältestes Prüfdatum 2026-07-25');
+    expect(html).toContain('außer Betrieb 1');
+    expect(html).toContain('Lebenszyklus ist kein Runtime-Status');
     expect(html).toContain('fresh · artifact_alignment_verified');
     expect(html).toContain('12 min · Grenze 168 h');
     expect(html).not.toContain('cdn.jsdelivr');
@@ -103,6 +113,12 @@ describe('ecosystem-map view', () => {
           freshness_state: 'stale',
           freshness_reason: 'current_artifact_mismatch:rendered/ecosystem-registry-map.mmd',
           stale_after_hours: 168,
+          semantic_review_state: 'unavailable',
+          semantic_review_reason: 'artifact_integrity_mismatch',
+          semantic_reviewed_at: null,
+          semantic_reviewed_node_count: 0,
+          semantic_node_count: 0,
+          lifecycle_counts: { active: 0, transition: 0, reference: 0, archived: 0, retired: 0 },
           does_not_establish: ['runtime_correctness'],
         },
         node_navigation_json: '[]',
@@ -154,6 +170,9 @@ describe('ecosystem-map view', () => {
     expect(browserModule).toContain('Umfeld erweitern');
     expect(browserModule).toContain('Kanonische Quelle');
     expect(browserModule).toContain("url.searchParams.set('node'");
+    expect(browserModule).toContain("url.searchParams.set('lifecycle'");
+    expect(browserModule).toContain('data-map-lifecycle-filters');
+    expect(browserModule).toContain('Alle Lebenszyklen');
     expect(browserModule).toContain("url.searchParams.set('view'");
     expect(browserModule).toContain("initialParameters.get('depth') === '2'");
     expect(browserModule).toContain("svg.addEventListener('pointermove'");


### PR DESCRIPTION
## Ziel

Macht die stabilen Systemkatalog-Lifecycle-Zustände in der read-only Ökosystemkarte sichtbar, ohne sie mit technischer Artefakt-Freshness oder Runtime-Gesundheit zu vermischen.

## Umsetzung

- liest `registry_nodes` ausschließlich aus dem hashgebundenen Systemkatalog-Artefakt;
- validiert Lifecycle-Zustände fail-closed;
- verlangt exakte, reale Kalendertage im Format `YYYY-MM-DD`;
- verwirft doppelte Knotenidentitäten und doppelte oder leere Evidenzreferenzen;
- zeigt deklarierte und erfolgreich geprüfte Knotenzahlen getrennt;
- ergänzt Suche, Detailansicht und URL-stabile Filter nach Lifecycle;
- zeigt `retired` als `Außer Betrieb`, ausdrücklich nicht als aktuellen Gesundheitsfehler;
- erhält die bekannte Zustandsaufschrift `Exakt gebunden` und präzisiert sie auf die technische Artefaktachse.

## Wahrheitsgrenze

Leitstand bleibt Consumer. Der Systemkatalog besitzt Systeme, Lifecycle, Beziehungen und Bedeutungen. Technische Artefaktkonsistenz etabliert weder semantische Aktualität noch Runtime-Gesundheit. Lifecycle etabliert keinen aktuellen Dienstzustand.

## Isolation

Die Implementierung erfolgte im eigenen sauberen Worktree auf Basis `a85c14d0df83da61c68e43fe814a19d483f3f6f2`. Der fremde Dirty-Worktree `ecosystem-lifecycle-freshness-v1` wurde nicht verändert; sein Diff diente nur als hashgebundener Reviewinput (`f9f6879b98626f87cf68932111ef520ecdc8f6206e544ff034cca3a36e00f38a`).

## Lokale Prüfung

- Lint: PASS
- Typecheck: PASS
- fokussierte Lifecycle-/Navigation-/View-Tests: 25/25 PASS
- vollständige Tests: 42 Dateien, 261/261 PASS
- Release-Runtime: PASS
- Browser-Shell: mobile 23/23, desktop 13/13 PASS
- Browser-View-Matrix: 197 Checks PASS
- Build und statischer Build: PASS
- Vendor-, Struktur-, Dokumentations-, Generated-, Drift- und Observer-Guards: PASS
- Diff-Hygiene: PASS

## Revisionsbindung

- Basis: `a85c14d0df83da61c68e43fe814a19d483f3f6f2`
- Head: `d4b3c39e6060c2318becf89d424b899f975be84a`
- Umfang: 8 Dateien, +359 / -21

Diese Aufgabe mergt ausschließlich Code. Ein Deployment ist separat als Bureau T062 vorgesehen.