### PR TITLE
fix(release): support isolated Systemkatalog sibling imports

### DIFF
--- a/docs/runbooks/local-release-runtime.md
+++ b/docs/runbooks/local-release-runtime.md
@@ -79,7 +79,7 @@ For `deploy`, the configured exact Systemkatalog release is a bootstrap and rele
 1. derives the Systemkatalog release base from the configured exact commit path;
 2. reads `main` directly from the canonical `git@github.com:heimgewebe/systemkatalog.git` remote;
 3. reuses `<release-base>/<remote-main-commit>` only when its Git `HEAD`, durable `refs/remotes/origin/main`, origin URL and tracked bytes still match that exact commit; unexpected untracked files are rejected, while inert `__pycache__/*.pyc` remnants are tolerated for compatibility with previously verified local releases; otherwise it clones canonical `main` into a temporary sibling and atomically publishes the verified commit directory;
-4. executes that release's own `scripts/write_ecosystem_map_artifact_manifest.py --check --durable-source-ref refs/remotes/origin/main --json` contract under isolated Python path handling and records the manifest digest, artifact count and manifest source commit;
+4. executes that release's own `scripts/write_ecosystem_map_artifact_manifest.py --check --durable-source-ref refs/remotes/origin/main --json` contract under Python `-I` isolation, explicitly adding only that verified release's `scripts` directory for tracked sibling imports, and records the manifest digest, artifact count and manifest source commit;
 5. re-reads live Systemkatalog `main` and re-verifies the release immediately before the Leitstand switch transaction.
 
 The published map manifest may legitimately bind an older artifact-producing commit than the Systemkatalog release `HEAD`. The producer's manifest checker owns the durable-ancestry and byte-binding proof; Leitstand must not replace it with an incorrect equality check between manifest source commit and repository head.

--- a/scripts/leitstand-release.py
+++ b/scripts/leitstand-release.py
@@ -93,6 +93,15 @@ SYSTEMKATALOG_REMOTE_REF = "refs/heads/main"
 SYSTEMKATALOG_TRACKING_REF = "refs/remotes/origin/main"
 SYSTEMKATALOG_MANIFEST_RELATIVE_PATH = Path("rendered/ecosystem-map-artifact-manifest.json")
 SYSTEMKATALOG_MANIFEST_CHECKER_RELATIVE_PATH = Path("scripts/write_ecosystem_map_artifact_manifest.py")
