### PR TITLE
fix(health): classify snapshot read failures structurally

### DIFF
--- a/src/runtimeHealth.ts
+++ b/src/runtimeHealth.ts
@@ -240,9 +240,13 @@ async function readSnapshotHealth(
       record_count: recordCount,
     };
   } catch (error) {
-    const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
-    const missing = message.includes('enoent') || message.includes('no such file');
-    const invalidJson = message.includes('json') || message.includes('unexpected');
+    // Classify structurally, not by message text: every snapshot path ends in
+    // `.json` and Node embeds that path in errno messages, so substring matching
+    // reported EACCES/ELOOP/ENOTDIR as corrupt JSON and made `snapshot_unreadable`
+    // unreachable. An operator reading the receipt must be able to tell a broken
+    // file from a broken mount or permission.
+    const missing = (error as NodeJS.ErrnoException | null)?.code === 'ENOENT';
+    const invalidJson = error instanceof SyntaxError;
     let mtime: string | null = null;
     if (!missing) {
       try {

--- a/tests/runtimeHealth.test.ts
+++ b/tests/runtimeHealth.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { getRuntimeHealthData } from '../src/runtimeHealth.js';
@@ -266,5 +266,35 @@ describe('runtime health receipt', () => {
     expect(receipt.status).toBe('fail');
     expect(receipt.snapshots.bureau_tasks.status).toBe('fail');
     expect(receipt.snapshots.bureau_tasks.reason).toBe('snapshot_missing');
+  });
+
+  it('reports corrupt snapshot content as invalid JSON', async () => {
+    await writeSnapshots('2026-07-08T17:55:00.000Z');
+    await writeFile(join(artifactsDir, 'bureau-tasks.json'), '{"tasks": [', 'utf-8');
+
+    const receipt = await getRuntimeHealthData({ cwd: testDir, now, ecosystemMapSourceRoot: join(testDir, 'a'.repeat(40)) });
+
+    expect(receipt.status).toBe('fail');
+    expect(receipt.snapshots.bureau_tasks.status).toBe('fail');
+    expect(receipt.snapshots.bureau_tasks.reason).toBe('snapshot_json_invalid');
+    expect(receipt.snapshots.bureau_tasks.exists).toBe(true);
+  });
+
+  it('separates an unreadable snapshot path from corrupt snapshot content', async () => {
+    // A symlink loop fails in `stat` with ELOOP before any byte is read, so the
+    // receipt must not blame the file's JSON. The errno message embeds the
+    // `.json` path, which is exactly what message-substring classification
+    // mistook for corruption.
+    await writeSnapshots('2026-07-08T17:55:00.000Z');
+    const loopingPath = join(artifactsDir, 'bureau-tasks.json');
+    await rm(loopingPath);
+    await symlink(loopingPath, loopingPath);
+
+    const receipt = await getRuntimeHealthData({ cwd: testDir, now, ecosystemMapSourceRoot: join(testDir, 'a'.repeat(40)) });
+
+    expect(receipt.status).toBe('fail');
+    expect(receipt.snapshots.bureau_tasks.status).toBe('fail');
+    expect(receipt.snapshots.bureau_tasks.reason).toBe('snapshot_unreadable');
+    expect(receipt.snapshots.bureau_tasks.age_seconds).toBeNull();
   });
 });


### PR DESCRIPTION
## Problem

`readSnapshotHealth` in `src/runtimeHealth.ts` classified snapshot read failures by substring-matching the lowercased error message:

```ts
const missing = message.includes('enoent') || message.includes('no such file');
const invalidJson = message.includes('json') || message.includes('unexpected');
```

Every snapshot path ends in `.json`, and Node embeds the offending path in errno messages for path-carrying errors. So *any* non-ENOENT filesystem error on a snapshot path matched the `json` probe:

```
ELOOP: too many symbolic links encountered, stat '/…/artifacts/bureau-tasks.json'
  → missing? false   invalidJson? true   → reason: snapshot_json_invalid
```

Two consequences on the `/health` operator receipt:

- **`snapshot_unreadable` was unreachable in practice.** EACCES, ELOOP, and ENOTDIR all reported as `snapshot_json_invalid`.
- **The receipt misdirected operators.** A permission or mount fault told them to go inspect file contents. `/health` is the in-process proof surface a release is validated against, so a wrong reason costs real debugging time.

## Solution

Classify structurally instead of by message text:

```ts
const missing = (error as NodeJS.ErrnoException | null)?.code === 'ENOENT';
const invalidJson = error instanceof SyntaxError;
```

`stat`/`readFile` failures carry an errno `code`; only `JSON.parse` throws `SyntaxError`. The three reason strings, `status: 'fail'`, and every other receipt field are unchanged — only *which* reason fires for a given failure changes.

## Evidence

Two tests added to `tests/runtimeHealth.test.ts`, covering branches that previously had no assertions at all (only `snapshot_missing` was tested):

- `reports corrupt snapshot content as invalid JSON` — genuine `JSON.parse` failure still yields `snapshot_json_invalid`.
- `separates an unreadable snapshot path from corrupt snapshot content` — a symlink loop (ELOOP in `stat`, before any byte is read) yields `snapshot_unreadable`.

The regression test fails against the pre-fix code with exactly the reported misclassification:

```
AssertionError: expected 'snapshot_json_invalid' to be 'snapshot_unreadable'
Tests  1 failed | 9 passed (10)
```

Full required-check suite from `AGENTS.md`, all green locally:

| Check | Result |
| --- | --- |
| `pnpm lint` | pass |
| `pnpm typecheck` | pass |
| `pnpm test:release-runtime` | 41 tests, OK |
| `pnpm test` | 42 files, 269 tests passed |
| `pnpm build` / `pnpm build:static` | pass |
| `pnpm test:browser-shell` | mobile 23/23, desktop 13/13 |
| `pnpm test:browser-views` | exit 0 |
| `check:vendor-contracts` + all 5 CI guards | pass |

## Limits

- A symlink loop is a stand-in for the whole non-ENOENT errno class; it was chosen over EACCES because it reproduces deterministically regardless of the running user. EACCES and ENOTDIR take the same corrected branch but are not separately asserted.
- Scope is the classification only. Adjacent observations left untouched: `exists` is still `!missing`, so an unresolvable symlink reports `exists: true`; and `snapshots[].path` still emits an absolute filesystem path alongside the sanitized `path_display`.
- No change to overall receipt `status`, the `/health` 503 threshold, or any reason string's spelling — so no deployment gate behavior shifts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)