### PR TITLE
Wait for persistent timer catch-up stabilization

### DIFF
--- a/docs/runbooks/local-release-runtime.md
+++ b/docs/runbooks/local-release-runtime.md
@@ -184,4 +184,4 @@ The adapter does not establish:
 
 ## Coupled operator snapshot timer
 
-The release transaction installs the web, storage-health, operator-snapshot, and snapshot-timer user units together. It activates the recurring timer, runs both release-bound producers, restarts the web service, and validates local and canonical routes before completion. Rollback restores all four unit files, timer enablement/activity, selectors, and prior service state.
+The release transaction installs the web, storage-health, operator-snapshot, and snapshot-timer user units together. It activates the recurring timer, runs both release-bound producers, restarts the web service, and validates local and canonical routes before completion. Because `Persistent=true` may immediately start one catch-up producer run, activation accepts `active/running` only as a bounded transient state and waits for `active/waiting` with a finite next realtime trigger. A timer that does not stabilize still fails closed. Rollback restores all four unit files, timer enablement/activity, selectors, and prior service state.

--- a/scripts/leitstand-release.py
+++ b/scripts/leitstand-release.py
@@ -58,6 +58,7 @@ DEFAULT_LOCK_TIMEOUT_SECONDS = 60.0
 DEFAULT_POSTFLIGHT_TIMEOUT_SECONDS = 35.0
 DEFAULT_STABILITY_SECONDS = 2.0
 DEFAULT_POLL_SECONDS = 1.0
+DEFAULT_SNAPSHOT_TIMER_STABILITY_SECONDS = 180.0
 BROWSER_BINARIES = ("chromium", "chromium-browser", "google-chrome-stable", "google-chrome")
 SYSTEM_CA_BUNDLE_CANDIDATES = (
     Path("/etc/ssl/certs/ca-certificates.crt"),
@@ -2254,21 +2255,43 @@ def _snapshot_timer_properties() -> dict[str, str]:
     )
 
 
-def _activate_snapshot_timer(paths: Paths) -> dict[str, str]:
+def _activate_snapshot_timer(
+    paths: Paths,
+    *,
+    stability_timeout_seconds: float = DEFAULT_SNAPSHOT_TIMER_STABILITY_SECONDS,
+) -> dict[str, str]:
     assert paths.snapshot_timer_target is not None
     run(("systemctl", "--user", "enable", SNAPSHOT_TIMER), timeout=60)
     run(("systemctl", "--user", "restart", SNAPSHOT_TIMER), timeout=60)
-    properties = _snapshot_timer_properties()
-    if (
-        properties.get("LoadState") != "loaded"
-        or properties.get("ActiveState") != "active"
-        or properties.get("SubState") != "waiting"
-        or properties.get("UnitFileState") != "enabled"
-        or Path(properties.get("FragmentPath", "")) != paths.snapshot_timer_target
-        or not properties.get("NextElapseUSecRealtime")
-    ):
-        raise ReleaseError(f"operator snapshot timer did not enter a recurring waiting state: {properties}")
-    return properties
+    deadline = time.monotonic() + max(0.0, stability_timeout_seconds)
+    properties: dict[str, str] = {}
+    while True:
+        properties = _snapshot_timer_properties()
+        if (
+            properties.get("LoadState") != "loaded"
+            or properties.get("ActiveState") != "active"
+            or properties.get("UnitFileState") != "enabled"
+            or properties.get("Result") != "success"
+            or Path(properties.get("FragmentPath", "")) != paths.snapshot_timer_target
+            or properties.get("Triggers") != SNAPSHOT_SERVICE
+        ):
+            raise ReleaseError(
+                f"operator snapshot timer identity or active state is invalid: {properties}"
+            )
+        sub_state = properties.get("SubState")
+        if sub_state == "waiting" and properties.get("NextElapseUSecRealtime"):
+            return properties
+        if sub_state not in {"running", "waiting"}:
+            raise ReleaseError(
+                f"operator snapshot timer entered an invalid transient state: {properties}"
+            )
+        now = time.monotonic()
+        if now >= deadline:
+            raise ReleaseError(
+                "operator snapshot timer did not stabilize after a persistent catch-up run: "
+                f"{properties}"
+            )
+        time.sleep(min(DEFAULT_POLL_SECONDS, deadline - now))
 
 
 def _restore_snapshot_timer_state(before: Mapping[str, str]) -> None:

