### PR TITLE
docs(release): bind secure source ancestry (LSV-V1-T012)

### DIFF
--- a/docs/runbooks/local-release-runtime.md
+++ b/docs/runbooks/local-release-runtime.md
@@ -31,13 +31,15 @@ Full Git-dependent CI runs first in the exact clean source checkout. The adapter
 
 ### Secure deployment-source ancestry
 
-A clean, commit-exact checkout is necessary but not sufficient. Before build or deploy, `assert_secure_ancestry` verifies the checkout and every relevant component of its resolved source path. A component that is writable by group or others is rejected, except for the narrow root-owned sticky-directory case handled by the existing guard. This check remains fail closed; operators must not add an exception for `/home/alex/repos`, weaken the guard, or change permissions on a foreign parent path merely to make a release pass.
+A clean, commit-exact checkout is necessary but not sufficient. Before the Leitstand release build, `source_identity` calls `assert_secure_ancestry` for the checkout and every relevant component of its resolved source path. A component that is writable by group or others is rejected, except for the narrow root-owned sticky-directory case handled by the existing guard. This check remains fail closed; operators must not add an exception for `/home/alex/repos`, weaken the guard, or change permissions on a foreign parent path merely to make a release pass.
 
 The observed failure mode is intentional: an otherwise clean checkout below `/home/alex/repos/.leitstand-worktrees/...` is rejected when `/home/alex/repos` is group- or other-writable. Git cleanliness does not make that parent chain a trusted release source. Prepare a private host-local source root instead, for example:
 
 ```text
 ~/.local/state/leitstand/deploy-sources/<commit>
 ```
+
+For `deploy`, the adapter may first materialize or reseal the immutable Systemkatalog release described below. The ancestry guarantee begins before the Leitstand release is built and before any unit, selector, daemon or service effect; it does not claim that deployment performs no earlier immutable filesystem preparation.
 
 The source root and its ancestors must be owned and writable only within the boundary accepted by `assert_secure_ancestry`; a mode such as `0700` is appropriate for the user-owned `deploy-sources` directory. Clone or materialize the exact reviewed commit there, verify that `HEAD`, `origin/main` and live remote `main` still agree, and pass that checkout to `--source-repo`. Do not move, chmod, clean or reuse a foreign worktree. The private source path is preparation for a later explicitly authorized deployment; creating it does not itself change units, release selectors or running services.
 

--- a/docs/runbooks/local-release-runtime.md
+++ b/docs/runbooks/local-release-runtime.md
@@ -29,6 +29,18 @@ A build accepts:
 
 Full Git-dependent CI runs first in the exact clean source checkout. The adapter then re-reads live remote `main`, creates the release with `git archive`, and runs frozen installation, release-adapter tests and deterministic builds inside the archive. `SOURCE_DATE_EPOCH` is bound to the source commit timestamp. Uncommitted files cannot enter the release.
 
+### Secure deployment-source ancestry
+
+A clean, commit-exact checkout is necessary but not sufficient. Before build or deploy, `assert_secure_ancestry` verifies the checkout and every relevant component of its resolved source path. A component that is writable by group or others is rejected, except for the narrow root-owned sticky-directory case handled by the existing guard. This check remains fail closed; operators must not add an exception for `/home/alex/repos`, weaken the guard, or change permissions on a foreign parent path merely to make a release pass.
+
+The observed failure mode is intentional: an otherwise clean checkout below `/home/alex/repos/.leitstand-worktrees/...` is rejected when `/home/alex/repos` is group- or other-writable. Git cleanliness does not make that parent chain a trusted release source. Prepare a private host-local source root instead, for example:
+
+```text
+~/.local/state/leitstand/deploy-sources/<commit>
+```
+
+The source root and its ancestors must be owned and writable only within the boundary accepted by `assert_secure_ancestry`; a mode such as `0700` is appropriate for the user-owned `deploy-sources` directory. Clone or materialize the exact reviewed commit there, verify that `HEAD`, `origin/main` and live remote `main` still agree, and pass that checkout to `--source-repo`. Do not move, chmod, clean or reuse a foreign worktree. The private source path is preparation for a later explicitly authorized deployment; creating it does not itself change units, release selectors or running services.
+
 Release directory:
 
 ```text

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "check:vendor-contracts": "node scripts/check-vendored-contracts.mjs",
     "test:browser-shell": "node scripts/browser-shell-regression.mjs",
     "test:browser-views": "node scripts/browser-view-regression.mjs",
-    "test:release-runtime": "python3 -B -m unittest tests/test_release_runtime.py"
+    "test:release-runtime": "python3 -B -m unittest tests/test_release_runtime.py tests/test_runbook_contracts.py"
   },
   "bin": {
     "leitstand": "./dist/cli.js"

--- a/tests/test_runbook_contracts.py
+++ b/tests/test_runbook_contracts.py
@@ -12,7 +12,9 @@ class RunbookContractTests(unittest.TestCase):
         )
         required = (
             "### Secure deployment-source ancestry",
-            "`assert_secure_ancestry` verifies the checkout and every relevant component",
+            "`source_identity` calls `assert_secure_ancestry` for the checkout",
+            "may first materialize or reseal the immutable Systemkatalog release",
+            "before any unit, selector, daemon or service effect",
             "below `/home/alex/repos/.leitstand-worktrees/...` is rejected",
             "~/.local/state/leitstand/deploy-sources/<commit>",
             "Do not move, chmod, clean or reuse a foreign worktree.",

--- a/tests/test_runbook_contracts.py
+++ b/tests/test_runbook_contracts.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class RunbookContractTests(unittest.TestCase):
+    def test_local_release_runbook_documents_secure_source_ancestry(self) -> None:
+        runbook = (ROOT / "docs/runbooks/local-release-runtime.md").read_text(
+            encoding="utf-8"
+        )
+        required = (
+            "### Secure deployment-source ancestry",
+            "`assert_secure_ancestry` verifies the checkout and every relevant component",
+            "below `/home/alex/repos/.leitstand-worktrees/...` is rejected",
+            "~/.local/state/leitstand/deploy-sources/<commit>",
+            "Do not move, chmod, clean or reuse a foreign worktree.",
+            "does not itself change units, release selectors or running services",
+        )
+        for statement in required:
+            with self.subTest(statement=statement):
+                self.assertIn(statement, runbook)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Bureau-Task: LSV-V1-T012

## Änderung
- dokumentiert den fail-closed Vertrag der vollständigen Deploy-Source-Ahnenkette
- hält den beobachteten unsicheren Elternpfad-Fall und den privaten hostlokalen Source-Pfad fest
- bindet die Runbook-Aussage mit einem fokussierten Regressionstest

## Prüfung
- `python3 -m unittest tests.test_runbook_contracts tests.test_release_runtime`
- `git diff --check`

Keine Runtime-Wirkung; `assert_secure_ancestry` und der Releaseadapter bleiben unverändert.