### PR TITLE
feat(decision-axis): project parallel now corridor (LSV-V1-T013)

### DIFF
--- a/docs/blueprints/operator-decision-axis.md
+++ b/docs/blueprints/operator-decision-axis.md
@@ -12,17 +12,17 @@ summary: >
 
 # Operator Decision Axis v1
 
-Task: `OPERATOR-MACHINE-READABILITY-V1-T024`
+Basis: `OPERATOR-MACHINE-READABILITY-V1-T024`; paralleler Jetzt-Korridor: `LSV-V1-T013`
 
 ## Ziel
 
 Der Leitstand zeigt eine read-only Entscheidungsprojektion für fünf Fragen:
 
-- **Jetzt** – der erste aktuell von Bureaus bestehender Statusprojektion aus der kanonischen Registry-Queue vorgeschlagene Task;
+- **Jetzt** – Bureaus globaler Spitzenkandidat plus höchstens ein bereits aktiver oder konfliktfrei claimbarer aktueller Repository-Ball je Ausführungsdomäne;
 - **Im Fokus** – der jüngste aktive Thread-Fokus aus dem Bureau Live Register;
 - **Blockiert** – explizite `blocked_reasons` beziehungsweise ein belegter blockierter Zustand aus Bureaus Statusprojektion;
 - **Konvergenz** – die bestehende Grabowski-`current_work`-Konvergenzprojektion;
-- **Danach** – weitere von Bureaus bestehender Statusprojektion aus der kanonischen Registry-Queue vorgeschlagene Tasks.
+- **Danach** – weitere kanonische Kandidaten außerhalb der `now`-Lane; nicht ausgewählte `now`-Tasks werden nicht fälschlich als spätere Arbeit bezeichnet.
 
 Die Achse ist ausschließlich eine Projektion. Sie erzeugt keine Task-, Queue-, Prioritäts-, Fokus-, Blocking-, Runtime- oder Konvergenzwahrheit.
 
@@ -30,7 +30,7 @@ Die Achse ist ausschließlich eine Projektion. Sie erzeugt keine Task-, Queue-, 
 
 | Abschnitt | Primär-/Projektionsquelle | Leitstand darf nicht |
 | --- | --- | --- |
-| Jetzt | Bureau `status-projection`, Quelle `registry-queue` | Task priorisieren, claimen oder dispatchen |
+| Jetzt | Bureau `status-projection`, `repository_balls` und Quelle `registry-queue` | Task priorisieren, claimen oder dispatchen |
 | Im Fokus | Bureau Live Register, jüngster aktiver Thread-Fokus | Fokus schreiben, schließen oder als Queue-Wahrheit behandeln |
 | Blockiert | Bureau `status-projection` | Blocker erfinden oder selbst auflösen |
 | Konvergenz | Grabowski `current_work` | Lifecycle-Zustand, Leases oder Prozesse mutieren |
@@ -42,7 +42,7 @@ Bureau bleibt Aufgaben- und Prioritätsautorität. Grabowski bleibt Ausführungs
 
 1. `scripts/leitstand-export-operator-snapshots` läuft producer-seitig außerhalb des HTTP-Request-Pfads.
 2. Der Producer bindet Bureau-Registry-Daten weiterhin an das digest-validierte kanonische Runtime-Snapshot.
-3. Der Producer liest Bureaus bestehende read-only Projektionen `status-projection` und `live-list`.
+3. Der Producer liest Bureaus bestehende read-only Projektionen `status-projection` einschließlich `repository_balls` und `live-list`.
 4. Der Producer liest Grabowskis bestehende `current_work`-Projektion für Konvergenzevidenz.
 5. `scripts/export-operator-snapshots.mjs` begrenzt die Abschnitte und schreibt atomar `artifacts/operator-decision-axis.json` mit Contract-Kind `leitstand_operator_decision_axis_snapshot`.
 6. `src/controllers/decisionAxis.ts` liest ausschließlich dieses Artefakt. Es gibt keinen request-time Aufruf von Bureau oder Grabowski.
@@ -54,7 +54,7 @@ Fehlt eine Producer-Quelle, wird der betroffene Abschnitt als `unavailable` mit 
 
 ## Bounds und Nicht-Ansprüche
 
-Jeder Abschnitt ist auf höchstens acht Items begrenzt. Das Snapshot nennt explizit unter anderem folgende Nicht-Ansprüche:
+Der Abschnitt `Jetzt` ist auf höchstens sechs Einträge begrenzt: zuerst der globale Spitzenkandidat, danach deterministisch deduplizierte aktive Repository-Bälle und schließlich konfliktfrei claimbare aktuelle `now`-Bälle. Ein Task, der mehreren Repository-Bällen zugeordnet ist, belegt alle diese Domänen. Unbekannte Domänen werden nicht als parallel sicher interpretiert. Die übrigen Abschnitte bleiben auf höchstens acht Items begrenzt. Das Snapshot nennt explizit unter anderem folgende Nicht-Ansprüche:
 
 - keine Task- oder Prioritätsautorität;
 - keine Queue-Wahrheit;
