### PR TITLE
fix(release): preserve historical manifest verification

### DIFF
--- a/docs/runbooks/local-release-runtime.md
+++ b/docs/runbooks/local-release-runtime.md
@@ -52,6 +52,8 @@ Release directory:
 Every release manifest binds source commit, source tree, origin URL, validation commands, release-tree digest and critical artifact digests.
 The critical-artifact set includes the versioned operator-snapshot launcher `scripts/leitstand-export-operator-snapshots` and its decision-axis selector `scripts/decision_axis_selection.py`; their exact bytes are therefore sealed and digest-bound with the release before the host-local installed copy may be updated. The launcher resolves both the format bridge and the selector from that same immutable release rather than from a mutable checkout. A missing or unloadable selector fails the producer before it can publish a decision-axis snapshot.
 
+Historical immutable releases retain the exact critical-artifact set written by their own manifest. Validation accepts only the four known sets produced by earlier release-contract revisions and hashes exactly those recorded paths; unknown, partial or invented sets remain fail-closed. This preserves rollback to older releases without weakening their whole-tree SHA-256 seal.
+
 ## Runtime configuration
 
 Host-specific source paths are not embedded in the repository. The effect commands read one exact-key JSON object, normally:

--- a/scripts/leitstand-release.py
+++ b/scripts/leitstand-release.py
@@ -124,7 +124,21 @@ SNAPSHOT_THRESHOLDS = {
 }
 RUNTIME_LINK_NAMES: tuple[str, ...] = ()
 
