### PR TITLE
feat(ui): consolidate decision axis (LSV-V1-T010)

### DIFF
--- a/scripts/browser-view-matrix.v1.json
+++ b/scripts/browser-view-matrix.v1.json
@@ -38,7 +38,18 @@
       "id": "dashboard",
       "path": "/",
       "activeHref": "/",
-      "heading": "Leitstand"
+      "heading": "Leitstand",
+      "decisionAxis": {
+        "selector": "[data-decision-section]",
+        "labels": [
+          "Jetzt",
+          "Im Fokus",
+          "Blockiert",
+          "Konvergenz",
+          "Danach"
+        ],
+        "minReadableFontPx": 11
+      }
     },
     {
       "id": "repoground",

--- a/scripts/browser-view-regression.mjs
+++ b/scripts/browser-view-regression.mjs
@@ -165,6 +165,21 @@ async function createFixtures(tempRoot) {
   const emptyBureauPath = join(tempRoot, 'bureau-empty.json');
   const corruptCheckoutPath = join(tempRoot, 'checkout-corrupt.json');
   const missingBureauPath = join(tempRoot, 'does-not-exist', 'bureau.json');
+  const decisionAxisPath = join(tempRoot, 'operator-decision-axis.json');
+  const observedAt = new Date().toISOString();
+  await writeJson(decisionAxisPath, {
+    schemaVersion: 1,
+    kind: 'leitstand_operator_decision_axis_snapshot',
+    generatedAt: observedAt,
+    sections: {
+      now: { status: 'available', source: 'bureau.frontier', observedAt, items: [{ id: 'now-1', title: 'Aktuelle revisionsgebundene Aufgabe abschließen', detail: 'Diese längere Beschreibung beweist lesbaren Umbruch ohne horizontales Überlaufen.', meta: 'task: LSV-V1-T010' }] },
+      focus: { status: 'available', source: 'grabowski.current_work', observedAt, items: [{ id: 'focus-1', title: 'Isolierten UI-Slice integrieren', detail: 'Der Leitstand bleibt eine reine Beobachtungsoberfläche.', meta: 'owner: browser-regression' }] },
+      blocked: { status: 'unknown', source: 'bureau.blockers', observedAt, items: [{ id: 'blocked-1', title: 'Keine unbelegte Blockade behaupten', detail: 'Die Testprojektion verändert keine externe Zustandswahrheit.', meta: 'boundary: read-only' }] },
+      convergence: { status: 'available', source: 'grabowski.convergence', observedAt, items: [{ id: 'convergence-1', title: 'Gemeinsame UI-Verträge wiederverwenden', detail: 'Karten, Raster und Typografie stammen aus dem gemeinsamen System.', meta: 'contract: shared-ui' }] },
+      later: { status: 'available', source: 'bureau.queue', observedAt, items: [{ id: 'later-1', title: 'Danach nur belegte Arbeit anzeigen', detail: 'Die semantische Reihenfolge bleibt unverändert.', meta: 'queue: later' }] },
+    },
+    doesNotEstablish: ['task_or_priority_authority', 'queue_truth', 'dispatch_or_mutation_authority'],
+  });
   await writeJson(staleBureauPath, { ...bureau, generatedAt: '2020-01-01T00:00:00Z' });
   await writeJson(emptyBureauPath, { ...bureau, generatedAt: new Date().toISOString(), tasks: [] });
   await writeFile(corruptCheckoutPath, '{not valid json\n', 'utf-8');
@@ -183,6 +198,7 @@ async function createFixtures(tempRoot) {
     sourceFixtures,
     ecosystem,
     repoGroundPath,
+    decisionAxisPath,
     staleBureauPath,
     emptyBureauPath,
     corruptCheckoutPath,
@@ -200,6 +216,7 @@ function baselineEnvironment(fixtures) {
     LEITSTAND_STORAGE_HEALTH_FIXTURE_FALLBACK: '0',
     LEITSTAND_STORAGE_HEALTH_PATH: join(fixtures.sourceFixtures, 'storage-health.json'),
     LEITSTAND_REPOGROUND_BUNDLES_PATH: fixtures.repoGroundPath,
+    LEITSTAND_DECISION_AXIS_SNAPSHOT_PATH: fixtures.decisionAxisPath,
     LEITSTAND_ECOSYSTEM_MAP_MANIFEST_PATH: fixtures.ecosystem.manifestPath,
     LEITSTAND_ECOSYSTEM_MAP_SOURCE_ROOT: fixtures.ecosystem.root,
     LEITSTAND_ECOSYSTEM_MAP_CURRENT_HEAD_PATH: fixtures.ecosystem.currentHeadPath,
@@ -323,6 +340,52 @@ async function checkMobileNavigation(page) {
   assert(await page.evaluate(() => document.activeElement === document.querySelector('[data-leitstand-nav-toggle]')), 'Escape did not restore navigation focus');
 }
 
+async function checkDecisionAxis(page, contract, viewport) {
+  const result = await page.evaluate(({ selector, labels }) => {
+    const axis = document.querySelector('[aria-labelledby="decision-axis-heading"]');
+    const grid = axis?.querySelector('[data-decision-axis-grid]');
+    const cards = [...(axis?.querySelectorAll(selector) || [])];
+    const cardMetrics = cards.map((card) => {
+      const rect = card.getBoundingClientRect();
+      const title = card.querySelector('.ui-item-title');
+      const source = card.querySelector('.ui-card__source');
+      return {
+        id: card.getAttribute('data-decision-section'),
+        label: card.querySelector('h3')?.textContent?.trim() || '',
+        left: rect.left,
+        right: rect.right,
+        width: rect.width,
+        scrollWidth: card.scrollWidth,
+        clientWidth: card.clientWidth,
+        title: title?.textContent?.trim() || '',
+        titleFontPx: title ? Number.parseFloat(getComputedStyle(title).fontSize) : 0,
+        sourceFontPx: source ? Number.parseFloat(getComputedStyle(source).fontSize) : 0,
+        sharedCard: card.classList.contains('card') && card.classList.contains('ui-card'),
+        statusClass: [...card.classList].some((name) => name.startsWith('ui-card--status-')),
+      };
+    });
+    const uniqueColumns = new Set(cardMetrics.map((card) => Math.round(card.left))).size;
+    return {
+      axisVisible: Boolean(axis && axis.getBoundingClientRect().height > 0),
+      sharedGrid: Boolean(grid?.classList.contains('ui-card-grid')),
+      labelsMatch: JSON.stringify(cardMetrics.map((card) => card.label)) === JSON.stringify(labels),
+      cardMetrics,
+      uniqueColumns,
+      innerWidth: window.innerWidth,
+    };
+  }, contract);
+
+  assert(result.axisVisible, `decision axis is not visible for ${viewport.id}`);
+  assert(result.sharedGrid && result.cardMetrics.every((card) => card.sharedCard && card.statusClass), `decision axis bypasses shared UI contracts for ${viewport.id}`);
+  assert(result.labelsMatch, `decision axis semantics changed for ${viewport.id}`, result.cardMetrics.map((card) => card.label).join(','));
+  assert(result.cardMetrics.length === contract.labels.length, `decision axis card count changed for ${viewport.id}`, result.cardMetrics.length);
+  assert(result.cardMetrics.every((card) => card.left >= -1 && card.right <= result.innerWidth + 1 && card.scrollWidth <= card.clientWidth + 1), `decision axis overflow for ${viewport.id}`, JSON.stringify(result.cardMetrics));
+  assert(result.cardMetrics.every((card) => card.title.length > 0 && card.titleFontPx >= contract.minReadableFontPx && card.sourceFontPx >= contract.minReadableFontPx), `decision axis copy is not readable for ${viewport.id}`, JSON.stringify(result.cardMetrics));
+  if (viewport.id === 'mobile') assert(result.uniqueColumns === 1, 'decision axis mobile layout is not single-column', result.uniqueColumns);
+  else assert(result.uniqueColumns >= 2, 'decision axis desktop layout did not use available width', result.uniqueColumns);
+  return 7;
+}
+
 async function runView(browser, origin, viewport, view, baseline) {
   applyEnvironment(baseline);
   const context = await browser.newContext({
@@ -349,13 +412,14 @@ async function runView(browser, origin, viewport, view, baseline) {
     assert(layout.injectedHarnessStyles === 0, `test harness style detected for ${view.id}`);
     assert(await checkSkipLink(page), `skip link did not focus main for ${view.id}`);
     if (viewport.id === 'mobile' && view.id === 'dashboard') await checkMobileNavigation(page);
+    const decisionAxisChecks = view.decisionAxis ? await checkDecisionAxis(page, view.decisionAxis, viewport) : 0;
     assert(diagnostics.diagnostics.length === 0, `browser diagnostics failed for ${view.id}/${viewport.id}`, diagnostics.diagnostics.join(' | '));
     return {
       viewport: viewport.id,
       view: view.id,
       path: view.path,
       assetPaths: [...diagnostics.assets.keys()].sort(),
-      checks: 11 + (viewport.id === 'mobile' && view.id === 'dashboard' ? 3 : 0),
+      checks: 11 + (viewport.id === 'mobile' && view.id === 'dashboard' ? 3 : 0) + decisionAxisChecks,
     };
   } finally {
     await context.close();

--- a/scripts/browser-view-regression.mjs
+++ b/scripts/browser-view-regression.mjs
@@ -362,6 +362,7 @@ async function checkDecisionAxis(page, contract, viewport) {
         titleFontPx: title ? Number.parseFloat(getComputedStyle(title).fontSize) : 0,
         sourceFontPx: source ? Number.parseFloat(getComputedStyle(source).fontSize) : 0,
         minimumCopyFontPx: copy.length > 0 ? Math.min(...copy.map((element) => Number.parseFloat(getComputedStyle(element).fontSize))) : 0,
+        borderLeftWidthPx: Number.parseFloat(getComputedStyle(card).borderLeftWidth),
         sharedCard: card.classList.contains('card') && card.classList.contains('ui-card'),
         statusClass: [...card.classList].some((name) => name.startsWith('ui-card--status-')),
       };
@@ -378,7 +379,7 @@ async function checkDecisionAxis(page, contract, viewport) {
   }, contract);
 
   assert(result.axisVisible, `decision axis is not visible for ${viewport.id}`);
-  assert(result.sharedGrid && result.cardMetrics.every((card) => card.sharedCard && card.statusClass), `decision axis bypasses shared UI contracts for ${viewport.id}`);
+  assert(result.sharedGrid && result.cardMetrics.every((card) => card.sharedCard && card.statusClass && card.borderLeftWidthPx === 3), `decision axis bypasses shared UI status contracts for ${viewport.id}`, JSON.stringify(result.cardMetrics));
   assert(result.labelsMatch, `decision axis semantics changed for ${viewport.id}`, result.cardMetrics.map((card) => card.label).join(','));
   assert(result.cardMetrics.length === contract.labels.length, `decision axis card count changed for ${viewport.id}`, result.cardMetrics.length);
   assert(result.cardMetrics.every((card) => card.left >= -1 && card.right <= result.innerWidth + 1 && card.scrollWidth <= card.clientWidth + 1), `decision axis overflow for ${viewport.id}`, JSON.stringify(result.cardMetrics));

--- a/scripts/browser-view-regression.mjs
+++ b/scripts/browser-view-regression.mjs
@@ -349,6 +349,7 @@ async function checkDecisionAxis(page, contract, viewport) {
       const rect = card.getBoundingClientRect();
       const title = card.querySelector('.ui-item-title');
       const source = card.querySelector('.ui-card__source');
+      const copy = [...card.querySelectorAll('.ui-card__source, .ui-item-title, .ui-item-detail, .ui-item-meta')];
       return {
         id: card.getAttribute('data-decision-section'),
         label: card.querySelector('h3')?.textContent?.trim() || '',
@@ -360,6 +361,7 @@ async function checkDecisionAxis(page, contract, viewport) {
         title: title?.textContent?.trim() || '',
         titleFontPx: title ? Number.parseFloat(getComputedStyle(title).fontSize) : 0,
         sourceFontPx: source ? Number.parseFloat(getComputedStyle(source).fontSize) : 0,
+        minimumCopyFontPx: copy.length > 0 ? Math.min(...copy.map((element) => Number.parseFloat(getComputedStyle(element).fontSize))) : 0,
         sharedCard: card.classList.contains('card') && card.classList.contains('ui-card'),
         statusClass: [...card.classList].some((name) => name.startsWith('ui-card--status-')),
       };
@@ -380,7 +382,7 @@ async function checkDecisionAxis(page, contract, viewport) {
   assert(result.labelsMatch, `decision axis semantics changed for ${viewport.id}`, result.cardMetrics.map((card) => card.label).join(','));
   assert(result.cardMetrics.length === contract.labels.length, `decision axis card count changed for ${viewport.id}`, result.cardMetrics.length);
   assert(result.cardMetrics.every((card) => card.left >= -1 && card.right <= result.innerWidth + 1 && card.scrollWidth <= card.clientWidth + 1), `decision axis overflow for ${viewport.id}`, JSON.stringify(result.cardMetrics));
-  assert(result.cardMetrics.every((card) => card.title.length > 0 && card.titleFontPx >= contract.minReadableFontPx && card.sourceFontPx >= contract.minReadableFontPx), `decision axis copy is not readable for ${viewport.id}`, JSON.stringify(result.cardMetrics));
+  assert(result.cardMetrics.every((card) => card.title.length > 0 && card.titleFontPx >= contract.minReadableFontPx && card.sourceFontPx >= contract.minReadableFontPx && card.minimumCopyFontPx >= contract.minReadableFontPx), `decision axis copy is not readable for ${viewport.id}`, JSON.stringify(result.cardMetrics));
   if (viewport.id === 'mobile') assert(result.uniqueColumns === 1, 'decision axis mobile layout is not single-column', result.uniqueColumns);
   else assert(result.uniqueColumns >= 2, 'decision axis desktop layout did not use available width', result.uniqueColumns);
   return 7;

--- a/src/public/ui-system.css
+++ b/src/public/ui-system.css
@@ -186,7 +186,7 @@ h1 {
 .ui-item-meta {
   margin-top: 4px;
   color: var(--ui-text-muted);
-  font-size: 0.68em;
+  font-size: 0.7em;
   overflow-wrap: anywhere;
 }
 

--- a/src/public/ui-system.css
+++ b/src/public/ui-system.css
@@ -113,6 +113,88 @@ h1 {
   text-transform: uppercase;
 }
 
+.ui-section {
+  margin-bottom: 32px;
+}
+
+.ui-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 220px), 1fr));
+  gap: 12px;
+}
+
+.ui-card {
+  min-width: 0;
+  margin: 0;
+  padding: 16px;
+}
+
+.ui-card--status-unavailable {
+  border-left: 3px solid var(--ui-fail);
+}
+
+.ui-card--status-unknown {
+  border-left: 3px solid var(--ui-warn);
+}
+
+.ui-card--status-available {
+  border-left: 3px solid var(--ui-ok);
+}
+
+.ui-card__title {
+  margin: 0 0 8px;
+  font-size: 0.95em;
+}
+
+.ui-card__source {
+  margin-bottom: 10px;
+  overflow-wrap: anywhere;
+}
+
+.ui-list {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.ui-list--divided > li {
+  min-width: 0;
+  padding-top: 8px;
+  border-top: 1px solid var(--ui-border);
+}
+
+.ui-list--divided > li:first-child {
+  padding-top: 0;
+  border-top: 0;
+}
+
+.ui-item-title {
+  font-size: 0.82em;
+  font-weight: 650;
+  overflow-wrap: anywhere;
+}
+
+.ui-item-detail {
+  color: var(--ui-text-secondary);
+  font-size: 0.74em;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.ui-item-meta {
+  margin-top: 4px;
+  color: var(--ui-text-muted);
+  font-size: 0.68em;
+  overflow-wrap: anywhere;
+}
+
+.ui-empty {
+  color: var(--ui-text-muted);
+  font-size: 0.78em;
+}
+
 .notice,
 .card,
 .panel,

--- a/src/public/ui-system.css
+++ b/src/public/ui-system.css
@@ -129,15 +129,15 @@ h1 {
   padding: 16px;
 }
 
-.ui-card--status-unavailable {
+.card.ui-card--status-unavailable {
   border-left: 3px solid var(--ui-fail);
 }
 
-.ui-card--status-unknown {
+.card.ui-card--status-unknown {
   border-left: 3px solid var(--ui-warn);
 }
 
-.ui-card--status-available {
+.card.ui-card--status-available {
   border-left: 3px solid var(--ui-ok);
 }
 

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -132,22 +132,6 @@
     }
 
 
-    .decision-axis { margin-bottom: 32px; }
-    .decision-axis-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; }
-    .decision-card { padding: 16px; border: 1px solid var(--border-glass); border-radius: 12px; background: var(--bg-card); }
-    .decision-card h3 { margin: 0 0 8px; font-size: 0.95em; }
-    .decision-source { color: var(--text-muted); font-size: 0.7em; line-height: 1.4; margin-bottom: 10px; }
-    .decision-list { display: grid; gap: 8px; list-style: none; padding: 0; margin: 0; }
-    .decision-item { padding-top: 8px; border-top: 1px solid var(--border-glass); }
-    .decision-item:first-child { border-top: 0; padding-top: 0; }
-    .decision-title { font-size: 0.82em; font-weight: 650; }
-    .decision-detail { color: var(--text-secondary); font-size: 0.74em; line-height: 1.4; }
-    .decision-meta { color: var(--text-muted); font-size: 0.68em; margin-top: 4px; }
-    .decision-empty { color: var(--text-muted); font-size: 0.78em; }
-    .decision-status-unavailable { border-left: 3px solid var(--fail); }
-    .decision-status-unknown { border-left: 3px solid var(--warn); }
-    .decision-status-available { border-left: 3px solid var(--ok); }
-
     .source-grid {
       display: grid;
       grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
@@ -357,26 +341,26 @@
     <% } %>
 
 
-    <section class="decision-axis" aria-labelledby="decision-axis-heading">
+    <section class="ui-section" aria-labelledby="decision-axis-heading">
       <h2 id="decision-axis-heading" class="section-title ui-section-title">Entscheidungsachse</h2>
       <p class="projection-note">Read-only-Projektion vorhandener Bureau- und Grabowski-Wahrheiten. Keine lokale Prioritäts-, Queue-, Fokus- oder Konvergenzwahrheit.</p>
-      <div class="decision-axis-grid">
+      <div class="ui-card-grid" data-decision-axis-grid>
         <% decisionSections.forEach(function(section) { %>
-          <article class="decision-card decision-status-<%= section.status %>" data-decision-section="<%= section.id %>">
-            <h3><%= section.label %></h3>
-            <p class="decision-source">Quelle: <%= section.source %> · <%= section.freshness_state === 'fresh' ? 'frisch' : section.freshness_state === 'stale' ? 'veraltet' : 'Frische unbekannt' %></p>
+          <article class="card ui-card ui-card--status-<%= section.status %>" data-decision-section="<%= section.id %>">
+            <h3 class="ui-card__title"><%= section.label %></h3>
+            <p class="ui-caption ui-card__source">Quelle: <%= section.source %> · <%= section.freshness_state === 'fresh' ? 'frisch' : section.freshness_state === 'stale' ? 'veraltet' : 'Frische unbekannt' %></p>
             <% if (section.items.length > 0) { %>
-              <ol class="decision-list">
+              <ol class="ui-list ui-list--divided">
                 <% section.items.forEach(function(item) { %>
-                  <li class="decision-item">
-                    <div class="decision-title"><%= item.title %></div>
-                    <% if (item.detail) { %><div class="decision-detail"><%= item.detail %></div><% } %>
-                    <% if (item.meta) { %><div class="decision-meta"><%= item.meta %></div><% } %>
+                  <li>
+                    <div class="ui-item-title"><%= item.title %></div>
+                    <% if (item.detail) { %><div class="ui-item-detail"><%= item.detail %></div><% } %>
+                    <% if (item.meta) { %><div class="ui-item-meta"><%= item.meta %></div><% } %>
                   </li>
                 <% }); %>
               </ol>
             <% } else { %>
-              <p class="decision-empty"><%= section.freshness_state === 'stale'
+              <p class="ui-empty"><%= section.freshness_state === 'stale'
                 ? 'Quelle veraltet; keine Priorität wird angezeigt.'
                 : section.freshness_state === 'unknown'
                   ? 'Frische nicht belegt; keine Priorität wird angezeigt.'

--- a/tests/browserViewMatrix.test.ts
+++ b/tests/browserViewMatrix.test.ts
@@ -19,6 +19,11 @@ interface BrowserViewMatrix {
     activeHref: string;
     heading: string;
     modal?: boolean;
+    decisionAxis?: {
+      selector: string;
+      labels: string[];
+      minReadableFontPx: number;
+    };
   }>;
   scenarios: Array<{
     id: string;
@@ -90,6 +95,11 @@ describe('LSV-V1-T009 browser view matrix', () => {
       expect(view.heading.length).toBeGreaterThan(2);
     }
     expect(matrix.views.find((view) => view.id === 'ecosystem-map')?.modal).toBe(true);
+    expect(matrix.views.find((view) => view.id === 'dashboard')?.decisionAxis).toEqual({
+      selector: '[data-decision-section]',
+      labels: ['Jetzt', 'Im Fokus', 'Blockiert', 'Konvergenz', 'Danach'],
+      minReadableFontPx: 11,
+    });
   });
 
   it('covers valid, degraded, empty and reduced-motion states without claiming live incidents', async () => {


### PR DESCRIPTION
## Bureau-Bindung

Bureau-Task: `LSV-V1-T010`

## Änderung

- konsolidiert die Entscheidungsachse in gemeinsame Karten-, Raster- und Typografie-Verträge
- entfernt die seitenlokalen Entscheidungsachsen-Stile
- erhält Reihenfolge und Bedeutung von Jetzt, Im Fokus, Blockiert, Konvergenz und Danach
- erweitert die gebaute Browserprüfung um lange Texte, Überlauf-, Lesbarkeits- und Spaltenprüfungen für 390×844 und 1440×900
- verändert keine Quellen-, Prioritäts-, Dispatch- oder Mutationsautorität

## Validierung

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` — 42 Dateien, 267 Tests
- `pnpm build`
- `pnpm test:browser-views`
- `pnpm test:browser-shell` — mobil 23/23, Desktop 13/13
- `pnpm test:release-runtime` — 40 Tests
- `git diff --check origin/main...HEAD`

## Review

Ein methodisch getrennter, headgebundener Self-Review folgt nach dem GitHub-Readback. Unabhängigkeit wird nicht behauptet.