### PR TITLE
fix: unify operator snapshot freshness policy

### DIFF
--- a/docs/runbooks/operator-snapshots.md
+++ b/docs/runbooks/operator-snapshots.md
@@ -79,15 +79,15 @@ Execution-axis data changes quickly enough that stale snapshots must be visible.
 
 | Snapshot | Expected refresh cadence | Leitstand stale threshold | Rationale |
 | --- | --- | --- | --- |
-| Bureau task lifecycle snapshot | at least every 60 minutes during active operator work; after relevant Bureau task/claim merges when possible | 6 hours | task/claim state is operationally volatile |
-| Grabowski checkout inventory | at least daily; after large worktree/branch cleanup or runtime-head changes when possible | 24 hours | checkout inventory changes slower but can drift materially |
+| Bureau task lifecycle snapshot | every 10 minutes through the versioned operator-snapshot timer; after relevant Bureau task/claim merges when possible | 20 minutes | two missed producer runs must be visible before task/claim evidence is treated as current |
+| Grabowski checkout inventory | every 10 minutes through the same versioned timer; after large worktree/branch cleanup or runtime-head changes when possible | 20 minutes | checkout ownership, process and lease bindings can change during active operator work |
 
-The controller thresholds are encoded in:
-
-- `src/controllers/bureau.ts` — 6 hour stale threshold.
-- `src/controllers/checkouts.ts` — 24 hour stale threshold.
-
-The runtime health receipt at `/health` is intentionally stricter: it warns when either operator snapshot is older than 20 minutes. The running service uses this tighter threshold to detect bridge/timer drift early; the human-facing boards remain renderable for longer.
+The shared threshold is encoded once in `src/freshnessPolicy.ts` as
+`OPERATIONAL_SNAPSHOT_STALE_AFTER_MINUTES = 20`. Bureau, checkout,
+decision-axis and canonical-head projections consume that policy, and `/health`
+uses the same value for the corresponding operational snapshots. The rendered
+boards and the health receipt therefore cannot classify the same evidence with
+different freshness boundaries.
 
 A stale snapshot remains renderable, but it is not a green status. Operators should refresh the raw producer export and rerun the bridge before treating the view as current.
 