--- a/tests/test_release_runtime.py
+++ b/tests/test_release_runtime.py
@@ -387,6 +387,69 @@ print(json.dumps({'ok': True, 'sourceCommit': manifest['sourceCommit'], 'artifac
                 config=self.config,
             )
 
+    def test_snapshot_timer_waits_for_persistent_catch_up_to_stabilize(self) -> None:
+        assert self.paths.snapshot_timer_target is not None
+        running = {
+            "LoadState": "loaded",
+            "ActiveState": "active",
+            "SubState": "running",
+            "UnitFileState": "enabled",
+            "Result": "success",
+            "FragmentPath": str(self.paths.snapshot_timer_target),
+            "NextElapseUSecRealtime": "",
+            "Triggers": release.SNAPSHOT_SERVICE,
+        }
+        waiting = {
+            **running,
+            "SubState": "waiting",
+            "NextElapseUSecRealtime": "Tue 2026-07-28 07:00:00 CEST",
+        }
+        with (
+            patch.object(
+                release,
+                "run",
+                return_value=subprocess.CompletedProcess([], 0, "", ""),
+            ),
+            patch.object(
+                release,
+                "_snapshot_timer_properties",
+                side_effect=[running, waiting],
+            ),
+            patch.object(release.time, "sleep") as sleep,
+        ):
+            result = release._activate_snapshot_timer(
+                self.paths,
+                stability_timeout_seconds=5,
+            )
+        self.assertEqual(result, waiting)
+        sleep.assert_called_once()
+
+    def test_snapshot_timer_fails_when_catch_up_never_stabilizes(self) -> None:
+        assert self.paths.snapshot_timer_target is not None
+        running = {
+            "LoadState": "loaded",
+            "ActiveState": "active",
+            "SubState": "running",
+            "UnitFileState": "enabled",
+            "Result": "success",
+            "FragmentPath": str(self.paths.snapshot_timer_target),
+            "NextElapseUSecRealtime": "",
+            "Triggers": release.SNAPSHOT_SERVICE,
+        }
+        with (
+            patch.object(
+                release,
+                "run",
+                return_value=subprocess.CompletedProcess([], 0, "", ""),
+            ),
+            patch.object(release, "_snapshot_timer_properties", return_value=running),
+        ):
+            with self.assertRaisesRegex(release.ReleaseError, "did not stabilize"):
+                release._activate_snapshot_timer(
+                    self.paths,
+                    stability_timeout_seconds=0,
+                )
+
     def test_release_verification_binds_tree_artifacts_git_head_and_seal(self) -> None:
         target = self.create_verified_release("3" * 40)
         manifest = release.verify_release_path(self.paths, target)


### PR DESCRIPTION
## Ursache

Der erste Produktivdeploy nach PR #191 wurde korrekt zurückgerollt. `Persistent=true` startete beim Timer-Neustart sofort einen Nachhol-Lauf. Der Timer war deshalb kurzzeitig `active/running` und hatte noch keinen nächsten Realtime-Termin, während der Releaseadapter unmittelbar `active/waiting` verlangte.

Reproduzierter Fehlerbeleg:

- fehlgeschlagener Deploy-Job: `grabowski-job-f5babd4a353c`
- Finalisierungsbeleg: `b3b555d133135a26295d14638939ac4f4f70a20f0dbc14c8f3bb9866df898737`
- beobachteter Übergang: `active/running`, `LastTriggerUSec=Tue 2026-07-28 06:35:35 CEST`, danach Rollback

## Fix

- akzeptiert `active/running` nur als begrenzten transienten Nachholzustand
- pollt höchstens 180 Sekunden bis `active/waiting` mit endlichem `NextElapseUSecRealtime`
- prüft bei jedem Poll LoadState, ActiveState, UnitFileState, Result, FragmentPath und Triggeridentität
- bleibt bei Timeout oder Zustandsabweichung fail-closed

## Prüfung

- Release-Runtime: 40/40
- Anwendung: 267/267
- Lint, Typecheck, Build und Static Build grün
- Browser-Shell mobile 23/23, desktop 13/13
- Repository-, Dokumentations-, Runbook-, Generated-, Drift- und Observer-Gates grün
