### PR TITLE
test: isolate controller artifact roots

### DIFF
--- a/src/controllers/bureau.ts
+++ b/src/controllers/bureau.ts
@@ -13,6 +13,10 @@ import { join, relative, resolve } from 'node:path';
  */
 
 export type BureauSourceKind = 'artifact' | 'fixture' | 'missing' | 'corrupt';
+
+export interface BureauDataOptions {
+  sourceRoot?: string;
+}
 export type BureauFreshness = 'fresh' | 'stale' | 'unknown';
 
 /** Canonical Bureau lifecycle states, normalised from producer vocab. */
@@ -85,13 +89,13 @@ const OPEN_STATES: ReadonlySet<BureauTaskState> = new Set<BureauTaskState>([
   'blocked',
 ]);
 
-function artifactSnapshotPath(): string {
+function artifactSnapshotPath(sourceRoot: string): string {
   return process.env.LEITSTAND_BUREAU_SNAPSHOT_PATH
-    || join(process.cwd(), 'artifacts', 'bureau-tasks.json');
+    || join(sourceRoot, 'artifacts', 'bureau-tasks.json');
 }
 
-function fixtureSnapshotPath(): string {
-  return join(process.cwd(), 'src', 'fixtures', 'bureau-tasks.json');
+function fixtureSnapshotPath(sourceRoot: string): string {
+  return join(sourceRoot, 'src', 'fixtures', 'bureau-tasks.json');
 }
 
 function fixtureFallbackEnabled(): boolean {
@@ -199,20 +203,25 @@ function buildColumns(tasks: BureauTaskView[]): BureauViewData['columns'] {
 }
 
 
-function displaySourcePath(sourcePath: string): string {
-  const rel = relative(resolve(process.cwd()), resolve(sourcePath));
+function displaySourcePath(sourcePath: string, sourceRoot: string): string {
+  const rel = relative(sourceRoot, resolve(sourcePath));
   if (rel && !rel.startsWith('..') && !rel.startsWith('/')) return rel;
   return '<external snapshot>';
 }
 
-function emptyData(kind: BureauSourceKind, reason: string, sourcePath: string): BureauViewData {
+function emptyData(
+  kind: BureauSourceKind,
+  reason: string,
+  sourcePath: string,
+  sourceRoot: string,
+): BureauViewData {
   return {
     tasks: [],
     columns: buildColumns([]),
     view_meta: {
       source_kind: kind,
       source_path: sourcePath,
-      source_path_display: displaySourcePath(sourcePath),
+      source_path_display: displaySourcePath(sourcePath, sourceRoot),
       missing_reason: reason,
       generated_at: null,
       freshness_state: 'unknown',
@@ -230,6 +239,7 @@ function dataFromParsed(
   sourceKind: BureauSourceKind,
   sourcePath: string,
   missingReason: string,
+  sourceRoot: string,
 ): BureauViewData {
   return {
     tasks: parsed.tasks,
@@ -237,7 +247,7 @@ function dataFromParsed(
     view_meta: {
       source_kind: sourceKind,
       source_path: sourcePath,
-      source_path_display: displaySourcePath(sourcePath),
+      source_path_display: displaySourcePath(sourcePath, sourceRoot),
       missing_reason: missingReason,
       generated_at: parsed.generatedAt,
       freshness_state: freshnessOf(parsed.generatedAt),
@@ -254,28 +264,30 @@ async function loadSnapshot(path: string): Promise<ReturnType<typeof parseSnapsh
   return parseSnapshot(JSON.parse(await readFile(path, 'utf-8')) as unknown);
 }
 
-export async function getBureauData(): Promise<BureauViewData> {
-  const sourcePath = resolve(artifactSnapshotPath());
+export async function getBureauData(options: BureauDataOptions = {}): Promise<BureauViewData> {
+  const sourceRoot = resolve(options.sourceRoot ?? process.cwd());
+  const sourcePath = resolve(artifactSnapshotPath(sourceRoot));
   try {
-    return dataFromParsed(await loadSnapshot(sourcePath), 'artifact', sourcePath, 'ok');
+    return dataFromParsed(await loadSnapshot(sourcePath), 'artifact', sourcePath, 'ok', sourceRoot);
   } catch (error) {
     const classified = classifyError(error);
     const envOverride = process.env.LEITSTAND_BUREAU_SNAPSHOT_PATH !== undefined;
     if (envOverride || classified.kind !== 'missing' || !fixtureFallbackEnabled()) {
-      return emptyData(classified.kind, classified.reason, sourcePath);
+      return emptyData(classified.kind, classified.reason, sourcePath, sourceRoot);
     }
 
-    const fallbackPath = resolve(fixtureSnapshotPath());
+    const fallbackPath = resolve(fixtureSnapshotPath(sourceRoot));
     try {
       return dataFromParsed(
         await loadSnapshot(fallbackPath),
         'fixture',
         fallbackPath,
         'bureau_snapshot_missing_fixture_fallback',
+        sourceRoot,
       );
     } catch (fallbackError) {
       const fallbackClassified = classifyError(fallbackError);
-      return emptyData(fallbackClassified.kind, fallbackClassified.reason, fallbackPath);
+      return emptyData(fallbackClassified.kind, fallbackClassified.reason, fallbackPath, sourceRoot);
     }
   }
 }

--- a/src/controllers/checkouts.ts
+++ b/src/controllers/checkouts.ts
@@ -12,6 +12,10 @@ import { join, relative, resolve } from 'node:path';
  */
 
 export type CheckoutSourceKind = 'artifact' | 'fixture' | 'missing' | 'corrupt';
+
+export interface CheckoutDataOptions {
+  sourceRoot?: string;
+}
 export type CheckoutFreshness = 'fresh' | 'stale' | 'unknown';
 
 /** Retention verdict, normalised from producer vocab. Ordered worst→best for triage. */
@@ -60,13 +64,13 @@ const DEFAULT_NON_CLAIMS = [
   'process_control',
 ];
 
-function artifactSnapshotPath(): string {
+function artifactSnapshotPath(sourceRoot: string): string {
   return process.env.LEITSTAND_CHECKOUT_SNAPSHOT_PATH
-    || join(process.cwd(), 'artifacts', 'checkout-inventory.json');
+    || join(sourceRoot, 'artifacts', 'checkout-inventory.json');
 }
 
-function fixtureSnapshotPath(): string {
-  return join(process.cwd(), 'src', 'fixtures', 'checkout-inventory.json');
+function fixtureSnapshotPath(sourceRoot: string): string {
+  return join(sourceRoot, 'src', 'fixtures', 'checkout-inventory.json');
 }
 
 function fixtureFallbackEnabled(): boolean {
@@ -172,19 +176,24 @@ function isSprawl(checkout: CheckoutView): boolean {
 }
 
 
-function displaySourcePath(sourcePath: string): string {
-  const rel = relative(resolve(process.cwd()), resolve(sourcePath));
+function displaySourcePath(sourcePath: string, sourceRoot: string): string {
+  const rel = relative(sourceRoot, resolve(sourcePath));
   if (rel && !rel.startsWith('..') && !rel.startsWith('/')) return rel;
   return '<external snapshot>';
 }
 
-function emptyData(kind: CheckoutSourceKind, reason: string, sourcePath: string): CheckoutViewData {
+function emptyData(
+  kind: CheckoutSourceKind,
+  reason: string,
+  sourcePath: string,
+  sourceRoot: string,
+): CheckoutViewData {
   return {
     checkouts: [],
     view_meta: {
       source_kind: kind,
       source_path: sourcePath,
-      source_path_display: displaySourcePath(sourcePath),
+      source_path_display: displaySourcePath(sourcePath, sourceRoot),
       missing_reason: reason,
       generated_at: null,
       freshness_state: 'unknown',
@@ -203,6 +212,7 @@ function dataFromParsed(
   sourceKind: CheckoutSourceKind,
   sourcePath: string,
   missingReason: string,
+  sourceRoot: string,
 ): CheckoutViewData {
   // Sort worst retention first so triage-relevant checkouts surface at the top.
   const order: Record<CheckoutRetention, number> = { orphan: 0, archivable: 1, unknown: 2, retained: 3 };
@@ -212,7 +222,7 @@ function dataFromParsed(
     view_meta: {
       source_kind: sourceKind,
       source_path: sourcePath,
-      source_path_display: displaySourcePath(sourcePath),
+      source_path_display: displaySourcePath(sourcePath, sourceRoot),
       missing_reason: missingReason,
       generated_at: parsed.generatedAt,
       freshness_state: freshnessOf(parsed.generatedAt),
@@ -230,28 +240,30 @@ async function loadSnapshot(path: string): Promise<ReturnType<typeof parseSnapsh
   return parseSnapshot(JSON.parse(await readFile(path, 'utf-8')) as unknown);
 }
 
-export async function getCheckoutData(): Promise<CheckoutViewData> {
-  const sourcePath = resolve(artifactSnapshotPath());
+export async function getCheckoutData(options: CheckoutDataOptions = {}): Promise<CheckoutViewData> {
+  const sourceRoot = resolve(options.sourceRoot ?? process.cwd());
+  const sourcePath = resolve(artifactSnapshotPath(sourceRoot));
   try {
-    return dataFromParsed(await loadSnapshot(sourcePath), 'artifact', sourcePath, 'ok');
+    return dataFromParsed(await loadSnapshot(sourcePath), 'artifact', sourcePath, 'ok', sourceRoot);
   } catch (error) {
     const classified = classifyError(error);
     const envOverride = process.env.LEITSTAND_CHECKOUT_SNAPSHOT_PATH !== undefined;
     if (envOverride || classified.kind !== 'missing' || !fixtureFallbackEnabled()) {
-      return emptyData(classified.kind, classified.reason, sourcePath);
+      return emptyData(classified.kind, classified.reason, sourcePath, sourceRoot);
     }
 
-    const fallbackPath = resolve(fixtureSnapshotPath());
+    const fallbackPath = resolve(fixtureSnapshotPath(sourceRoot));
     try {
       return dataFromParsed(
         await loadSnapshot(fallbackPath),
         'fixture',
         fallbackPath,
         'checkout_inventory_missing_fixture_fallback',
+        sourceRoot,
       );
     } catch (fallbackError) {
       const fallbackClassified = classifyError(fallbackError);
-      return emptyData(fallbackClassified.kind, fallbackClassified.reason, fallbackPath);
+      return emptyData(fallbackClassified.kind, fallbackClassified.reason, fallbackPath, sourceRoot);
     }
   }
 }

--- a/src/controllers/storageHealth.ts
+++ b/src/controllers/storageHealth.ts
@@ -3,6 +3,10 @@ import { join, relative, resolve } from 'node:path';
 
 export type StorageTruth = 'observed' | 'estimated' | 'unavailable';
 export type StorageHealthSourceKind = 'artifact' | 'fixture' | 'missing' | 'corrupt';
+
+export interface StorageHealthDataOptions {
+  sourceRoot?: string;
+}
 export type StorageHealthFreshness = 'fresh' | 'stale' | 'unknown';
 
 export interface StorageMetric {
@@ -105,13 +109,13 @@ const DEFAULT_NON_CLAIMS = [
 ];
 const TRUTH_VALUES = new Set<StorageTruth>(['observed', 'estimated', 'unavailable']);
 
-function artifactPath(): string {
+function artifactPath(sourceRoot: string): string {
   return process.env.LEITSTAND_STORAGE_HEALTH_PATH
-    || join(process.cwd(), 'artifacts', 'storage-health.json');
+    || join(sourceRoot, 'artifacts', 'storage-health.json');
 }
 
-function fixturePath(): string {
-  return join(process.cwd(), 'src', 'fixtures', 'storage-health.json');
+function fixturePath(sourceRoot: string): string {
+  return join(sourceRoot, 'src', 'fixtures', 'storage-health.json');
 }
 
 function fixtureFallbackEnabled(): boolean {
@@ -138,8 +142,8 @@ function freshnessOf(generatedAt: string | null): StorageHealthFreshness {
   return Date.now() - timestamp <= STALE_AFTER_MS ? 'fresh' : 'stale';
 }
 
-function displaySourcePath(sourcePath: string): string {
-  const rel = relative(resolve(process.cwd()), resolve(sourcePath));
+function displaySourcePath(sourcePath: string, sourceRoot: string): string {
+  const rel = relative(sourceRoot, resolve(sourcePath));
   if (rel && !rel.startsWith('..') && !rel.startsWith('/')) return rel;
   return '<external snapshot>';
 }
@@ -390,14 +394,19 @@ function parseSnapshot(raw: unknown): {
   };
 }
 
-function emptyData(kind: StorageHealthSourceKind, reason: string, sourcePath: string): StorageHealthViewData {
+function emptyData(
+  kind: StorageHealthSourceKind,
+  reason: string,
+  sourcePath: string,
+  sourceRoot: string,
+): StorageHealthViewData {
   return {
     current: null,
     notifications: [],
     view_meta: {
       source_kind: kind,
       source_path: sourcePath,
-      source_path_display: displaySourcePath(sourcePath),
+      source_path_display: displaySourcePath(sourcePath, sourceRoot),
       missing_reason: reason,
       generated_at: null,
       freshness_state: 'unknown',
@@ -420,6 +429,7 @@ function dataFromParsed(
   sourceKind: StorageHealthSourceKind,
   sourcePath: string,
   missingReason: string,
+  sourceRoot: string,
 ): StorageHealthViewData {
   return {
     current: parsed.current,
@@ -427,7 +437,7 @@ function dataFromParsed(
     view_meta: {
       source_kind: sourceKind,
       source_path: sourcePath,
-      source_path_display: displaySourcePath(sourcePath),
+      source_path_display: displaySourcePath(sourcePath, sourceRoot),
       missing_reason: missingReason,
       generated_at: parsed.generatedAt,
       freshness_state: freshnessOf(parsed.generatedAt),
@@ -449,27 +459,29 @@ async function loadSnapshot(path: string): Promise<ReturnType<typeof parseSnapsh
   return parseSnapshot(JSON.parse(await readFile(path, 'utf8')) as unknown);
 }
 
-export async function getStorageHealthData(): Promise<StorageHealthViewData> {
-  const sourcePath = resolve(artifactPath());
+export async function getStorageHealthData(options: StorageHealthDataOptions = {}): Promise<StorageHealthViewData> {
+  const sourceRoot = resolve(options.sourceRoot ?? process.cwd());
+  const sourcePath = resolve(artifactPath(sourceRoot));
   try {
-    return dataFromParsed(await loadSnapshot(sourcePath), 'artifact', sourcePath, 'ok');
+    return dataFromParsed(await loadSnapshot(sourcePath), 'artifact', sourcePath, 'ok', sourceRoot);
   } catch (error) {
     const classified = classifyError(error);
     const envOverride = process.env.LEITSTAND_STORAGE_HEALTH_PATH !== undefined;
     if (envOverride || classified.kind !== 'missing' || !fixtureFallbackEnabled()) {
-      return emptyData(classified.kind, classified.reason, sourcePath);
+      return emptyData(classified.kind, classified.reason, sourcePath, sourceRoot);
     }
-    const fallbackPath = resolve(fixturePath());
+    const fallbackPath = resolve(fixturePath(sourceRoot));
     try {
       return dataFromParsed(
         await loadSnapshot(fallbackPath),
         'fixture',
         fallbackPath,
         'storage_health_missing_fixture_fallback',
+        sourceRoot,
       );
     } catch (fallbackError) {
       const fallbackClassified = classifyError(fallbackError);
-      return emptyData(fallbackClassified.kind, fallbackClassified.reason, fallbackPath);
+      return emptyData(fallbackClassified.kind, fallbackClassified.reason, fallbackPath, sourceRoot);
     }
   }
 }

--- a/tests/controllers/bureau.test.ts
+++ b/tests/controllers/bureau.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, writeFile, rm } from 'fs/promises';
+import { copyFile, mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -8,6 +8,17 @@ const OLD_PATH = process.env.LEITSTAND_BUREAU_SNAPSHOT_PATH;
 const OLD_FIXTURE_FALLBACK = process.env.LEITSTAND_BUREAU_FIXTURE_FALLBACK;
 const OLD_STRICT = process.env.LEITSTAND_STRICT;
 let tempRoots: string[] = [];
+
+async function isolatedSourceRoot(fixtureName?: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'leitstand-bureau-root-'));
+  tempRoots.push(root);
+  if (fixtureName) {
+    const fixtureDir = join(root, 'src', 'fixtures');
+    await mkdir(fixtureDir, { recursive: true });
+    await copyFile(join(process.cwd(), 'src', 'fixtures', fixtureName), join(fixtureDir, fixtureName));
+  }
+  return root;
+}
 
 afterEach(async () => {
   if (OLD_PATH === undefined) delete process.env.LEITSTAND_BUREAU_SNAPSHOT_PATH;
@@ -48,17 +59,27 @@ describe('getBureauData', () => {
     delete process.env.LEITSTAND_BUREAU_SNAPSHOT_PATH;
     delete process.env.LEITSTAND_BUREAU_FIXTURE_FALLBACK;
     delete process.env.LEITSTAND_STRICT;
-    const data = await getBureauData();
+    const sourceRoot = await isolatedSourceRoot();
+    const data = await getBureauData({ sourceRoot });
     expect(data.view_meta.source_kind).toBe('missing');
     expect(data.view_meta.missing_reason).toBe('bureau_snapshot_missing');
     expect(data.view_meta.source_path_display.startsWith('artifacts/')).toBe(true);
     expect(data.view_meta.source_path.endsWith('/artifacts/bureau-tasks.json')).toBe(true);
   });
 
+  it('keeps process.cwd() as the production default source root', async () => {
+    delete process.env.LEITSTAND_BUREAU_SNAPSHOT_PATH;
+    delete process.env.LEITSTAND_BUREAU_FIXTURE_FALLBACK;
+    delete process.env.LEITSTAND_STRICT;
+    const data = await getBureauData();
+    expect(data.view_meta.source_path).toBe(join(process.cwd(), 'artifacts', 'bureau-tasks.json'));
+  });
+
   it('uses the demo fixture only when fixture fallback is explicit', async () => {
     delete process.env.LEITSTAND_BUREAU_SNAPSHOT_PATH;
     process.env.LEITSTAND_BUREAU_FIXTURE_FALLBACK = '1';
-    const data = await getBureauData();
+    const sourceRoot = await isolatedSourceRoot('bureau-tasks.json');
+    const data = await getBureauData({ sourceRoot });
     expect(data.view_meta.source_kind).toBe('fixture');
     expect(data.view_meta.missing_reason).toBe('bureau_snapshot_missing_fixture_fallback');
     expect(data.view_meta.source_path_display.startsWith('src/fixtures/')).toBe(true);
@@ -69,7 +90,8 @@ describe('getBureauData', () => {
     delete process.env.LEITSTAND_BUREAU_SNAPSHOT_PATH;
     delete process.env.LEITSTAND_BUREAU_FIXTURE_FALLBACK;
     process.env.LEITSTAND_STRICT = 'false';
-    const data = await getBureauData();
+    const sourceRoot = await isolatedSourceRoot('bureau-tasks.json');
+    const data = await getBureauData({ sourceRoot });
     expect(data.view_meta.source_kind).toBe('fixture');
     expect(data.view_meta.missing_reason).toBe('bureau_snapshot_missing_fixture_fallback');
   });

--- a/tests/controllers/checkouts.test.ts
+++ b/tests/controllers/checkouts.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, writeFile, rm } from 'fs/promises';
+import { copyFile, mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -8,6 +8,17 @@ const OLD_PATH = process.env.LEITSTAND_CHECKOUT_SNAPSHOT_PATH;
 const OLD_FIXTURE_FALLBACK = process.env.LEITSTAND_CHECKOUT_FIXTURE_FALLBACK;
 const OLD_STRICT = process.env.LEITSTAND_STRICT;
 let tempRoots: string[] = [];
+
+async function isolatedSourceRoot(fixtureName?: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'leitstand-checkout-root-'));
+  tempRoots.push(root);
+  if (fixtureName) {
+    const fixtureDir = join(root, 'src', 'fixtures');
+    await mkdir(fixtureDir, { recursive: true });
+    await copyFile(join(process.cwd(), 'src', 'fixtures', fixtureName), join(fixtureDir, fixtureName));
+  }
+  return root;
+}
 
 afterEach(async () => {
   if (OLD_PATH === undefined) delete process.env.LEITSTAND_CHECKOUT_SNAPSHOT_PATH;
@@ -46,17 +57,27 @@ describe('getCheckoutData', () => {
     delete process.env.LEITSTAND_CHECKOUT_SNAPSHOT_PATH;
     delete process.env.LEITSTAND_CHECKOUT_FIXTURE_FALLBACK;
     delete process.env.LEITSTAND_STRICT;
-    const data = await getCheckoutData();
+    const sourceRoot = await isolatedSourceRoot();
+    const data = await getCheckoutData({ sourceRoot });
     expect(data.view_meta.source_kind).toBe('missing');
     expect(data.view_meta.missing_reason).toBe('checkout_inventory_missing');
     expect(data.view_meta.source_path_display.startsWith('artifacts/')).toBe(true);
     expect(data.view_meta.source_path.endsWith('/artifacts/checkout-inventory.json')).toBe(true);
   });
 
+  it('keeps process.cwd() as the production default source root', async () => {
+    delete process.env.LEITSTAND_CHECKOUT_SNAPSHOT_PATH;
+    delete process.env.LEITSTAND_CHECKOUT_FIXTURE_FALLBACK;
+    delete process.env.LEITSTAND_STRICT;
+    const data = await getCheckoutData();
+    expect(data.view_meta.source_path).toBe(join(process.cwd(), 'artifacts', 'checkout-inventory.json'));
+  });
+
   it('uses the demo fixture only when fixture fallback is explicit', async () => {
     delete process.env.LEITSTAND_CHECKOUT_SNAPSHOT_PATH;
     process.env.LEITSTAND_CHECKOUT_FIXTURE_FALLBACK = 'true';
-    const data = await getCheckoutData();
+    const sourceRoot = await isolatedSourceRoot('checkout-inventory.json');
+    const data = await getCheckoutData({ sourceRoot });
     expect(data.view_meta.source_kind).toBe('fixture');
     expect(data.view_meta.missing_reason).toBe('checkout_inventory_missing_fixture_fallback');
     expect(data.view_meta.source_path_display.startsWith('src/fixtures/')).toBe(true);
@@ -67,7 +88,8 @@ describe('getCheckoutData', () => {
     delete process.env.LEITSTAND_CHECKOUT_SNAPSHOT_PATH;
     delete process.env.LEITSTAND_CHECKOUT_FIXTURE_FALLBACK;
     process.env.LEITSTAND_STRICT = '0';
-    const data = await getCheckoutData();
+    const sourceRoot = await isolatedSourceRoot('checkout-inventory.json');
+    const data = await getCheckoutData({ sourceRoot });
     expect(data.view_meta.source_kind).toBe('fixture');
     expect(data.view_meta.missing_reason).toBe('checkout_inventory_missing_fixture_fallback');
   });

--- a/tests/controllers/storageHealth.test.ts
+++ b/tests/controllers/storageHealth.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -8,6 +8,17 @@ const oldPath = process.env.LEITSTAND_STORAGE_HEALTH_PATH;
 const oldFallback = process.env.LEITSTAND_STORAGE_HEALTH_FIXTURE_FALLBACK;
 const oldStrict = process.env.LEITSTAND_STRICT;
 const roots: string[] = [];
+
+async function isolatedSourceRoot(fixtureName?: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'leitstand-storage-root-'));
+  roots.push(root);
+  if (fixtureName) {
+    const fixtureDir = join(root, 'src', 'fixtures');
+    await mkdir(fixtureDir, { recursive: true });
+    await copyFile(join(process.cwd(), 'src', 'fixtures', fixtureName), join(fixtureDir, fixtureName));
+  }
+  return root;
+}
 
 function restore(name: string, value: string | undefined) {
   if (value === undefined) delete process.env[name];
@@ -30,17 +41,27 @@ describe('getStorageHealthData', () => {
     delete process.env.LEITSTAND_STORAGE_HEALTH_PATH;
     delete process.env.LEITSTAND_STORAGE_HEALTH_FIXTURE_FALLBACK;
     delete process.env.LEITSTAND_STRICT;
-    const data = await getStorageHealthData();
+    const sourceRoot = await isolatedSourceRoot();
+    const data = await getStorageHealthData({ sourceRoot });
     expect(data.current).toBeNull();
     expect(data.view_meta.source_kind).toBe('missing');
     expect(data.view_meta.missing_reason).toBe('storage_health_missing');
     expect(data.view_meta.unavailable_count).toBe(1);
   });
 
+  it('keeps process.cwd() as the production default source root', async () => {
+    delete process.env.LEITSTAND_STORAGE_HEALTH_PATH;
+    delete process.env.LEITSTAND_STORAGE_HEALTH_FIXTURE_FALLBACK;
+    delete process.env.LEITSTAND_STRICT;
+    const data = await getStorageHealthData();
+    expect(data.view_meta.source_path).toBe(join(process.cwd(), 'artifacts', 'storage-health.json'));
+  });
+
   it('uses fixture data only when fallback is explicit', async () => {
     delete process.env.LEITSTAND_STORAGE_HEALTH_PATH;
     process.env.LEITSTAND_STORAGE_HEALTH_FIXTURE_FALLBACK = 'true';
-    const data = await getStorageHealthData();
+    const sourceRoot = await isolatedSourceRoot('storage-health.json');
+    const data = await getStorageHealthData({ sourceRoot });
     expect(data.view_meta.source_kind).toBe('fixture');
     expect(data.view_meta.missing_reason).toBe('storage_health_missing_fixture_fallback');
     expect(data.current?.topProducers[0].id).toBe('linked-worktrees');


### PR DESCRIPTION
## Problem

Drei Controller-Suites setzten für den erwarteten Missing-Fall lediglich die Pfad-Umgebungsvariable zurück. Dadurch lasen sie aus dem echten Repository-`artifacts/`-Verzeichnis und schlugen auf produktnahen Checkouts mit vorhandenen Snapshots fehl.

## Änderung

- `getBureauData`, `getCheckoutData` und `getStorageHealthData` akzeptieren optional einen `sourceRoot`.
- Ohne Option bleibt der Produktionsstandard unverändert: `process.cwd()`.
- Artefakt- und Fixture-Pfade sowie die sichere Pfadanzeige werden relativ zu diesem Root aufgelöst.
- Die Tests erzeugen eigene temporäre Roots und kopieren Fixtures nur dort hinein.
- Je Controller belegt ein zusätzlicher Test den unveränderten Produktionsstandard.

## Nachweise

- Betroffene Suites: 22/22 bestanden.
- Typecheck, Lint und Build bestanden.
- Vollsuite ohne Runtime-Artefakte: 272/272 bestanden.
- Vollsuite mit Kopien der realen `bureau-tasks.json`, `checkout-inventory.json` und `storage-health.json`: 272/272 bestanden.
- Exakt sechs Task-Pfade geändert; keine Netzwerk-, Schreib- oder Ausführungsautorität ergänzt.

## Abgrenzung

Die Änderung erzeugt keine Produktionsartefakte und verändert weder Environment-Override-, Strict- noch Fixture-Fallback-Semantik. Sie stellt keine Artefaktfrische oder Runtime-Gesundheit her.

Task: OPERATOR-ECOSYSTEM-REDUNDANCY-V1-T074
Candidate: candidate-dd384310e6f990c6e38d2f39