+SYSTEMKATALOG_MANIFEST_CHECKER_BOOTSTRAP = """\
+import runpy
+import sys
+
+scripts_directory, checker, *arguments = sys.argv[1:]
+sys.path.insert(0, scripts_directory)
+sys.argv = [checker, *arguments]
+runpy.run_path(checker, run_name="__main__")
+"""
 COMPLETION_KIND = "leitstand_local_deployment_completion"
 ACTIVE_ROUTES = (
     "/",
@@ -1502,6 +1511,18 @@ def _systemkatalog_remote_main() -> str:
     return lines[0][0]
 
 
+def _systemkatalog_manifest_checker_command(checker: Path) -> tuple[str, ...]:
+    checker = Path(os.path.abspath(checker))
+    return (
+        sys.executable,
+        "-I",
+        "-c",
+        SYSTEMKATALOG_MANIFEST_CHECKER_BOOTSTRAP,
+        str(checker.parent),
+        str(checker),
+    )
+
+
 def _verify_systemkatalog_release(target: Path, expected_head: str) -> dict[str, Any]:
     head = validate_head(expected_head)
     target = Path(os.path.abspath(target))
@@ -1558,9 +1579,7 @@ def _verify_systemkatalog_release(target: Path, expected_head: str) -> dict[str,
     _require_regular_file(checker, owner_uid=os.getuid(), label="Systemkatalog map manifest checker")
     completed = run(
         (
-            sys.executable,
-            "-I",
-            str(checker),
+            *_systemkatalog_manifest_checker_command(checker),
             "--repo-root",
             str(target),
             "--check",

--- a/tests/test_release_runtime.py
+++ b/tests/test_release_runtime.py
@@ -81,12 +81,20 @@ class ReleaseRuntimeTest(unittest.TestCase):
         subprocess.run(["git", "-C", str(source), "config", "user.name", "Leitstand Test"], check=True)
         (source / "rendered").mkdir()
         (source / "scripts").mkdir()
+        provenance = source / "scripts/system_catalog_provenance.py"
+        provenance.write_text(
+            "def manifest_summary(manifest):\n"
+            "    return {\"ok\": True, \"sourceCommit\": manifest[\"sourceCommit\"], \"artifactCount\": manifest[\"artifactCount\"]}\n",
+            encoding="utf-8",
+        )
         checker = source / release.SYSTEMKATALOG_MANIFEST_CHECKER_RELATIVE_PATH
         checker.write_text(
             """#!/usr/bin/env python3
 import argparse
 import json
 from pathlib import Path
+
+from system_catalog_provenance import manifest_summary
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--repo-root', required=True)
@@ -95,7 +103,7 @@ parser.add_argument('--durable-source-ref')
 parser.add_argument('--json', action='store_true')
 args = parser.parse_args()
 manifest = json.loads((Path(args.repo_root) / 'rendered/ecosystem-map-artifact-manifest.json').read_text())
-print(json.dumps({'ok': True, 'sourceCommit': manifest['sourceCommit'], 'artifactCount': manifest['artifactCount']}))
+print(json.dumps(manifest_summary(manifest)))
 """,
             encoding="utf-8",
         )
@@ -290,6 +298,16 @@ print(json.dumps({'ok': True, 'sourceCommit': manifest['sourceCommit'], 'artifac
         self.config_path.write_text(json.dumps(changed), encoding="utf-8")
         with self.assertRaisesRegex(release.ReleaseError, "key mismatch"):
             release.load_runtime_config(self.config_path)
+
+    def test_systemkatalog_manifest_checker_command_keeps_isolation_and_binds_scripts(self) -> None:
+        checker = Path("/verified/systemkatalog/scripts/write_ecosystem_map_artifact_manifest.py")
+        command = release._systemkatalog_manifest_checker_command(checker)
+
+        self.assertEqual(command[:3], (sys.executable, "-I", "-c"))
+        self.assertEqual(command[4:], (str(checker.parent), str(checker)))
+        self.assertIn("sys.path.insert(0, scripts_directory)", command[3])
+        self.assertIn("runpy.run_path", command[3])
+        self.assertNotIn("PYTHONPATH", command[3])
 
     def test_prepare_systemkatalog_runtime_config_materializes_and_reuses_exact_remote_release(self) -> None:
         remote, latest, manifest_source = self._create_systemkatalog_remote()


### PR DESCRIPTION
## Befund

Der kanonische Leitstand-Deploy auf aktuellem `main` brach vor dem Cutover fail-closed ab. Der aktuelle Systemkatalog-Manifestprüfer importiert das getrackte Schwesterobjekt `system_catalog_provenance`, während Leitstand den Prüfer mit `python -I <script>` ausführte. Unter `-I` wurde das verifizierte `scripts`-Verzeichnis nicht in `sys.path` aufgenommen; Folge: `ModuleNotFoundError` und weiterhin HTTP 503 auf `/health`, weil der alte Systemkatalog-Release hinter dem kanonischen Head lag.

## Änderung

- `python -I` bleibt erhalten.
- Ein kleiner Bootstrap fügt ausschließlich das `scripts`-Verzeichnis des bereits commit-, origin-, worktree- und manifestverifizierten Systemkatalog-Releases hinzu.
- Der getrackte Prüfer wird mit `runpy.run_path(..., run_name="__main__")` gestartet.
- Kein globaler `PYTHONPATH`, kein fremder Checkout und kein gelockertes Health-Gate.
- Die Test-Fixture verwendet nun einen echten getrackten Schwesterimport; ein separater Test bindet den Isolationsvertrag.

## Prüfung

- `pnpm test:release-runtime`: 51/51 PASS
- `git diff --check`: PASS
- Basis und live Remote-`main`: `68961aa9a2fa370fe633b467d1ac1c123ec9d774`
- erster produktiver Deployversuch: vor jeder Servicewirkung abgebrochen; alter Release blieb aktiv

## Nach Merge

Der exakte Merge-Commit wird über den kanonischen Leitstand-Releaseadapter deployed. Akzeptanz: lokales und kanonisches `/health` liefern 200/`ok`, Unit und `/ecosystem-map` binden denselben automatisch vorbereiteten Systemkatalog-Commit; der bisherige Release bleibt rollbackfähig.