@@ -69,4 +69,5 @@ Verifiziert durch:
 - `tests/controllers/decisionAxis.test.ts` – vollständige fünf Abschnitte, stale/missing, keine erfundenen Werte;
 - `tests/exportDecisionAxis.test.ts` – bounded Snapshot und Nicht-Ansprüche;
 - `tests/operatorSnapshotWrapper.test.ts` – kanonisch digest-gebundene Bureau-Quelle;
+- `tests/test_decision_axis_selection.py` – globaler Spitzenkandidat, aktive und claimbare Domänen, Mehrrepo-Deduplikation, Bounds und Ausschluss von `now` aus `Danach`;
 - `tests/controllers/dashboardAuthority.test.ts` und Repository-CI – bestehende Observer-Grenzen bleiben erhalten.

--- a/docs/runbooks/local-release-runtime.md
+++ b/docs/runbooks/local-release-runtime.md
@@ -50,7 +50,7 @@ Release directory:
 ```
 
 Every release manifest binds source commit, source tree, origin URL, validation commands, release-tree digest and critical artifact digests.
-The critical-artifact set includes the versioned operator-snapshot launcher `scripts/leitstand-export-operator-snapshots`; its exact bytes are therefore sealed and digest-bound with the release before the host-local installed copy may be updated. The launcher resolves the format bridge from that same immutable release rather than from a mutable checkout.
+The critical-artifact set includes the versioned operator-snapshot launcher `scripts/leitstand-export-operator-snapshots` and its decision-axis selector `scripts/decision_axis_selection.py`; their exact bytes are therefore sealed and digest-bound with the release before the host-local installed copy may be updated. The launcher resolves both the format bridge and the selector from that same immutable release rather than from a mutable checkout. A missing or unloadable selector fails the producer before it can publish a decision-axis snapshot.
 
 ## Runtime configuration
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "check:vendor-contracts": "node scripts/check-vendored-contracts.mjs",
     "test:browser-shell": "node scripts/browser-shell-regression.mjs",
     "test:browser-views": "node scripts/browser-view-regression.mjs",
-    "test:release-runtime": "python3 -B -m unittest tests/test_release_runtime.py tests/test_runbook_contracts.py"
+    "test:release-runtime": "python3 -B -m unittest tests/test_release_runtime.py tests/test_runbook_contracts.py tests/test_decision_axis_selection.py"
   },
   "bin": {
     "leitstand": "./dist/cli.js"

--- a/scripts/browser-view-matrix.v1.json
+++ b/scripts/browser-view-matrix.v1.json
@@ -48,7 +48,8 @@
           "Konvergenz",
           "Danach"
         ],
-        "minReadableFontPx": 11
+        "minReadableFontPx": 11,
+        "minimumNowItems": 4
       }
     },
     {

--- a/scripts/browser-view-regression.mjs
+++ b/scripts/browser-view-regression.mjs
@@ -172,7 +172,12 @@ async function createFixtures(tempRoot) {
     kind: 'leitstand_operator_decision_axis_snapshot',
     generatedAt: observedAt,
     sections: {
-      now: { status: 'available', source: 'bureau.frontier', observedAt, items: [{ id: 'now-1', title: 'Aktuelle revisionsgebundene Aufgabe abschließen', detail: 'Diese längere Beschreibung beweist lesbaren Umbruch ohne horizontales Überlaufen.', meta: 'task: LSV-V1-T010' }] },
+      now: { status: 'available', source: 'bureau.status-projection / repository_balls', observedAt, items: [
+        { id: 'now-global', title: 'Audio-Systemwahrheit sicher abschließen', detail: 'Globale Bureau-Spitzenpriorität mit lesbarem Umbruch ohne horizontales Überlaufen.', meta: 'global first · already active · repo.audio' },
+        { id: 'now-bureau', title: 'Bureau-Registrierung revisionsgebunden fortführen', detail: 'Bereits aktiver Repository-Ball ohne neue Claim-Entscheidung.', meta: 'already active · repo.bureau' },
+        { id: 'now-grabowski', title: 'Grabowski-Konvergenzarbeit abschließen', detail: 'Zweite aktive, nicht überlappende Ausführungsdomäne.', meta: 'already active · repo.grabowski' },
+        { id: 'now-repoground', title: 'RepoGround-Kernkomplexität reduzieren', detail: 'Konfliktfrei claimbarer aktueller Repository-Ball.', meta: 'parallel claimable · repo.repoground' },
+      ] },
       focus: { status: 'available', source: 'grabowski.current_work', observedAt, items: [{ id: 'focus-1', title: 'Isolierten UI-Slice integrieren', detail: 'Der Leitstand bleibt eine reine Beobachtungsoberfläche.', meta: 'owner: browser-regression' }] },
       blocked: { status: 'unknown', source: 'bureau.blockers', observedAt, items: [{ id: 'blocked-1', title: 'Keine unbelegte Blockade behaupten', detail: 'Die Testprojektion verändert keine externe Zustandswahrheit.', meta: 'boundary: read-only' }] },
       convergence: { status: 'available', source: 'grabowski.convergence', observedAt, items: [{ id: 'convergence-1', title: 'Gemeinsame UI-Verträge wiederverwenden', detail: 'Karten, Raster und Typografie stammen aus dem gemeinsamen System.', meta: 'contract: shared-ui' }] },
@@ -352,6 +357,7 @@ async function checkDecisionAxis(page, contract, viewport) {
       const copy = [...card.querySelectorAll('.ui-card__source, .ui-item-title, .ui-item-detail, .ui-item-meta')];
       return {
         id: card.getAttribute('data-decision-section'),
+        itemCount: card.querySelectorAll('.ui-list > li').length,
         label: card.querySelector('h3')?.textContent?.trim() || '',
         left: rect.left,
         right: rect.right,
@@ -384,9 +390,11 @@ async function checkDecisionAxis(page, contract, viewport) {
   assert(result.cardMetrics.length === contract.labels.length, `decision axis card count changed for ${viewport.id}`, result.cardMetrics.length);
   assert(result.cardMetrics.every((card) => card.left >= -1 && card.right <= result.innerWidth + 1 && card.scrollWidth <= card.clientWidth + 1), `decision axis overflow for ${viewport.id}`, JSON.stringify(result.cardMetrics));
   assert(result.cardMetrics.every((card) => card.title.length > 0 && card.titleFontPx >= contract.minReadableFontPx && card.sourceFontPx >= contract.minReadableFontPx && card.minimumCopyFontPx >= contract.minReadableFontPx), `decision axis copy is not readable for ${viewport.id}`, JSON.stringify(result.cardMetrics));
+  const nowCard = result.cardMetrics.find((card) => card.id === 'now');
+  assert(nowCard?.itemCount >= contract.minimumNowItems, `decision axis does not render the bounded parallel Now corridor for ${viewport.id}`, JSON.stringify(nowCard));
   if (viewport.id === 'mobile') assert(result.uniqueColumns === 1, 'decision axis mobile layout is not single-column', result.uniqueColumns);
   else assert(result.uniqueColumns >= 2, 'decision axis desktop layout did not use available width', result.uniqueColumns);
-  return 7;
+  return 8;
 }
 
 async function runView(browser, origin, viewport, view, baseline) {

--- a/scripts/decision_axis_selection.py
+++ b/scripts/decision_axis_selection.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+UNKNOWN = "unknown"
+
+
+def _text(value: object) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _repository_balls(
+    status_projection: Mapping[str, object],
+) -> dict[str, Mapping[str, object]]:
+    raw = status_projection.get("repository_balls")
+    if not isinstance(raw, Mapping):
+        return {}
+    return {
+        str(domain): ball
+        for domain, ball in raw.items()
+        if isinstance(domain, str) and isinstance(ball, Mapping)
+    }
+
+
+def _task_domains(
+    balls: Mapping[str, Mapping[str, object]],
+) -> dict[str, tuple[str, ...]]:
+    domains_by_task: dict[str, set[str]] = {}
+    for domain, ball in balls.items():
+        task_ids = ball.get("task_ids")
+        if not isinstance(task_ids, list):
+            continue
+        for raw_task_id in task_ids:
+            task_id = _text(raw_task_id)
+            if task_id:
+                domains_by_task.setdefault(task_id, set()).add(domain)
+    return {
+        task_id: tuple(sorted(domains))
+        for task_id, domains in domains_by_task.items()
+    }
+
+
+def _current_balls(
+    balls: Mapping[str, Mapping[str, object]],
+) -> dict[str, dict[str, object]]:
+    current_by_task: dict[str, dict[str, object]] = {}
+    for domain, ball in balls.items():
+        current = ball.get("current_ball")
+        if not isinstance(current, Mapping):
+            continue
+        task_id = _text(current.get("task_id"))
+        if not task_id:
+            continue
+        entry = current_by_task.setdefault(
+            task_id,
+            {
+                "domains": set(),
+                "statuses": set(),
+                "kinds": set(),
+                "queue_lanes": set(),
+                "title": "",
+            },
+        )
+        entry["domains"].add(domain)
+        status = _text(ball.get("status"))
+        kind = _text(current.get("kind"))
+        lane = _text(current.get("queue_lane"))
+        if status:
+            entry["statuses"].add(status)
+        if kind:
+            entry["kinds"].add(kind)
+        if lane:
+            entry["queue_lanes"].add(lane)
+        if not entry["title"]:
+            entry["title"] = _text(current.get("title"))
+    return current_by_task
+
+
+def _ranked_actions(
+    status_projection: Mapping[str, object],
+) -> list[Mapping[str, object]]:
+    raw = status_projection.get("next_actions")
+    if not isinstance(raw, list):
+        return []
+    return [
+        action
+        for action in raw
+        if isinstance(action, Mapping) and _text(action.get("task_id"))
+    ]
+
+
+def _title(
+    task_id: str,
+    *,
+    task_by_id: Mapping[str, Mapping[str, object]],
+    current: Mapping[str, object] | None = None,
+) -> str:
+    task = task_by_id.get(task_id)
+    if isinstance(task, Mapping):
+        value = _text(task.get("title"))
+        if value:
+            return value
+    if isinstance(current, Mapping):
+        value = _text(current.get("title"))
+        if value:
+            return value
+    return task_id
+
+
+def _domains_for(
+    task_id: str,
+    memberships: Mapping[str, tuple[str, ...]],
+    current_by_task: Mapping[str, Mapping[str, object]],
+) -> tuple[str, ...]:
+    domains = memberships.get(task_id, ())
+    if domains:
+        return domains
+    current = current_by_task.get(task_id)
+    if not isinstance(current, Mapping):
+        return ()
+    raw = current.get("domains")
+    if not isinstance(raw, set):
+        return ()
+    return tuple(sorted(str(value) for value in raw))
+
+
+def _item(
+    task_id: str,
+    *,
+    title: str,
+    role: str,
+    domains: tuple[str, ...],
+    detail: str,
+    source: str,
+) -> dict[str, str]:
+    domain_text = " + ".join(domains) if domains else UNKNOWN
+    return {
+        "id": task_id,
+        "title": title,
+        "detail": detail,
+        "meta": f"{source} · {role} · {domain_text}",
+    }
+
+
+def build_decision_axis_queue_items(
+    status_projection: Mapping[str, object] | None,
+    task_by_id: Mapping[str, Mapping[str, object]],
+    *,
+    max_now_items: int = 6,
+    max_later_items: int = 5,
+) -> tuple[list[dict[str, str]], list[dict[str, str]]]:
+    """Project a bounded, conflict-free Now corridor from Bureau truth.
+
+    This function is read-only. It preserves Bureau's supplied ranking and uses
+    repository_balls as the execution-domain projection. Unknown domains fail
+    closed for additional parallel work.
+    """
+    if not isinstance(status_projection, Mapping):
+        return [], []
+    if max_now_items < 1 or max_later_items < 0:
+        raise ValueError("decision-axis item limits are invalid")
+
+    actions = _ranked_actions(status_projection)
+    balls = _repository_balls(status_projection)
+    memberships = _task_domains(balls)
+    current_by_task = _current_balls(balls)
+
+    now_items: list[dict[str, str]] = []
+    selected_task_ids: set[str] = set()
+    occupied_domains: set[str] = set()
+    parallel_selection_allowed = not actions
+
+    if actions:
+        global_action = actions[0]
+        task_id = _text(global_action.get("task_id"))
+        current = current_by_task.get(task_id)
+        domains = _domains_for(task_id, memberships, current_by_task)
+        statuses = (
+            current.get("statuses", set())
+            if isinstance(current, Mapping)
+            else set()
+        )
+        kinds = (
+            current.get("kinds", set())
+            if isinstance(current, Mapping)
+            else set()
+        )
+        active = "active" in statuses or "active_run" in kinds
+        role = "global first · already active" if active else "global first"
+        lane = _text(global_action.get("queue_lane")) or UNKNOWN
+        now_items.append(
+            _item(
+                task_id,
+                title=_title(task_id, task_by_id=task_by_id, current=current),
+                role=role,
+                domains=domains,
+                detail=(
+                    "Globale Bureau-Spitzenpriorität; "
+                    f"kanonische Queue-Lane: {lane}"
+                ),
+                source="Bureau status-projection",
+            )
+        )
+        selected_task_ids.add(task_id)
+        occupied_domains.update(domains)
+        parallel_selection_allowed = bool(domains)
+
+    active_candidates: list[
+        tuple[tuple[str, ...], str, Mapping[str, object]]
+    ] = []
+    for task_id, current in current_by_task.items():
+        statuses = current.get("statuses", set())
+        kinds = current.get("kinds", set())
+        if "active" not in statuses and "active_run" not in kinds:
+            continue
+        domains = _domains_for(task_id, memberships, current_by_task)
+        active_candidates.append((domains, task_id, current))
+
+    for domains, task_id, current in sorted(
+        active_candidates,
+        key=lambda value: (value[0], value[1]),
+    ):
+        if len(now_items) >= max_now_items:
+            break
+        if (
+            not parallel_selection_allowed
+            or task_id in selected_task_ids
+            or not domains
+            or occupied_domains.intersection(domains)
+        ):
+            continue
+        now_items.append(
+            _item(
+                task_id,
+                title=_title(task_id, task_by_id=task_by_id, current=current),
+                role="already active",
+                domains=domains,
+                detail=(
+                    "Aktiver Bureau-Repository-Ball; "
+                    "keine neue Claim-Entscheidung"
+                ),
+                source="Bureau repository_balls",
+            )
+        )
+        selected_task_ids.add(task_id)
+        occupied_domains.update(domains)
+
+    for action in actions:
+        if len(now_items) >= max_now_items:
+            break
+        task_id = _text(action.get("task_id"))
+        if (
+            not parallel_selection_allowed
+            or task_id in selected_task_ids
+            or _text(action.get("queue_lane")) != "now"
+        ):
+            continue
+        current = current_by_task.get(task_id)
+        if not isinstance(current, Mapping):
+            continue
+        statuses = current.get("statuses", set())
+        kinds = current.get("kinds", set())
+        lanes = current.get("queue_lanes", set())
+        if (
+            "ready" not in statuses
+            or "eligible_task" not in kinds
+            or "now" not in lanes
+        ):
+            continue
+        domains = _domains_for(task_id, memberships, current_by_task)
+        if not domains or occupied_domains.intersection(domains):
+            continue
+        now_items.append(
+            _item(
+                task_id,
+                title=_title(task_id, task_by_id=task_by_id, current=current),
+                role="parallel claimable",
+                domains=domains,
+                detail=(
+                    "Konfliktfreier aktueller Repository-Ball "
+                    "in der kanonischen Now-Lane"
+                ),
+                source="Bureau status-projection",
+            )
+        )
+        selected_task_ids.add(task_id)
+        occupied_domains.update(domains)
+
+    later_items: list[dict[str, str]] = []
+    for action in actions:
+        if len(later_items) >= max_later_items:
+            break
+        task_id = _text(action.get("task_id"))
+        lane = _text(action.get("queue_lane")) or UNKNOWN
+        if task_id in selected_task_ids or lane == "now":
+            continue
+        current = current_by_task.get(task_id)
+        domains = _domains_for(task_id, memberships, current_by_task)
+        later_items.append(
+            _item(
+                task_id,
+                title=_title(task_id, task_by_id=task_by_id, current=current),
+                role="after parallel corridor",
+                domains=domains,
+                detail=f"Weitere kanonische Bureau-Aktion; Queue-Lane: {lane}",
+                source="Bureau status-projection",
+            )
+        )
+
+    return now_items, later_items

--- a/scripts/leitstand-export-operator-snapshots
+++ b/scripts/leitstand-export-operator-snapshots
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import datetime
 import hashlib
+import importlib.util
 import json
 import os
 from pathlib import Path
@@ -458,6 +459,16 @@ if release_root.name != f"{release_commit}-runtime-v1":
     raise RuntimeError("Leitstand release path and source commit disagree")
 bridge_path = release_root / "scripts" / "export-operator-snapshots.mjs"
 require_regular(bridge_path, "versioned Leitstand snapshot bridge")
+selection_path = release_root / "scripts" / "decision_axis_selection.py"
+require_regular(selection_path, "versioned Leitstand decision-axis selector")
+selection_spec = importlib.util.spec_from_file_location(
+    "leitstand_decision_axis_selection", selection_path
+)
+if selection_spec is None or selection_spec.loader is None:
+    raise RuntimeError("cannot load versioned Leitstand decision-axis selector")
+selection_module = importlib.util.module_from_spec(selection_spec)
+selection_spec.loader.exec_module(selection_module)
+build_decision_axis_queue_items = selection_module.build_decision_axis_queue_items
 
 _runtime_bytes, runtime_config = load_json_file(runtime_config_path, "Leitstand runtime config")
 if (
@@ -711,18 +722,12 @@ except Exception as error:
     convergence_projection = None
     convergence_error = error.__class__.__name__
 
-next_actions = status_projection.get("next_actions", []) if status_projection else []
-ranked_actions = [item for item in next_actions if isinstance(item, dict) and item.get("task_id")]
-
-def task_action_item(action: dict[str, object]) -> dict[str, str]:
-    task_id = str(action.get("task_id"))
-    task = task_by_id.get(task_id, {})
-    title = str(task.get("title") or task_id)
-    lane = str(action.get("queue_lane") or "unknown")
-    return {"id": task_id, "title": title, "detail": f"Bureau queue lane: {lane}", "meta": "Bureau status-projection"}
-
-now_items = [task_action_item(ranked_actions[0])] if ranked_actions else []
-later_items = [task_action_item(item) for item in ranked_actions[1:6]]
+now_items, later_items = build_decision_axis_queue_items(
+    status_projection,
+    task_by_id,
+    max_now_items=6,
+    max_later_items=5,
+)
 status_observed_at = str(status_projection.get("generated_at")) if status_projection and status_projection.get("generated_at") else observed_at
 
 blocked_items: list[dict[str, str]] = []
@@ -798,7 +803,7 @@ if convergence_projection:
 
 decision_payload = {
     "sections": {
-        "now": section("unavailable" if status_error else ("available" if now_items else "unknown"), "Bureau status-projection / registry queue", status_observed_at if not status_error else None, now_items),
+        "now": section("unavailable" if status_error else ("available" if now_items else "unknown"), "Bureau status-projection / repository_balls / registry queue", status_observed_at if not status_error else None, now_items),
         "focus": section("unavailable" if focus_error else ("available" if focus_items else "unknown"), "Bureau Live Register", observed_at if not focus_error else None, focus_items),
         "blocked": section("unavailable" if status_error else ("available" if blocked_items else "unknown"), "Bureau status-projection blocker evidence", status_observed_at if not status_error else None, blocked_items),
         "convergence": section("unavailable" if convergence_error else ("unknown" if convergence_degraded or not convergence_items else "available"), "Grabowski current_work convergence projection", convergence_observed_at if not convergence_error else None, convergence_items),

--- a/scripts/leitstand-release.py
+++ b/scripts/leitstand-release.py
@@ -133,6 +133,7 @@ CRITICAL_ARTIFACTS: tuple[str, ...] = (
     SNAPSHOT_UNIT_RELATIVE_PATH.as_posix(),
     SNAPSHOT_TIMER_RELATIVE_PATH.as_posix(),
     "scripts/collect-storage-health-runtime",
+    "scripts/decision_axis_selection.py",
     "scripts/leitstand-export-operator-snapshots",
     "scripts/leitstand-release.py",
 )

--- a/tests/browserViewMatrix.test.ts
+++ b/tests/browserViewMatrix.test.ts
@@ -23,6 +23,7 @@ interface BrowserViewMatrix {
       selector: string;
       labels: string[];
       minReadableFontPx: number;
+      minimumNowItems: number;
     };
   }>;
   scenarios: Array<{
@@ -99,6 +100,7 @@ describe('LSV-V1-T009 browser view matrix', () => {
       selector: '[data-decision-section]',
       labels: ['Jetzt', 'Im Fokus', 'Blockiert', 'Konvergenz', 'Danach'],
       minReadableFontPx: 11,
+      minimumNowItems: 4,
     });
   });
 

--- a/tests/operatorSnapshotWrapper.test.ts
+++ b/tests/operatorSnapshotWrapper.test.ts
@@ -53,6 +53,10 @@ async function fixture() {
   );
   await writeFile(join(releaseRoot, 'scripts', 'export-operator-snapshots.mjs'), '// bridge\n');
   await writeFile(
+    join(releaseRoot, 'scripts', 'decision_axis_selection.py'),
+    'def build_decision_axis_queue_items(*args, **kwargs):\n    return [], []\n',
+  );
+  await writeFile(
     runtimeConfig,
     `${JSON.stringify({
       schema_version: 1,
@@ -209,6 +213,7 @@ describe('leitstand-export-operator-snapshots', () => {
     expect(source).toContain('canonical_registry_inventory_sha256');
     expect(source).toContain('canonical_registry_tree_sha256');
     expect(source).toContain('export-operator-snapshots.mjs');
+    expect(source).toContain('decision_axis_selection.py');
     expect(source).toContain('raw = json.loads(snapshot_contents[relative.as_posix()])');
     expect(source).not.toContain('raw = json.loads(path.read_text())');
   });

--- a/tests/test_decision_axis_selection.py
+++ b/tests/test_decision_axis_selection.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "decision_axis_selection.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "decision_axis_selection",
+    MODULE_PATH,
+)
+assert SPEC is not None and SPEC.loader is not None
+selection = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(selection)
+
+
+def current_ball(
+    task_id: str,
+    *,
+    status: str,
+    kind: str,
+    lane: str | None = None,
+    title: str | None = None,
+    task_ids: list[str] | None = None,
+) -> dict[str, object]:
+    current: dict[str, object] = {
+        "kind": kind,
+        "task_id": task_id,
+        "title": title or task_id,
+    }
+    if lane is not None:
+        current["queue_lane"] = lane
+    return {
+        "status": status,
+        "current_ball": current,
+        "task_ids": task_ids or [task_id],
+    }
+
+
+class DecisionAxisSelectionTests(unittest.TestCase):
+    def test_projects_global_active_and_conflict_free_now_corridor(self) -> None:
+        projection = {
+            "next_actions": [
+                {"task_id": "AUDIO-T001", "queue_lane": "now"},
+                {"task_id": "CROSS-T022", "queue_lane": "now"},
+                {"task_id": "NEXT-T021", "queue_lane": "next"},
+                {"task_id": "GRABOWSKI-T083", "queue_lane": "now"},
+                {"task_id": "BUREAU-T069", "queue_lane": "now"},
+                {"task_id": "REPOGROUND-T004", "queue_lane": "now"},
+                {"task_id": "REPOGROUND-T012", "queue_lane": "now"},
+            ],
+            "repository_balls": {
+                "repo.audio": current_ball(
+                    "AUDIO-T001",
+                    status="active",
+                    kind="active_run",
+                    task_ids=["AUDIO-T001"],
+                ),
+                "repo.bureau": current_ball(
+                    "BUREAU-RUN-T009",
+                    status="active",
+                    kind="active_run",
+                    task_ids=[
+                        "BUREAU-RUN-T009",
+                        "CROSS-T022",
+                        "BUREAU-T069",
+                        "NEXT-T021",
+                    ],
+                ),
+                "repo.grabowski": current_ball(
+                    "GRABOWSKI-T083",
+                    status="active",
+                    kind="active_run",
+                    task_ids=[
+                        "GRABOWSKI-T083",
+                        "CROSS-T022",
+                        "NEXT-T021",
+                    ],
+                ),
+                "repo.repoground": current_ball(
+                    "REPOGROUND-T004",
+                    status="ready",
+                    kind="eligible_task",
+                    lane="now",
+                    task_ids=["REPOGROUND-T004", "REPOGROUND-T012"],
+                ),
+            },
+        }
+        task_by_id = {
+            task_id: {"title": f"Title {task_id}"}
+            for task_id in [
+                "AUDIO-T001",
+                "CROSS-T022",
+                "NEXT-T021",
+                "GRABOWSKI-T083",
+                "BUREAU-T069",
+                "REPOGROUND-T004",
+                "REPOGROUND-T012",
+                "BUREAU-RUN-T009",
+            ]
+        }
+
+        now_items, later_items = selection.build_decision_axis_queue_items(
+            projection,
+            task_by_id,
+        )
+
+        self.assertEqual(
+            [item["id"] for item in now_items],
+            [
+                "AUDIO-T001",
+                "BUREAU-RUN-T009",
+                "GRABOWSKI-T083",
+                "REPOGROUND-T004",
+            ],
+        )
+        self.assertEqual([item["id"] for item in later_items], ["NEXT-T021"])
+        self.assertIn("global first · already active", now_items[0]["meta"])
+        self.assertIn("already active", now_items[1]["meta"])
+        self.assertIn("parallel claimable", now_items[3]["meta"])
+        self.assertNotIn("CROSS-T022", {item["id"] for item in later_items})
+        self.assertTrue(
+            all("Queue-Lane: now" not in item["detail"] for item in later_items)
+        )
+
+    def test_deduplicates_one_cross_repository_current_ball(self) -> None:
+        projection = {
+            "next_actions": [
+                {"task_id": "GLOBAL", "queue_lane": "now"},
+                {"task_id": "CROSS", "queue_lane": "now"},
+            ],
+            "repository_balls": {
+                "repo.audio": current_ball(
+                    "GLOBAL",
+                    status="ready",
+                    kind="eligible_task",
+                    lane="now",
+                ),
+                "repo.bureau": current_ball(
+                    "CROSS",
+                    status="ready",
+                    kind="eligible_task",
+                    lane="now",
+                    task_ids=["CROSS"],
+                ),
+                "repo.grabowski": current_ball(
+                    "CROSS",
+                    status="ready",
+                    kind="eligible_task",
+                    lane="now",
+                    task_ids=["CROSS"],
+                ),
+            },
+        }
+
+        now_items, later_items = selection.build_decision_axis_queue_items(
+            projection,
+            {},
+        )
+
+        self.assertEqual([item["id"] for item in now_items], ["GLOBAL", "CROSS"])
+        self.assertEqual(later_items, [])
+        self.assertIn("repo.bureau + repo.grabowski", now_items[1]["meta"])
+
+    def test_active_ball_occupies_domain_before_claimable_action(self) -> None:
+        projection = {
+            "next_actions": [
+                {"task_id": "GLOBAL", "queue_lane": "now"},
+                {"task_id": "READY-SAME-DOMAIN", "queue_lane": "now"},
+            ],
+            "repository_balls": {
+                "repo.global": current_ball(
+                    "GLOBAL",
+                    status="ready",
+                    kind="eligible_task",
+                    lane="now",
+                ),
+                "repo.shared": current_ball(
+                    "ACTIVE",
+                    status="active",
+                    kind="active_run",
+                    task_ids=["ACTIVE", "READY-SAME-DOMAIN"],
+                ),
+            },
+        }
+
+        now_items, later_items = selection.build_decision_axis_queue_items(
+            projection,
+            {},
+        )
+
+        self.assertEqual([item["id"] for item in now_items], ["GLOBAL", "ACTIVE"])
+        self.assertEqual(later_items, [])
+
+    def test_bounds_now_items_and_orders_active_domains_deterministically(self) -> None:
+        balls = {
+            "repo.global": current_ball(
+                "GLOBAL",
+                status="ready",
+                kind="eligible_task",
+                lane="now",
+            )
+        }
+        for index in range(8):
+            balls[f"repo.{index}"] = current_ball(
+                f"ACTIVE-{index}",
+                status="active",
+                kind="active_run",
+            )
+        projection = {
+            "next_actions": [{"task_id": "GLOBAL", "queue_lane": "now"}],
+            "repository_balls": balls,
+        }
+
+        now_items, later_items = selection.build_decision_axis_queue_items(
+            projection,
+            {},
+        )
+
+        self.assertEqual(len(now_items), 6)
+        self.assertEqual(
+            [item["id"] for item in now_items],
+            ["GLOBAL", "ACTIVE-0", "ACTIVE-1", "ACTIVE-2", "ACTIVE-3", "ACTIVE-4"],
+        )
+        self.assertEqual(later_items, [])
+
+    def test_unknown_global_domain_blocks_parallel_corridor(self) -> None:
+        projection = {
+            "next_actions": [
+                {"task_id": "GLOBAL-UNKNOWN", "queue_lane": "now"},
+                {"task_id": "READY", "queue_lane": "now"},
+            ],
+            "repository_balls": {
+                "repo.active": current_ball(
+                    "ACTIVE",
+                    status="active",
+                    kind="active_run",
+                ),
+                "repo.ready": current_ball(
+                    "READY",
+                    status="ready",
+                    kind="eligible_task",
+                    lane="now",
+                ),
+            },
+        }
+
+        now_items, later_items = selection.build_decision_axis_queue_items(
+            projection,
+            {},
+        )
+
+        self.assertEqual([item["id"] for item in now_items], ["GLOBAL-UNKNOWN"])
+        self.assertEqual(later_items, [])
+        self.assertIn("unknown", now_items[0]["meta"])
+
+    def test_unknown_domain_fails_closed_for_parallel_now(self) -> None:
+        projection = {
+            "next_actions": [
+                {"task_id": "GLOBAL", "queue_lane": "now"},
+                {"task_id": "UNKNOWN-NOW", "queue_lane": "now"},
+                {"task_id": "NEXT", "queue_lane": "next"},
+            ],
+            "repository_balls": {
+                "repo.global": current_ball(
+                    "GLOBAL",
+                    status="ready",
+                    kind="eligible_task",
+                    lane="now",
+                )
+            },
+        }
+
+        now_items, later_items = selection.build_decision_axis_queue_items(
+            projection,
+            {},
+        )
+
+        self.assertEqual([item["id"] for item in now_items], ["GLOBAL"])
+        self.assertEqual([item["id"] for item in later_items], ["NEXT"])
+
+    def test_rejects_invalid_limits(self) -> None:
+        with self.assertRaisesRegex(ValueError, "item limits"):
+            selection.build_decision_axis_queue_items(
+                {},
+                {},
+                max_now_items=0,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_release_runtime.py
+++ b/tests/test_release_runtime.py
@@ -166,6 +166,8 @@ print(json.dumps({'ok': True, 'sourceCommit': manifest['sourceCommit'], 'artifac
         collector = target / "scripts/collect-storage-health-runtime"
         collector.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
         os.chmod(collector, 0o755)
+        selector = target / "scripts/decision_axis_selection.py"
+        selector.write_text("def build_decision_axis_queue_items(*args, **kwargs):\n    return [], []\n", encoding="utf-8")
         snapshot_wrapper = target / "scripts/leitstand-export-operator-snapshots"
         snapshot_wrapper.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
         os.chmod(snapshot_wrapper, 0o755)


### PR DESCRIPTION
## Summary
- project the global Bureau top candidate plus conflict-free active/claimable repository balls into the Now section
- fail closed when execution domains are unknown and reserve all domains of multi-repository tasks
- keep non-selected now tasks out of Danach and bind the selector into the immutable release
- extend mobile/desktop browser regression coverage for the bounded parallel corridor

## Validation
- npm test: 269/269
- npm run typecheck
- npm run lint
- npm run test:release-runtime: 48/48
- npm run build
- npm run test:browser-views: 213 checks across mobile/desktop
- revision-bound self-review on e94ba2ce2c5e71734c246edfb7e9f8fb3a8e0381

## Review note
Self-review identified and fixed two issues before publication: unknown global domains did not initially close parallel selection, and the browser matrix contract test had not been updated.