-CRITICAL_ARTIFACTS: tuple[str, ...] = (
+BASE_CRITICAL_ARTIFACTS: tuple[str, ...] = (
+    "package.json",
+    "pnpm-lock.yaml",
+    "dist/server.js",
+    WEB_UNIT_RELATIVE_PATH.as_posix(),
+    STORAGE_UNIT_RELATIVE_PATH.as_posix(),
+    "scripts/collect-storage-health-runtime",
+    "scripts/leitstand-release.py",
+)
+SNAPSHOT_WRAPPER_CRITICAL_ARTIFACTS: tuple[str, ...] = (
+    *BASE_CRITICAL_ARTIFACTS[:-1],
+    "scripts/leitstand-export-operator-snapshots",
+    BASE_CRITICAL_ARTIFACTS[-1],
+)
+SNAPSHOT_TIMER_CRITICAL_ARTIFACTS: tuple[str, ...] = (
     "package.json",
     "pnpm-lock.yaml",
     "dist/server.js",
@@ -133,9 +147,19 @@ CRITICAL_ARTIFACTS: tuple[str, ...] = (
     SNAPSHOT_UNIT_RELATIVE_PATH.as_posix(),
     SNAPSHOT_TIMER_RELATIVE_PATH.as_posix(),
     "scripts/collect-storage-health-runtime",
-    "scripts/decision_axis_selection.py",
     "scripts/leitstand-export-operator-snapshots",
     "scripts/leitstand-release.py",
+)
+CRITICAL_ARTIFACTS: tuple[str, ...] = (
+    *SNAPSHOT_TIMER_CRITICAL_ARTIFACTS[:-2],
+    "scripts/decision_axis_selection.py",
+    *SNAPSHOT_TIMER_CRITICAL_ARTIFACTS[-2:],
+)
+SUPPORTED_CRITICAL_ARTIFACT_SETS: tuple[tuple[str, ...], ...] = (
+    BASE_CRITICAL_ARTIFACTS,
+    SNAPSHOT_WRAPPER_CRITICAL_ARTIFACTS,
+    SNAPSHOT_TIMER_CRITICAL_ARTIFACTS,
+    CRITICAL_ARTIFACTS,
 )
 
 SOURCE_VALIDATION_COMMANDS: tuple[tuple[str, ...], ...] = (
@@ -743,9 +767,11 @@ def release_tree_sha256(root: Path) -> str:
     return digest.hexdigest()
 
 
-def critical_hashes(root: Path) -> dict[str, str]:
+def critical_hashes(
+    root: Path, artifacts: Sequence[str] = CRITICAL_ARTIFACTS
+) -> dict[str, str]:
     result: dict[str, str] = {}
-    for relative in CRITICAL_ARTIFACTS:
+    for relative in artifacts:
         path = root / relative
         _require_regular_file(path, owner_uid=os.getuid(), label=f"critical artifact {relative}")
         result[relative] = sha256_file(path)
@@ -839,6 +865,14 @@ def _validate_string_list(value: object, label: str) -> list[str]:
     return value
 
 
+def _critical_artifact_set(critical: Mapping[str, object]) -> tuple[str, ...]:
+    keys = frozenset(critical)
+    for candidate in SUPPORTED_CRITICAL_ARTIFACT_SETS:
+        if keys == frozenset(candidate):
+            return candidate
+    raise ReleaseError("critical artifact manifest keys mismatch")
+
+
 def validate_manifest(manifest: object, *, target: Path | None = None) -> dict[str, Any]:
     if not isinstance(manifest, dict):
         raise ReleaseError("release manifest must be one JSON object")
@@ -875,8 +909,7 @@ def validate_manifest(manifest: object, *, target: Path | None = None) -> dict[s
         raise ReleaseError("release attempt_id is invalid")
     _validate_string_list(manifest["does_not_establish"], "does_not_establish")
     critical = manifest["critical_artifacts"]
-    if set(critical) != set(CRITICAL_ARTIFACTS):
-        raise ReleaseError("critical artifact manifest keys mismatch")
+    _critical_artifact_set(critical)
     for key, value in critical.items():
         if not isinstance(value, str) or not SHA256_RE.fullmatch(value):
             raise ReleaseError(f"critical artifact digest is invalid: {key}")
@@ -930,7 +963,8 @@ def verify_release_path(paths: Paths, target: Path) -> dict[str, Any]:
         raise ReleaseError(
             f"release tree SHA-256 mismatch: expected {manifest['release_tree_sha256']}, got {actual_tree}"
         )
-    actual_critical = critical_hashes(target)
+    artifact_set = _critical_artifact_set(manifest["critical_artifacts"])
+    actual_critical = critical_hashes(target, artifact_set)
     if actual_critical != manifest["critical_artifacts"]:
         raise ReleaseError("release critical artifact hashes mismatch")
     if runtime_links(target) != manifest["runtime_links"]:

--- a/tests/test_release_runtime.py
+++ b/tests/test_release_runtime.py
@@ -241,6 +241,39 @@ print(json.dumps({'ok': True, 'sourceCommit': manifest['sourceCommit'], 'artifac
         buffer.seek(0)
         return tarfile.open(fileobj=buffer, mode="r:")
 
+    def test_historical_critical_artifact_sets_remain_verifiable(self) -> None:
+        historical_sets = release.SUPPORTED_CRITICAL_ARTIFACT_SETS[:-1]
+        for index, artifact_set in enumerate(historical_sets, 1):
+            with self.subTest(artifact_count=len(artifact_set)):
+                head = f"{index:x}" * 40
+                target = self.create_verified_release(head, seal=False)
+                manifest_path = target / release.MANIFEST_NAME
+                manifest = json.loads(manifest_path.read_text("utf-8"))
+                manifest["critical_artifacts"] = release.critical_hashes(target, artifact_set)
+                manifest_path.write_bytes(release.canonical_json_bytes(manifest))
+                release.seal_release(target)
+
+                verified = release.verify_release_path(self.paths, target)
+
+                self.assertEqual(set(verified["critical_artifacts"]), set(artifact_set))
+                self.assertNotIn(
+                    "scripts/decision_axis_selection.py", verified["critical_artifacts"]
+                )
+
+    def test_unknown_critical_artifact_set_fails_closed(self) -> None:
+        head = "8" * 40
+        target = self.create_verified_release(head, seal=False)
+        manifest_path = target / release.MANIFEST_NAME
+        manifest = json.loads(manifest_path.read_text("utf-8"))
+        manifest["critical_artifacts"].pop("scripts/leitstand-release.py")
+        manifest_path.write_bytes(release.canonical_json_bytes(manifest))
+        release.seal_release(target)
+
+        with self.assertRaisesRegex(
+            release.ReleaseError, "critical artifact manifest keys mismatch"
+        ):
+            release.verify_release_path(self.paths, target)
+
     def test_head_and_release_identity_are_strict(self) -> None:
         head = "a" * 40
         self.assertEqual(release.validate_head(head), head)


### PR DESCRIPTION
## Problem
PR #197 added a new critical artifact while schema-v2 manifests require exact current keys. Historical releases with 7, 8, or 10 critical artifacts therefore fail rollback verification.

## Change
- recognize the four exact critical-artifact sets already present in live immutable release manifests
- hash each release against the set recorded by its own accepted manifest
- keep unknown or partially removed sets fail-closed

## Evidence
- 50 release/runtime tests pass
- 269 Vitest tests pass
- lint, typecheck, build and `git diff --check` pass
- all 15 live release manifests match one accepted historical/current set and their recorded critical hashes

Fixes the unresolved P1 review thread on #197.