--- a/src/controllers/bureau.ts
+++ b/src/controllers/bureau.ts
@@ -1,5 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import { join, relative, resolve } from 'node:path';
+import { OPERATIONAL_SNAPSHOT_STALE_AFTER_MS } from '../freshnessPolicy.js';
 
 /**
  * Bureau task-board controller — Phase "Ausführungs-Achse".
@@ -61,8 +62,6 @@ export interface BureauViewData {
 }
 
 const CONTRACT_KIND = 'leitstand_bureau_task_snapshot';
-/** Bureau tasks are operational; a snapshot older than this reads as stale. */
-const STALE_AFTER_MS = 20 * 60 * 1000; // 20m
 
 const DEFAULT_NON_CLAIMS = [
   'task_ownership',
@@ -132,7 +131,7 @@ function freshnessOf(generatedAt: string | null): BureauFreshness {
   if (!generatedAt) return 'unknown';
   const ts = Date.parse(generatedAt);
   if (Number.isNaN(ts)) return 'unknown';
-  return Date.now() - ts <= STALE_AFTER_MS ? 'fresh' : 'stale';
+  return Date.now() - ts <= OPERATIONAL_SNAPSHOT_STALE_AFTER_MS ? 'fresh' : 'stale';
 }
 
 function nullableString(raw: unknown): string | null {

--- a/src/controllers/checkouts.ts
+++ b/src/controllers/checkouts.ts
@@ -1,5 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import { join, relative, resolve } from 'node:path';
+import { OPERATIONAL_SNAPSHOT_STALE_AFTER_MS } from '../freshnessPolicy.js';
 
 /**
  * Checkout / worktree health controller — Phase "Ausführungs-Achse".
@@ -53,8 +54,6 @@ export interface CheckoutViewData {
 }
 
 const CONTRACT_KIND = 'leitstand_checkout_inventory';
-/** Checkout inventory changes slowly; a day-old snapshot is still useful but flagged. */
-const STALE_AFTER_MS = 20 * 60 * 1000; // 20m
 
 const DEFAULT_NON_CLAIMS = [
   'checkout_ownership',
@@ -104,7 +103,7 @@ function freshnessOf(generatedAt: string | null): CheckoutFreshness {
   if (!generatedAt) return 'unknown';
   const ts = Date.parse(generatedAt);
   if (Number.isNaN(ts)) return 'unknown';
-  return Date.now() - ts <= STALE_AFTER_MS ? 'fresh' : 'stale';
+  return Date.now() - ts <= OPERATIONAL_SNAPSHOT_STALE_AFTER_MS ? 'fresh' : 'stale';
 }
 
 function nullableString(raw: unknown): string | null {

--- a/src/controllers/decisionAxis.ts
+++ b/src/controllers/decisionAxis.ts
@@ -1,5 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import { join, relative, resolve } from 'node:path';
+import { OPERATIONAL_SNAPSHOT_STALE_AFTER_MS } from '../freshnessPolicy.js';
 
 export type DecisionSourceKind = 'artifact' | 'missing' | 'corrupt';
 export type DecisionFreshness = 'fresh' | 'stale' | 'unknown';
@@ -36,7 +37,6 @@ export interface DecisionAxisViewData {
 }
 
 const CONTRACT_KIND = 'leitstand_operator_decision_axis_snapshot';
-const STALE_AFTER_MS = 20 * 60 * 1000;
 const SECTION_ORDER: Array<{ id: DecisionAxisSection['id']; label: DecisionAxisSection['label'] }> = [
   { id: 'now', label: 'Jetzt' },
   { id: 'focus', label: 'Im Fokus' },
@@ -61,7 +61,7 @@ function freshnessOf(value: string | null): DecisionFreshness {
   if (!value) return 'unknown';
   const timestamp = Date.parse(value);
   if (Number.isNaN(timestamp)) return 'unknown';
-  return Date.now() - timestamp <= STALE_AFTER_MS ? 'fresh' : 'stale';
+  return Date.now() - timestamp <= OPERATIONAL_SNAPSHOT_STALE_AFTER_MS ? 'fresh' : 'stale';
 }
 
 function displaySourcePath(sourcePath: string): string {

--- a/src/controllers/ecosystemMap.ts
+++ b/src/controllers/ecosystemMap.ts
@@ -2,6 +2,7 @@ import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { lstat, readFile } from 'node:fs/promises';
 import { basename, dirname, join, relative, resolve } from 'node:path';
+import { OPERATIONAL_SNAPSHOT_STALE_AFTER_MS } from '../freshnessPolicy.js';
 import {
   loadEcosystemCrossLinks,
   type EcosystemCrossLinkData,
@@ -13,7 +14,6 @@ const MANIFEST_SCHEMA_PATH = 'catalog/ecosystem-map-artifact-manifest.schema.v1.
 const MANIFEST_MODE = 'read_only_projection_source';
 const DEFAULT_STALE_AFTER_HOURS = 168;
 const CURRENT_HEAD_CONTRACT_KIND = 'leitstand_source_head_snapshot';
-const CURRENT_HEAD_STALE_AFTER_MS = 20 * 60 * 1000;
 const GIT_TIMEOUT_MS = 2_500;
 const MAX_GIT_OUTPUT_BYTES = 1_000_000;
 
@@ -575,7 +575,7 @@ async function readCanonicalHeadInspection(): Promise<CanonicalHeadInspection> {
       return { status: 'unavailable', reason: 'canonical_head_contract_mismatch', head: null, generatedAt: null };
     }
     const generatedMs = Date.parse(raw.generatedAt);
-    if (!Number.isFinite(generatedMs) || Date.now() - generatedMs > CURRENT_HEAD_STALE_AFTER_MS) {
+    if (!Number.isFinite(generatedMs) || Date.now() - generatedMs > OPERATIONAL_SNAPSHOT_STALE_AFTER_MS) {
       return { status: 'unavailable', reason: 'canonical_head_snapshot_stale', head: null, generatedAt: raw.generatedAt };
     }
     if (raw.status !== 'available' || typeof raw.head !== 'string' || !/^[0-9a-f]{40}$/.test(raw.head)) {

--- a/src/freshnessPolicy.ts
+++ b/src/freshnessPolicy.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared freshness policy for fast-moving operator snapshots.
+ *
+ * The producer timer runs every ten minutes. A snapshot becomes stale after
+ * two missed producer runs so the rendered boards and `/health` cannot disagree
+ * about whether the same operational evidence is current.
+ */
+export const OPERATIONAL_SNAPSHOT_STALE_AFTER_MINUTES = 20;
+export const OPERATIONAL_SNAPSHOT_STALE_AFTER_MS =
+  OPERATIONAL_SNAPSHOT_STALE_AFTER_MINUTES * 60 * 1000;

--- a/src/runtimeHealth.ts
+++ b/src/runtimeHealth.ts
@@ -1,5 +1,6 @@
 import { readFile, stat } from 'node:fs/promises';
 import { basename, join, relative, resolve } from 'node:path';
+import { OPERATIONAL_SNAPSHOT_STALE_AFTER_MS } from './freshnessPolicy.js';
 
 export type RuntimeHealthStatus = 'ok' | 'warn' | 'fail';
 export type RuntimeHealthCheckStatus = RuntimeHealthStatus | 'unknown';
@@ -69,11 +70,11 @@ export interface RuntimeHealthOptions {
 }
 
 const SNAPSHOT_STALE_LIMITS_MS: Record<SnapshotKind, number> = {
-  bureau_tasks: 20 * 60 * 1000,
-  checkout_inventory: 20 * 60 * 1000,
-  decision_axis: 20 * 60 * 1000,
-  repoground: 20 * 60 * 1000,
-  ecosystem_map_head: 20 * 60 * 1000,
+  bureau_tasks: OPERATIONAL_SNAPSHOT_STALE_AFTER_MS,
+  checkout_inventory: OPERATIONAL_SNAPSHOT_STALE_AFTER_MS,
+  decision_axis: OPERATIONAL_SNAPSHOT_STALE_AFTER_MS,
+  repoground: OPERATIONAL_SNAPSHOT_STALE_AFTER_MS,
+  ecosystem_map_head: OPERATIONAL_SNAPSHOT_STALE_AFTER_MS,
   storage_health: 90 * 60 * 1000,
   ecosystem_map: 168 * 60 * 60 * 1000,
 };

--- a/tests/controllers/freshnessAlignment.test.ts
+++ b/tests/controllers/freshnessAlignment.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { getBureauData } from '../../src/controllers/bureau.js';
 import { getCheckoutData } from '../../src/controllers/checkouts.js';
 import { getStorageHealthData } from '../../src/controllers/storageHealth.js';
+import { OPERATIONAL_SNAPSHOT_STALE_AFTER_MINUTES } from '../../src/freshnessPolicy.js';
 
 const OLD_BUREAU = process.env.LEITSTAND_BUREAU_SNAPSHOT_PATH;
 const OLD_CHECKOUT = process.env.LEITSTAND_CHECKOUT_SNAPSHOT_PATH;
@@ -33,6 +34,21 @@ afterEach(async () => {
 });
 
 describe('controller freshness policy alignment', () => {
+  it('keeps the documented operational threshold bound to the shared policy', async () => {
+    const runbook = await readFile(
+      join(process.cwd(), 'docs', 'runbooks', 'operator-snapshots.md'),
+      'utf-8',
+    );
+
+    expect(OPERATIONAL_SNAPSHOT_STALE_AFTER_MINUTES).toBe(20);
+    expect(runbook).toContain(
+      '`OPERATIONAL_SNAPSHOT_STALE_AFTER_MINUTES = 20`',
+    );
+    expect(runbook).toContain('| Bureau task lifecycle snapshot | every 10 minutes');
+    expect(runbook).toContain('| Grabowski checkout inventory | every 10 minutes');
+    expect(runbook).not.toMatch(/6 hours|24 hours|6 hour|24 hour/i);
+  });
+
   it('uses the same 20-minute boundary for Bureau and checkout projections', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-07-19T12:00:00Z'));


### PR DESCRIPTION
## Summary
- centralize the 20-minute freshness boundary for fast-moving operator snapshots
- make Bureau, checkout, decision-axis, canonical-head and runtime-health consumers use the same policy
- correct the operator snapshot runbook to the actual 10-minute producer cadence
- add a regression guard that binds documentation to the shared policy

## Validation
- pnpm test: 296 passed
- pnpm typecheck
- pnpm lint
- pnpm build
- pnpm test:release-runtime: 54 passed
- git diff --check