### PR TITLE
chore(deps): update pnpm to v9.15.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,5 +53,5 @@
     "node": ">=20.0.0",
     "pnpm": ">=8.0.0"
   },
-  "packageManager": "pnpm@9.1.0"
+  "packageManager": "pnpm@9.15.9"
 }


### PR DESCRIPTION
Manual, evidence-bound replacement for Renovate PR #205. The dependency declaration is updated to pnpm 9.15.9. `pnpm install --lockfile-only` produced no lockfile delta; frozen install, lint, typecheck, tests and build all passed. This replacement avoids the false `renovate/artifacts` failure caused by the local Node wrapper losing the user-bus environment.